### PR TITLE
Make dataset reader compatible with predictor

### DIFF
--- a/src/biome/allennlp/dataset_readers/classification_dataset_reader.py
+++ b/src/biome/allennlp/dataset_readers/classification_dataset_reader.py
@@ -79,14 +79,14 @@ class SequenceClassifierDatasetReader(DatasetReader):
             if instance:
                 yield instance
 
-    def example_to_instance(self, example: Dict[str, str], exclude_defaults: bool = False) -> Optional[Instance]:
+    def example_to_instance(self, example: Dict[str, str], exclude_optional: bool = False) -> Optional[Instance]:
         """Extracts the forward parameters from the example and transforms them to an `Instance`
 
         Parameters
         ----------
         example
             The keys of this dictionary should match the arguments of the `forward` method of your model.
-        exclude_defaults
+        exclude_optional
             Only extract the mandatory parameters of the model's forward method.
 
         Returns
@@ -99,7 +99,8 @@ class SequenceClassifierDatasetReader(DatasetReader):
             for param_name, param in self.forward_params.items():
                 if param_name == 'self':
                     continue
-                if exclude_defaults and param.default is not Parameter.empty:
+                # if desired, skip optional parameters like the label for example
+                if exclude_optional and param.default is not Parameter.empty:
                     continue
 
                 value = example[param_name]
@@ -149,7 +150,7 @@ class SequenceClassifierDatasetReader(DatasetReader):
         instance
             Returns `None` if the example could not be transformed to an Instance.
         """
-        return self.example_to_instance(example, exclude_defaults=True)
+        return self.example_to_instance(example, exclude_optional=True)
 
 
 @DatasetReader.register("sequence_pair_classifier")

--- a/src/biome/allennlp/predictors/default_predictor.py
+++ b/src/biome/allennlp/predictors/default_predictor.py
@@ -33,3 +33,8 @@ class DefaultBasePredictor(Predictor):
     @staticmethod
     def __to_prediction(inputs, output):
         return dict(input=inputs, annotation=sanitize(output))
+
+
+@Predictor.register("sequence_classifier")
+class SequenceClassifierPredictor(DefaultBasePredictor):
+    pass

--- a/src/biome/allennlp/predictors/utils.py
+++ b/src/biome/allennlp/predictors/utils.py
@@ -16,10 +16,10 @@ def get_predictor_from_archive(
     # Matching predictor name with model name
     model_config = archive.config.get("model")
     dataset_reader_config = archive.config.get("dataset_reader")
-    predictor = predictor_name if predictor_name else model_config.get("type")
+    predictor_name = predictor_name or model_config.get("type")
     try:
-        return Predictor.from_archive(archive, predictor)
+        return Predictor.from_archive(archive, predictor_name)
     except Exception as e:
-        _logger.warning("Cannot create predictor {}, usind default. Error: {}".format(predictor, e))
+        _logger.warning("Cannot create predictor {}, usind default. Error: {}".format(predictor_name, e))
         ds_reader = DatasetReader.from_params(dataset_reader_config)
         return DefaultBasePredictor(archive.model, ds_reader)


### PR DESCRIPTION
I also registered a SequenceClassifier predictor to suppress the warning.
Remember:
- training uses the `read` (`_read`) method!
- predictor uses the `text_to_instance` method!