### PR TITLE
refactor(datasource): manage data sources as tabular data

### DIFF
--- a/src/biome/allennlp/models/sequence_classifier.py
+++ b/src/biome/allennlp/models/sequence_classifier.py
@@ -53,7 +53,7 @@ class SequenceClassifier(Model):
         initializer: Optional[InitializerApplicator] = None,
         regularizer: Optional[RegularizerApplicator] = None,
         accuracy: Optional[Metric] = None,
-        model_location:Optional[str] = None
+        model_location: Optional[str] = None,
     ) -> None:
         super().__init__(
             vocab, regularizer

--- a/src/biome/data/sources/example_preparator.py
+++ b/src/biome/data/sources/example_preparator.py
@@ -1,5 +1,6 @@
 from typing import Dict, Optional, Any, List
 
+import deprecated
 from biome.data.utils import get_nested_property_from_data
 
 from numpy import number
@@ -13,6 +14,7 @@ RESERVED_FIELD_PREFIX = "@"
 SOURCE_FIELD = "{}source".format(RESERVED_FIELD_PREFIX)
 
 
+@deprecated.deprecated(reason="Will be removed!!")
 class TransformationConfig(object):
     def __init__(
         self,
@@ -42,6 +44,7 @@ class TransformationConfig(object):
         return mapping
 
 
+@deprecated.deprecated(reason="This class will be removed")
 class ExamplePreparator(object):
     def __init__(self, dataset_transformations: Dict):
         transformations = (dataset_transformations or dict()).copy()
@@ -129,6 +132,4 @@ class ExamplePreparator(object):
         if not example:
             example = source
 
-        return (
-            example if not include_source else {**example, SOURCE_FIELD: source}
-        )
+        return example if not include_source else {**example, SOURCE_FIELD: source}

--- a/src/biome/data/sources/readers.py
+++ b/src/biome/data/sources/readers.py
@@ -1,23 +1,26 @@
 import glob
+import logging
+import pandas
 from typing import Dict, Optional, Union, List
 
 import dask
 import dask.dataframe as dd
 import dask.distributed
+import deprecated
 import pandas as pd
 from dask import delayed
-from dask.bag import Bag
+from dask.dataframe import DataFrame
 from elasticsearch import Elasticsearch
 from elasticsearch.helpers import scan
 
-from .utils import row2dict
-
-
+_logger = logging.getLogger(__name__)
 # TODO: The idea is to make the readers a class and define a metaclass that they have to follow.
 #       For now, all reader methods have to return a dask.Bag of dicts
 
 
-def from_csv(path: Union[str, List[str]], columns: List[str] = [], **params) -> Bag:
+def from_csv(
+    path: Union[str, List[str]], columns: List[str] = [], **params
+) -> DataFrame:
     """Creates a dask.Bag of dict objects from a collection of csv files
 
     Parameters
@@ -35,17 +38,10 @@ def from_csv(path: Union[str, List[str]], columns: List[str] = [], **params) -> 
         A `dask.Bag` of dicts
 
     """
-    dataframe = dd.read_csv(path, **params, include_path_column=True)
-
-    columns = (
-        [str(column).strip() for column in dataframe.columns]
-        if not columns
-        else columns
-    )
-    return dataframe.to_bag(index=True).map(row2dict, columns)
+    return dd.read_csv(path, include_path_column=True, **params)
 
 
-def from_json(path: Union[str, List[str]], **params) -> Bag:
+def from_json(path: Union[str, List[str]], **params) -> DataFrame:
     """
     Creates a dask.Bag of dict objects from a collection of json files
 
@@ -53,12 +49,13 @@ def from_json(path: Union[str, List[str]], **params) -> Bag:
     :param params: extra arguments passed to pandas.read_json
     :return: dask.bag.Bag
     """
-    dataframe = dd.read_json(path, **params)
+    ddf = dd.read_json(path, **params)
+    ddf["path"] = path
 
-    columns = [str(column).strip() for column in dataframe.columns]
-    return dataframe.to_bag(index=True).map(row2dict, columns, path)
+    return ddf
 
-def from_parquet(path: Union[str, List[str]], **params) -> Bag:
+
+def from_parquet(path: Union[str, List[str]], **params) -> DataFrame:
     """
     Creates a dask.Bag of dict objects from a parquet paths
 
@@ -66,12 +63,13 @@ def from_parquet(path: Union[str, List[str]], **params) -> Bag:
     :param params: extra arguments passed to pandas.read_json
     :return: dask.bag.Bag
     """
-    dataframe = dd.read_parquet(path, **params)
+    ddf = dd.read_parquet(path, **params)
+    ddf["path"] = path
 
-    columns = [str(column).strip() for column in dataframe.columns]
-    return dataframe.to_bag(index=True).map(row2dict, columns, path)
+    return ddf
 
-def from_excel(path: str, **params) -> Bag:
+
+def from_excel(path: str, **params) -> DataFrame:
     """
     Creates a dask.Bag of dict objects from a collection excel files
 
@@ -80,23 +78,23 @@ def from_excel(path: str, **params) -> Bag:
     :return: dask.bag.Bag
     """
     file_names = glob.glob(path, recursive=True)
-    dataframe = dd.from_pandas(
+    ddf = dd.from_pandas(
         pd.read_excel(path, **params).fillna(""), npartitions=max(1, len(file_names))
     )
 
-    columns = [str(column).strip() for column in dataframe.columns]
+    ddf["path"] = path
+    return ddf
 
-    return dataframe.to_bag(index=True).map(row2dict, columns, path)
 
-
+@deprecated.deprecated(reason="source-only field will be removed")
 def from_elasticsearch(
     query: Optional[Dict] = None,
     npartitions: int = 2,
     client_cls: Optional = None,
     client_kwargs=None,
-    source_only=False,
+    source_only=True,
     **kwargs
-) -> Bag:
+) -> DataFrame:
     """Reads documents from Elasticsearch.
 
     By default, documents are sorted by ``_doc``. For more information see the
@@ -107,7 +105,7 @@ def from_elasticsearch(
     query : dict, optional
         Search query.
     npartitions : int, optional
-        Number of partitions, default is 1.
+        Number of partitions, default is 2.
     client_cls : elasticsearch.Elasticsearch, optional
         Elasticsearch client class.
     client_kwargs : dict, optional
@@ -135,12 +133,11 @@ def from_elasticsearch(
 
     """
 
-    def map_to_source(x: Dict) -> Dict:
-        return x["_source"] if source_only else x
-
-    assert (
-        npartitions > 1
-    ), "Elasticsearch source doesn't work with single partition. Minimum partition size is 2"
+    if npartitions < 2:
+        _logger.warning(
+            "A minium of 2 partitions is needed for elasticsearch scan slices....Setting partitions number to 2"
+        )
+        npartitions = 2
 
     query = query or {}
     # Sorting by _doc is preferred for scrolling.
@@ -148,22 +145,24 @@ def from_elasticsearch(
     if client_cls is None:
         client_cls = Elasticsearch
     # We load documents in parallel using the scrolling + slicing feature.
-
-    return dask.bag.from_delayed(
-        [
-            delayed(_elasticsearch_scan)(client_cls, client_kwargs, **scan_kwargs)
-            for scan_kwargs in [
-                dict(kwargs, query=dict(query, slice=slice))
-                for slice in [
-                    {"id": idx, "max": npartitions} for idx in range(npartitions)
-                ]
-            ]
+    index_scan = [
+        delayed(_elasticsearch_scan)(client_cls, client_kwargs, **scan_kwargs)
+        for scan_kwargs in [
+            dict(kwargs, query=dict(query, slice=slice))
+            for slice in [{"id": idx, "max": npartitions} for idx in range(npartitions)]
         ]
-    ).map(map_to_source)
+    ]
+
+    return dask.dataframe.from_delayed(index_scan)
 
 
-def _elasticsearch_scan(client_cls, client_kwargs, **params):
+def _elasticsearch_scan(client_cls, client_kwargs, **params) -> pandas.DataFrame:
+    def map_to_source(x: Dict) -> Dict:
+        return dict(id=x["_id"], resource=x["_index"], **x["_source"])
+
     # This method is executed in the worker's process and here we instantiate
     # the ES client as it cannot be serialized.
     client = client_cls(**(client_kwargs or {}))
-    return list(scan(client, **params))
+    return pandas.DataFrame(
+        (map_to_source(document) for document in scan(client, **params))
+    ).set_index("id")

--- a/src/biome/data/utils.py
+++ b/src/biome/data/utils.py
@@ -70,7 +70,7 @@ def default_elasticsearch_sink(
 
 def yaml_to_dict(filepath: str):
     with open(filepath) as yaml_content:
-        config = yaml.load(yaml_content)
+        config = yaml.safe_load(yaml_content)
     return config
 
 

--- a/tests/allennlp/dataset_readers/test_dataset_reader_forward.py
+++ b/tests/allennlp/dataset_readers/test_dataset_reader_forward.py
@@ -1,75 +1,94 @@
 import os
-import pytest
 
+import pytest
 import yaml
 from allennlp.common import Params
 from allennlp.data.fields import TextField, LabelField
-
-from biome.allennlp.dataset_readers import SequenceClassifierDatasetReader, SequencePairClassifierDatasetReader
+from biome.allennlp.dataset_readers import SequenceClassifierDatasetReader
 from tests.test_context import TEST_RESOURCES, create_temp_configuration
+
 from tests.test_support import DaskSupportTest
 
-DS_READER_DEFINITION = os.path.join(TEST_RESOURCES,
-                                    'resources/dataset_readers/definitions/forward_input_label_reader_definition.yml')
+DS_READER_DEFINITION = os.path.join(
+    TEST_RESOURCES,
+    "resources/dataset_readers/definitions/forward_input_label_reader_definition.yml",
+)
 
-MULTIPLE_INPUT_READER_DEFINITION = os.path.join(TEST_RESOURCES,
-                                                'resources/dataset_readers/definitions/forward_r1_r2_gold_reader_definition.yml')
+MULTIPLE_INPUT_READER_DEFINITION = os.path.join(
+    TEST_RESOURCES,
+    "resources/dataset_readers/definitions/forward_r1_r2_gold_reader_definition.yml",
+)
 
-JSON_PATH = os.path.join(TEST_RESOURCES, 'resources/data/dataset_source.jsonl')
-NOLABEL_JSON_PATH = os.path.join(TEST_RESOURCES, 'resources/data/dataset_source_without_label.jsonl')
+JSON_PATH = os.path.join(TEST_RESOURCES, "resources/data/dataset_source.jsonl")
+NOLABEL_JSON_PATH = os.path.join(
+    TEST_RESOURCES, "resources/data/dataset_source_without_label.jsonl"
+)
 
 # TODO: Review the forward format in the DatasetReader and adapt tests!!!
 class DatasetReaderForwardTest(DaskSupportTest):
-
     @pytest.mark.xfail
     def test_reader_with_forward_definition(self):
         with open(DS_READER_DEFINITION) as yml_config:
             reader = SequenceClassifierDatasetReader()
-            read_config = dict(path=JSON_PATH, forward=dict(input=['reviewText'], label='overall'))
+            read_config = dict(
+                path=JSON_PATH, forward=dict(input=["reviewText"], label="overall")
+            )
 
             dataset = reader.read(create_temp_configuration(read_config))
             for example in dataset:
-                input = example.fields.get('input')
-                label = example.fields.get('label')
+                input = example.fields.get("input")
+                label = example.fields.get("label")
 
-                assert input is not None, 'None input'
-                assert label is not None, 'None label'
+                assert input is not None, "None input"
+                assert label is not None, "None label"
 
-                assert isinstance(input, TextField), 'input is not a TextField instance'
-                assert isinstance(label, LabelField), 'label is not a LabelField instance'
+                assert isinstance(input, TextField), "input is not a TextField instance"
+                assert isinstance(
+                    label, LabelField
+                ), "label is not a LabelField instance"
 
     @pytest.mark.xfail
     def test_reader_with_another_forward_definition(self):
         with open(MULTIPLE_INPUT_READER_DEFINITION) as yml_config:
-            reader = SequenceClassifierDatasetReader.from_params(params=Params(yaml.load(yml_config)))
-            read_config = dict(path=JSON_PATH, forward=dict(r1=['reviewText'], r2=['reviewText'], gold='overall'))
+            reader = SequenceClassifierDatasetReader.from_params(
+                params=Params(yaml.load(yml_config))
+            )
+            read_config = dict(
+                path=JSON_PATH,
+                forward=dict(r1=["reviewText"], r2=["reviewText"], gold="overall"),
+            )
 
             dataset = reader.read(create_temp_configuration(read_config))
             for example in dataset:
-                r1 = example.fields.get('r1')
-                r2 = example.fields.get('r2')
-                gold = example.fields.get('gold')
+                r1 = example.fields.get("r1")
+                r2 = example.fields.get("r2")
+                gold = example.fields.get("gold")
 
-                assert r1 is not None, 'None r1'
-                assert r2 is not None, 'None r2'
-                assert gold is not None, 'None gold'
+                assert r1 is not None, "None r1"
+                assert r2 is not None, "None r2"
+                assert gold is not None, "None gold"
 
-                assert isinstance(r1, TextField), 'r1 is not a TextField instance'
-                assert isinstance(r2, TextField), 'r2 is not a TextField instance'
-                assert isinstance(gold, LabelField), 'gold is not a LabelField instance'
+                assert isinstance(r1, TextField), "r1 is not a TextField instance"
+                assert isinstance(r2, TextField), "r2 is not a TextField instance"
+                assert isinstance(gold, LabelField), "gold is not a LabelField instance"
 
     @pytest.mark.xfail
     def test_reader_with_optional_params(self):
         with open(DS_READER_DEFINITION) as yml_config:
-            reader = SequenceClassifierDatasetReader.from_params(params=Params(yaml.load(yml_config)))
-            read_config = dict(path=NOLABEL_JSON_PATH, forward=dict(input=['reviewText'], label='overall'))
+            reader = SequenceClassifierDatasetReader.from_params(
+                params=Params(yaml.load(yml_config))
+            )
+            read_config = dict(
+                path=NOLABEL_JSON_PATH,
+                forward=dict(input=["reviewText"], label="overall"),
+            )
 
             dataset = reader.read(create_temp_configuration(read_config))
             for example in dataset:
-                input = example.fields.get('input')
-                label = example.fields.get('label')
+                input = example.fields.get("input")
+                label = example.fields.get("label")
 
-                assert input is not None, 'None input'
-                assert label is None, 'Expeced None label'
+                assert input is not None, "None input"
+                assert label is None, "Expeced None label"
 
-                assert isinstance(input, TextField), 'input is not a TextField instance'
+                assert isinstance(input, TextField), "input is not a TextField instance"

--- a/tests/allennlp/predictors/test_default_base_predictor.py
+++ b/tests/allennlp/predictors/test_default_base_predictor.py
@@ -52,7 +52,7 @@ def test_predict_batch_json(predictor):
     ]
 
     results = predictor.predict_batch_json(inputs)
-    assert len(results) == 2
+    assert len(results) == len(inputs) - 1
 
     with pytest.raises(IndexError) as err:
         predictor.predict_batch_json([inputs[2]])

--- a/tests/data/sources/test_es_reader.py
+++ b/tests/data/sources/test_es_reader.py
@@ -1,25 +1,24 @@
-import unittest
-
 from biome.data.sources.readers import from_elasticsearch
+from dask.dataframe import DataFrame
 
 from tests.test_support import DaskSupportTest
 
 NPARTITIONS = 4
-ES_HOST = 'http://localhost:9200'
-ES_INDEX = 'gourmet-food'
+ES_HOST = "http://34.242.123.170:9200/"
+ES_INDEX = "another-classifier::test-explore"
 
 
 class ElasticsearchReaderTest(DaskSupportTest):
-    @unittest.skip
     def test_read_whole_index(self):
         es_index = from_elasticsearch(
-            npartitions=NPARTITIONS,
-            client_kwargs={'hosts': ES_HOST},
-            index=ES_INDEX,
-            source_only=True
+            npartitions=NPARTITIONS, client_kwargs={"hosts": ES_HOST}, index=ES_INDEX
         )
 
-        self.assertTrue(es_index.npartitions == NPARTITIONS)
-
-        for example in es_index:
-            print(example)
+        self.assertTrue(
+            isinstance(es_index, DataFrame),
+            f"elasticsearch datasource is not a dataframe :{type(es_index)}",
+        )
+        self.assertTrue(
+            es_index.npartitions == NPARTITIONS, "Wrong number of partitions"
+        )
+        self.assertTrue("id" not in es_index.columns.values, "Expected id as index")


### PR DESCRIPTION
Data sources handling  as `dask.dataframe`types.

Also avoid use of `ExamplePreparator` class inside `DataSource` since is a very coupled logic of `SequenceClassifierDatasetReader`. The `tokens`-`label` transformation are handled in dataset reader