### PR TITLE
Simplify dataset reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ tools
 generated*
 
 *venv
+
+.DS_Store

--- a/src/biome/allennlp/dataset_readers/__init__.py
+++ b/src/biome/allennlp/dataset_readers/__init__.py
@@ -1,1 +1,1 @@
-from .classification_dataset_reader import ClassificationDatasetReader
+from .classification_dataset_reader import SequenceClassifierDatasetReader, SequencePairClassifierDatasetReader

--- a/src/biome/allennlp/dataset_readers/classification_dataset_reader.py
+++ b/src/biome/allennlp/dataset_readers/classification_dataset_reader.py
@@ -45,7 +45,7 @@ class SequenceClassifierDatasetReader(DatasetReader):
 
     @overrides
     def _read(self, file_path: str) -> Iterable[Instance]:
-        """
+        """An generator that yields `Instance`s that are fed to the model
 
         Parameters
         ----------
@@ -54,7 +54,8 @@ class SequenceClassifierDatasetReader(DatasetReader):
 
         Yields
         ------
-
+        instance
+            An `Instance` that is fed to the model
         """
         config = read_datasource_cfg(file_path)
         ds_key = id(config)
@@ -73,7 +74,7 @@ class SequenceClassifierDatasetReader(DatasetReader):
                 yield instance
 
     def text_to_instance(self, example: Dict) -> Optional[Instance]:
-        """ Transforms an example to an Instance
+        """Transforms an example to an Instance
 
         The actual work is done in the private method `_example_to_instance`.
 
@@ -86,6 +87,11 @@ class SequenceClassifierDatasetReader(DatasetReader):
         -------
         instance
             Returns `None` if the example could not be transformed to an Instance.
+
+        Raises
+        ------
+        ValueError
+            If a value in the `example` dict resolves to False.
         """
         fields = {}
         try:
@@ -100,13 +106,12 @@ class SequenceClassifierDatasetReader(DatasetReader):
         return Instance(fields)
 
     def _value_to_field(self, field_type: str, value: Any) -> Union[LabelField, TextField]:
-        """
-        Embeds the values in one of the `allennlp.data.fields`.
+        """Embeds the value in one of the `allennlp.data.fields`
 
         Parameters
         ----------
         field_type
-            Name of the field, must match one of the arguments of the `forward` method of your model.
+            Name of the field, must match one of the arguments in the `forward` method of your model.
         value
             Value of the field.
 
@@ -122,7 +127,7 @@ class SequenceClassifierDatasetReader(DatasetReader):
         param = self.forward_params.get(field_type)
         if not param:
             raise ValueError(f"{field_type} must not form part of the Instance passed on to the model!")
-        # the gold label should be optional in the classification model, otherwise no predict is possible
+        # the gold label must be optional in the classification model, otherwise no predict is possible
         if param.default is not Parameter.empty:
             return LabelField(value)
         else:

--- a/src/biome/allennlp/dataset_readers/classification_dataset_reader.py
+++ b/src/biome/allennlp/dataset_readers/classification_dataset_reader.py
@@ -2,12 +2,12 @@ import logging
 from inspect import signature, Parameter
 from typing import Any, Dict, Iterable, Optional, Union
 
-from allennlp.data import DatasetReader, Instance, TokenIndexer, Field, Tokenizer
+from allennlp.data import DatasetReader, Instance, TokenIndexer, Tokenizer
 from allennlp.data.fields import TextField, LabelField
 from allennlp.data.token_indexers import SingleIdTokenIndexer
 from allennlp.data.tokenizers import WordTokenizer
-from biome.allennlp.models import SequenceClassifier
-from biome.data.sources import read_dataset, RESERVED_FIELD_PREFIX
+from biome.allennlp.models import SequenceClassifier, SequencePairClassifier
+from biome.data.sources import read_dataset
 from biome.data.utils import read_datasource_cfg
 from overrides import overrides
 
@@ -20,11 +20,10 @@ class SequenceClassifierDatasetReader(DatasetReader):
 
     Parameters
     ----------
-    forward
-        We want to get rid of this one, or at least infer it from the model type
     tokenizer
         By default we use a WordTokenizer with the SpacyWordSplitter
     token_indexers
+        By default we use a SingleIdTokenIndexer for all token fields
     """
     def __init__(
         self,
@@ -38,7 +37,7 @@ class SequenceClassifierDatasetReader(DatasetReader):
 
         # The keys of the Instances have to match the signature of the forward method of the model
         self.forward_params = signature(SequenceClassifier.forward).parameters
-        self.token_field_id = list(self.forward_params)[0]
+        self.tokens_field_id = list(self.forward_params)[0]
 
         self.token_indexers = token_indexers or {self.tokens_field_id: SingleIdTokenIndexer}
 
@@ -69,11 +68,11 @@ class SequenceClassifierDatasetReader(DatasetReader):
             self._cached_datasets[ds_key] = dataset
 
         for example in dataset:
-            instance = self._example_to_instance(example)
+            instance = self.text_to_instance(example)
             if instance:
                 yield instance
 
-    def example_to_instance(self, example: Dict) -> Optional[Instance]:  # type: ignore
+    def text_to_instance(self, example: Dict) -> Optional[Instance]:
         """ Transforms an example to an Instance
 
         The actual work is done in the private method `_example_to_instance`.
@@ -88,183 +87,77 @@ class SequenceClassifierDatasetReader(DatasetReader):
         instance
             Returns `None` if the example could not be transformed to an Instance.
         """
-        # pylint: disable=arguments-differ
-        logger.debug("Example:[%s]", example)
-        try:
-            if self.forward_definition:
-                instance = self._instance_by_forward_definition(example)
-            else:
-                instance = self._instance_by_target_definition(example)  # deprecated
-        except Exception as e:
-            logger.warning(e)
-            return None
-
-        return instance
-
-    def _example_to_instance(self, example: Dict) -> Optional[Instance]:
-        """
-
-        Parameters
-        ----------
-        example
-
-        Returns
-        -------
-
-        """
         fields = {}
         try:
             for field, value in example.items():
                 if not value:
-                    raise ValueError(f"{field} contains an empty string!")
-                fields[field] = self.value_to_field(field, value)
+                    raise ValueError(f"{field} probably contains an empty string!")
+                fields[field] = self._value_to_field(field, value)
         except Exception as e:
             logger.warning(e)
             return None
 
         return Instance(fields)
 
-    def value_to_field(self, field_type: str, value: Any) -> Union[LabelField, TextField]:
+    def _value_to_field(self, field_type: str, value: Any) -> Union[LabelField, TextField]:
         """
+        Embeds the values in one of the `allennlp.data.fields`.
+
         Parameters
         ----------
         field_type
+            Name of the field, must match one of the arguments of the `forward` method of your model.
         value
+            Value of the field.
 
         Returns
         -------
+        Returns either a `LabelField` or a `TextField` depending on the `field_type` parameter.
 
         Raises
         ------
+        ValueError
+            If `field_type` is not found in the arguments of your model's `forward` method.
         """
         param = self.forward_params.get(field_type)
         if not param:
             raise ValueError(f"{field_type} must not form part of the Instance passed on to the model!")
-        # the gold label should be optional in the model, otherwise no predict is possible
+        # the gold label should be optional in the classification model, otherwise no predict is possible
         if param.default is not Parameter.empty:
             return LabelField(value)
         else:
             return TextField(self.tokenizer.tokenize(value), self.token_indexers)
 
 
-
-        for par_name, par in self.forward_params.items():
-            if
-
-        if field_type == self.gold_label_field_id:
-            return LabelField(value)
-        # allow multiple token fields to be passed on to the forward of the model
-        elif field_type.startswith(self.tokens_field_id):  # allow multiple token fields to be passed on to the forward of the model
-            return TextField(self.tokenizer.tokenize(value), self.token_indexers)
-        else:
-            raise ValueError(f"{field_type} must not form part of the Instance passed on to the model!")
-
-    def _field_from_type(self, field_type: str, field_value: Any) -> Field:
-        if field_type == "LabelField":
-            return LabelField(field_value)
-        elif field_type == "TextField":
-            return TextField(self.tokenizer.tokenize(field_value), self.token_indexers)
-        else:
-            raise TypeError(f"{field_type} is not supported yet.")
-
-    def _instance_by_forward_definition(self, example) -> Instance:
-        def field_from_type(field_type: str, field_value: Any) -> Field:
-            if field_type == "LabelField":
-                return LabelField(field_value)
-            elif field_type == "TextField":
-                return TextField(self.tokenizer.tokenize(field_value), self.token_indexers)
-            else:
-                raise TypeError(f"{field_type} is not supported yet.")
-
-        fields = {
-            field: field_from_type(field_type, example[field])
-            for field, field_type in self.forward_definition.items()
-            if example.get(field) is not None
-        }
-
-        return Instance(fields)
-
-    def _instance_by_target_definition(self, example) -> Instance:
-        logger.warning(
-            "Call to the deprecated method _instance_by_target_definition(). "
-            "Use forward definition in config file instead of target."
-        )
-        fields: Dict[str, Field] = {}
-
-        for field, value in example.items():
-            if not self._is_reserved_field(field):
-                tensor = (
-                    LabelField(value)
-                    if field == self.gold_label_id
-                    else TextField(self.tokenizer.tokenize(value), self.token_indexers)
-                )
-                fields[field] = tensor
-
-        return Instance(fields)
-
-    def _is_reserved_field(self, field_name: str) -> bool:
-        return field_name and field_name.startswith(RESERVED_FIELD_PREFIX)
-
-"""
-    @staticmethod
-    def _text_to_instance(
-        example: Dict,
-        forward_definition: Dict[str, Any],
-        gold_label_id: str,
-        token_indexers: Dict[str, TokenIndexer],
-        tokenizer: Tokenizer,
-    ) -> Instance:
-        def is_reserved_field(field_name: str) -> bool:
-            return field_name and field_name.startswith(RESERVED_FIELD_PREFIX)
-
-        def instance_by_forward_definition() -> Instance:
-            def field_from_type(field_type: str, field_value: Any) -> Field:
-                if field_type == "LabelField":
-                    return LabelField(field_value)
-                elif field_type == "TextField":
-                    return TextField(tokenizer.tokenize(field_value), token_indexers)
-                else:
-                    raise TypeError(f"{field_type} is not supported yet.")
-
-            fields = {
-                field: field_from_type(field_type, example[field])
-                for field, field_type in forward_definition.items()
-                if example.get(field) is not None
-            }
-
-            return Instance(fields)
-
-        def instance_by_target_definition() -> Instance:
-            logger.warning(
-                "Call to the deprecated method instance_by_target_definition(). "
-                "Use forward definition in config file instead of target."
-            )
-            fields: Dict[str, Field] = {}
-
-            for field, value in example.items():
-                if not is_reserved_field(field):
-                    tensor = (
-                        LabelField(value)
-                        if field == gold_label_id
-                        else TextField(tokenizer.tokenize(value), token_indexers)
-                    )
-                    fields[field] = tensor
-
-            return Instance(fields)
-
-        return (
-            instance_by_forward_definition()
-            if forward_definition
-            else instance_by_target_definition()
-        )
-"""
-
 @DatasetReader.register("sequence_pair_classifier")
 class SequencePairClassifierDatasetReader(SequenceClassifierDatasetReader):
-    """
+    """A DatasetReader for the SequencePairClassifier model.
 
+    Parameters
+    ----------
+    tokenizer
+        By default we use a WordTokenizer with the SpacyWordSplitter
+    token_indexers
+        By default we use a SingleIdTokenIndexer for all token fields
     """
-    def __init__(self):
-        super(SequenceClassifierDatasetReader, self).__init__(lazy=True)
+    def __init__(
+            self,
+            tokenizer: Tokenizer = None,
+            token_indexers: Dict[str, TokenIndexer] = None,
+    ) -> None:
+
+        super(SequenceClassifier, self).__init__(lazy=True)
+
+        self.tokenizer = tokenizer or WordTokenizer()
+
+        # The keys of the Instances have to match the signature of the forward method of the model
+        self.forward_params = signature(SequencePairClassifier.forward).parameters
+        self.tokens_field_id = list(self.forward_params)[0]
+        self.tokens2_field_id = list(self.forward_params)[1]
+
+        self.token_indexers = token_indexers or {self.tokens_field_id: SingleIdTokenIndexer,
+                                                 self.tokens2_field_id: SingleIdTokenIndexer}
+
+        self._cached_datasets = dict()
 
 

--- a/tests/allennlp/dataset_readers/test_biome_dataset_reader.py
+++ b/tests/allennlp/dataset_readers/test_biome_dataset_reader.py
@@ -2,53 +2,19 @@ import os
 from typing import Iterable
 
 import yaml
-from allennlp.common import Params
-from allennlp.data import DatasetReader
 from allennlp.data.fields import TextField, LabelField
 
-from biome.allennlp.dataset_readers import ClassificationDatasetReader
+from biome.allennlp.dataset_readers import SequenceClassifierDatasetReader
 from tests.test_context import TEST_RESOURCES
 from tests.test_support import DaskSupportTest
 
 TOKENS_FIELD = "tokens"
 LABEL_FIELD = "gold_label"
 
-CLASSIFIER_SPEC = os.path.join(
-    TEST_RESOURCES,
-    "resources/dataset_readers/definitions/classifier_dataset_reader.json",
-)
-reader = ClassificationDatasetReader.from_params(
-    params=Params.from_file(CLASSIFIER_SPEC)
-)
+reader = SequenceClassifierDatasetReader()
 
 
 class BiomeDatasetReaderTest(DaskSupportTest):
-    def test_dataset_reader_registration(self):
-        dataset_reader = DatasetReader.by_name("classification_dataset_reader")
-        self.assertEquals(ClassificationDatasetReader, dataset_reader)
-
-    def test_read_input_csv(self):
-        expected_length = 9
-        expected_labels = [
-            "blue-collar",
-            "technician",
-            "management",
-            "services",
-            "retired",
-            "admin.",
-        ]
-        expected_inputs = ["44", "53", "28", "39", "55", "30", "37", "36"]
-
-        yaml_config = os.path.join(
-            TEST_RESOURCES, "resources/datasets/biome.csv.spec.yml"
-        )
-        with open(yaml_config) as dataset_cfg:
-            params = yaml.load(dataset_cfg.read())
-            dataset = reader.read(params)
-            self._check_dataset(
-                dataset, expected_length, expected_inputs, expected_labels
-            )
-
     def test_read_input_csv_multi_file(self):
         expected_length = 18  # Two times the same file
         expected_labels = [

--- a/tests/allennlp/dataset_readers/test_dataset_reader_forward.py
+++ b/tests/allennlp/dataset_readers/test_dataset_reader_forward.py
@@ -5,7 +5,7 @@ import yaml
 from allennlp.common import Params
 from allennlp.data.fields import TextField, LabelField
 
-from biome.allennlp.dataset_readers import ClassificationDatasetReader
+from biome.allennlp.dataset_readers import SequenceClassifierDatasetReader, SequencePairClassifierDatasetReader
 from tests.test_context import TEST_RESOURCES, create_temp_configuration
 from tests.test_support import DaskSupportTest
 
@@ -24,7 +24,7 @@ class DatasetReaderForwardTest(DaskSupportTest):
     @pytest.mark.xfail
     def test_reader_with_forward_definition(self):
         with open(DS_READER_DEFINITION) as yml_config:
-            reader = ClassificationDatasetReader.from_params(params=Params(yaml.load(yml_config)))
+            reader = SequenceClassifierDatasetReader()
             read_config = dict(path=JSON_PATH, forward=dict(input=['reviewText'], label='overall'))
 
             dataset = reader.read(create_temp_configuration(read_config))
@@ -41,7 +41,7 @@ class DatasetReaderForwardTest(DaskSupportTest):
     @pytest.mark.xfail
     def test_reader_with_another_forward_definition(self):
         with open(MULTIPLE_INPUT_READER_DEFINITION) as yml_config:
-            reader = ClassificationDatasetReader.from_params(params=Params(yaml.load(yml_config)))
+            reader = SequenceClassifierDatasetReader.from_params(params=Params(yaml.load(yml_config)))
             read_config = dict(path=JSON_PATH, forward=dict(r1=['reviewText'], r2=['reviewText'], gold='overall'))
 
             dataset = reader.read(create_temp_configuration(read_config))
@@ -61,7 +61,7 @@ class DatasetReaderForwardTest(DaskSupportTest):
     @pytest.mark.xfail
     def test_reader_with_optional_params(self):
         with open(DS_READER_DEFINITION) as yml_config:
-            reader = ClassificationDatasetReader.from_params(params=Params(yaml.load(yml_config)))
+            reader = SequenceClassifierDatasetReader.from_params(params=Params(yaml.load(yml_config)))
             read_config = dict(path=NOLABEL_JSON_PATH, forward=dict(input=['reviewText'], label='overall'))
 
             dataset = reader.read(create_temp_configuration(read_config))

--- a/tests/allennlp/dataset_readers/test_parallel_dataset_reader.py
+++ b/tests/allennlp/dataset_readers/test_parallel_dataset_reader.py
@@ -5,7 +5,7 @@ from allennlp.common import Params
 from allennlp.data import DatasetReader
 from allennlp.data.fields import TextField, LabelField
 
-from biome.allennlp.dataset_readers import ClassificationDatasetReader
+from biome.allennlp.dataset_readers import SequenceClassifierDatasetReader
 from tests.test_context import TEST_RESOURCES, create_temp_configuration
 from tests.test_support import DaskSupportTest
 
@@ -15,14 +15,13 @@ DEFINITIONS_PATH = os.path.join(TEST_RESOURCES, 'resources/dataset_readers/defin
 
 TOKENS_FIELD = 'tokens'
 
-CLASSIFIER_SPEC = os.path.join(TEST_RESOURCES, 'resources/dataset_readers/definitions/classifier_dataset_reader.json')
-reader = ClassificationDatasetReader.from_params(params=Params.from_file(CLASSIFIER_SPEC))
+reader = SequenceClassifierDatasetReader()
 
 
 class ParallelDatasetReaderTest(DaskSupportTest):
     def test_dataset_reader_registration(self):
-        dataset_reader = DatasetReader.by_name('classification_dataset_reader')
-        self.assertEquals(ClassificationDatasetReader, dataset_reader)
+        dataset_reader = DatasetReader.by_name('sequence_classifier')
+        self.assertEquals(SequenceClassifierDatasetReader, dataset_reader)
 
     def test_read_csv(self):
         expected_length = 9

--- a/tests/resources/datasets/biome.csv.spec.yml
+++ b/tests/resources/datasets/biome.csv.spec.yml
@@ -8,7 +8,8 @@ format: csv
 forward:
   tokens:
   - age
-  gold_label: job
+  target:
+    gold_label: job
 
 # Extra arguments passed to pandas.read_csv method
 encoding: UTF-8

--- a/tests/resources/datasets/biome.csv.spec.yml
+++ b/tests/resources/datasets/biome.csv.spec.yml
@@ -8,8 +8,7 @@ format: csv
 forward:
   tokens:
   - age
-  target:
-    gold_label: job
+  gold_label: job
 
 # Extra arguments passed to pandas.read_csv method
 encoding: UTF-8


### PR DESCRIPTION
This is a first step to simplify the dataset readers.
It also updates the tests a bit.

- the idea is to tie them to the models -> they are named accordingly
- the names of the forward parameters are directly taken from the model's forward method
- the label field is identified by checking if it is optional in the model's forward method 

Follow-up MR will be:
- Update the ExamplePreparator
- Update tests properly

All tests pass locally for me.
@dvsrepo @frascuchon can you have a quick look at it? i would like to merge this soon, to update the ExamplePreparator next. 