### PR TITLE
Introduce the SimilarityClassifier Model

### DIFF
--- a/src/biome/allennlp/dataset_readers/sequence_classifier_dataset_reader.py
+++ b/src/biome/allennlp/dataset_readers/sequence_classifier_dataset_reader.py
@@ -38,7 +38,9 @@ class _ForwardConfiguration:
             if isinstance(label, str):
                 self._label = label
             else:
-                self._label = label.get("name", label.get("gold_label"))
+                self._label = label.get("name") or label.get("label") or label.get("gold_label")
+                if not self._label:
+                    raise RuntimeError("I am missing the label name!")
                 self._default_label = label.get(
                     "default", label.get("use_missing_label")
                 )

--- a/src/biome/allennlp/dataset_readers/sequence_pair_classifier_dataset_reader.py
+++ b/src/biome/allennlp/dataset_readers/sequence_pair_classifier_dataset_reader.py
@@ -45,7 +45,9 @@ class _ForwardConfiguration:
             if isinstance(label, str):
                 self._label = label
             else:
-                self._label = label.get("name", label.get("gold_label"))
+                self._label = label.get("name") or label.get("label") or label.get("gold_label")
+                if not self._label:
+                    raise RuntimeError("I am missing the label name!")
                 self._default_label = label.get(
                     "default", label.get("use_missing_label")
                 )

--- a/src/biome/allennlp/models/__init__.py
+++ b/src/biome/allennlp/models/__init__.py
@@ -1,3 +1,4 @@
 from .sequence_classifier import SequenceClassifier
 from .sequence_pair_classifier import SequencePairClassifier
+from .similarity_classifier import SimilarityClassifier
 from .archival import load_archive, to_local_archive

--- a/src/biome/allennlp/models/sequence_classifier.py
+++ b/src/biome/allennlp/models/sequence_classifier.py
@@ -97,8 +97,8 @@ class SequenceClassifier(Model):
         self._check_configuration()
 
         # metrics
-        self.accuracy = accuracy or CategoricalAccuracy()
-        self.metrics = {
+        self._accuracy = accuracy or CategoricalAccuracy()
+        self._metrics = {
             label: F1Measure(index)
             for index, label in self.vocab.get_index_to_token_vocabulary(
                 "labels"
@@ -176,8 +176,8 @@ class SequenceClassifier(Model):
         if label is not None:
             loss = self._loss(logits, label.long())
             output_dict["loss"] = loss
-            self.accuracy(logits, label)
-            for name, metric in self.metrics.items():
+            self._accuracy(logits, label)
+            for name, metric in self._metrics.items():
                 metric(logits, label)
 
         return output_dict
@@ -235,7 +235,7 @@ class SequenceClassifier(Model):
         total_f1 = 0.0
         total_precision = 0.0
         total_recall = 0.0
-        for metric_name, metric in self.metrics.items():
+        for metric_name, metric in self._metrics.items():
             precision, recall, f1 = metric.get_metric(
                 reset
             )  # pylint: disable=invalid-name
@@ -246,11 +246,11 @@ class SequenceClassifier(Model):
             all_metrics[metric_name + "/precision"] = precision
             all_metrics[metric_name + "/recall"] = recall
 
-        num_metrics = len(self.metrics)
+        num_metrics = len(self._metrics)
         all_metrics["average/f1"] = total_f1 / num_metrics
         all_metrics["average/precision"] = total_precision / num_metrics
         all_metrics["average/recall"] = total_recall / num_metrics
-        all_metrics["accuracy"] = self.accuracy.get_metric(reset)
+        all_metrics["accuracy"] = self._accuracy.get_metric(reset)
 
         return all_metrics
 

--- a/src/biome/allennlp/models/sequence_classifier.py
+++ b/src/biome/allennlp/models/sequence_classifier.py
@@ -121,14 +121,17 @@ class SequenceClassifier(Model):
         Parameters
         ----------
         tokens
-            The output of ``TextField.as_array()``, which should typically be passed directly to a
-            ``TextFieldEmbedder``. This output is a dictionary mapping keys to ``TokenIndexer``
-            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is: ``{"tokens":
-            Tensor(batch_size, num_tokens)}``. This dictionary will have the same keys as were used
-            for the ``TokenIndexers`` when you created the ``TextField`` representing your
-            sequence.  The dictionary is designed to be passed directly to a ``TextFieldEmbedder``,
-            which knows how to combine different word representations into a single vector per
-            token in your input.
+            The input tokens.
+            The dictionary is the output of a ``TextField.as_array()``. It gives names to the tensors created by
+            the ``TokenIndexer``s.
+            In its most basic form, using a ``SingleIdTokenIndexer``, the dictionary is composed of:
+            ``{"tokens": Tensor(batch_size, num_tokens)}``.
+            The keys of the dictionary are defined in the `model.yml` input.
+            The dictionary is designed to be passed on directly to a ``TextFieldEmbedder``, that has a
+            ``TokenEmbedder`` for each key in the dictionary (except you set `allow_unmatched_keys` in the
+            ``TextFieldEmbedder`` to False) and knows how to combine different word/character representations into a
+            single vector per token in your input.
+
         label
             A torch tensor representing the sequence of integer gold class label of shape
             ``(batch_size, num_classes)``.

--- a/src/biome/allennlp/models/sequence_pair_classifier.py
+++ b/src/biome/allennlp/models/sequence_pair_classifier.py
@@ -81,7 +81,7 @@ class SequencePairClassifier(SequenceClassifier):
         if label is not None:
             loss = self._loss(logits, label.long())
             output_dict["loss"] = loss
-            self.accuracy(logits, label)
-            for name, metric in self.metrics.items():
+            self._accuracy(logits, label)
+            for name, metric in self._metrics.items():
                 metric(logits, label)
         return output_dict

--- a/src/biome/allennlp/models/sequence_pair_classifier.py
+++ b/src/biome/allennlp/models/sequence_pair_classifier.py
@@ -24,24 +24,19 @@ class SequencePairClassifier(SequenceClassifier):
         """
         Parameters
         ----------
-        record1 : Dict[str, torch.LongTensor], required
-            The output of ``TextField.as_array()``, which should typically be passed directly to a
-            ``TextFieldEmbedder``. This output is a dictionary mapping keys to ``TokenIndexer``
-            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is: ``{"tokens":
-            Tensor(batch_size, num_tokens)}``. This dictionary will have the same keys as were used
-            for the ``TokenIndexers`` when you created the ``TextField`` representing your
-            sequence.  The dictionary is designed to be passed directly to a ``TextFieldEmbedder``,
-            which knows how to combine different word representations into a single vector per
-            token in your input.
-        record2 : Dict[str, torch.LongTensor], required
-            The output of ``TextField.as_array()``, which should typically be passed directly to a
-            ``TextFieldEmbedder``. This output is a dictionary mapping keys to ``TokenIndexer``
-            tensors.  At its most basic, using a ``SingleIdTokenIndexer`` this is: ``{"tokens":
-            Tensor(batch_size, num_tokens)}``. This dictionary will have the same keys as were used
-            for the ``TokenIndexers`` when you created the ``TextField`` representing your
-            sequence.  The dictionary is designed to be passed directly to a ``TextFieldEmbedder``,
-            which knows how to combine different word representations into a single vector per
-            token in your input.
+        record1
+            The first input tokens.
+            The dictionary is the output of a ``TextField.as_array()``. It gives names to the tensors created by
+            the ``TokenIndexer``s.
+            In its most basic form, using a ``SingleIdTokenIndexer``, the dictionary is composed of:
+            ``{"tokens": Tensor(batch_size, num_tokens)}``.
+            The keys of the dictionary are defined in the `model.yml` input.
+            The dictionary is designed to be passed on directly to a ``TextFieldEmbedder``, that has a
+            ``TokenEmbedder`` for each key in the dictionary (except you set `allow_unmatched_keys` in the
+            ``TextFieldEmbedder`` to False) and knows how to combine different word/character representations into a
+            single vector per token in your input.
+        record2
+            The second input tokens.
         label : torch.LongTensor, optional (default = None)
             A torch tensor representing the sequence of integer gold class label of shape
             ``(batch_size, num_classes)``.
@@ -59,21 +54,30 @@ class SequencePairClassifier(SequenceClassifier):
             A scalar loss to be optimised.
 
         """
-        embedded_text_input_record1 = self.text_field_embedder(record1)
-        embedded_text_input_record2 = self.text_field_embedder(record2)
-        mask_record1 = get_text_field_mask(record1)
-        mask_record2 = get_text_field_mask(record2)
-        if self.pre_encoder:
-            embedded_text_input_record1 = self.pre_encoder(embedded_text_input_record1)
-            embedded_text_input_record2 = self.pre_encoder(embedded_text_input_record2)
-        if self.encoder:
-            encoded_record1 = self.encoder(embedded_text_input_record1, mask_record1)
-            encoded_record2 = self.encoder(embedded_text_input_record2, mask_record2)
+        encoded_texts = []
+        for tokens in [record1, record2]:
+            embedded_text = self._text_field_embedder(tokens)
+            mask = get_text_field_mask(tokens).float()
 
-        aggregated_records = torch.cat([encoded_record1, encoded_record2], dim=-1)
-        decoded_text = self.decoder(aggregated_records)
+            if self._pre_encoder:
+                embedded_text = self._pre_encoder(embedded_text)
 
-        logits = self.output_layer(decoded_text)
+            if self._seq2seq_encoder:
+                embedded_text = self._seq2seq_encoder(embedded_text, mask=mask)
+
+            encoded_text = self._encoder(embedded_text, mask=mask)
+
+            # apply dropout to encoded vector
+            if self._dropout:
+                encoded_text = self._dropout(encoded_text)
+
+            encoded_texts.append(encoded_text)
+
+        aggregated_records = torch.cat(encoded_texts, dim=-1)
+
+        decoded_text = self._decoder(aggregated_records)
+
+        logits = self._output_layer(decoded_text)
         class_probabilities = softmax(logits, dim=1)
 
         output_dict = {"logits": logits, "class_probabilities": class_probabilities}

--- a/src/biome/allennlp/models/similarity_classifier.py
+++ b/src/biome/allennlp/models/similarity_classifier.py
@@ -91,7 +91,7 @@ class SimilarityClassifier(SequenceClassifier):
         self._accuracy = CategoricalAccuracy()
         self._loss = torch.nn.CrossEntropyLoss()
 
-        self.metrics = {
+        self._metrics = {
             label: F1Measure(index)
             for index, label in self.vocab.get_index_to_token_vocabulary(
                 "labels"
@@ -167,6 +167,8 @@ class SimilarityClassifier(SequenceClassifier):
             loss = self._loss(logits, label.long().view(-1))
             output_dict["loss"] = loss
             self._accuracy(logits, label)
+            for name, metric in self._metrics.items():
+                metric(logits, label)
 
         return output_dict
 

--- a/src/biome/allennlp/models/similarity_classifier.py
+++ b/src/biome/allennlp/models/similarity_classifier.py
@@ -1,0 +1,151 @@
+from typing import Dict, Optional
+
+from overrides import overrides
+import torch
+
+from allennlp.data import Vocabulary
+from allennlp.models.model import Model
+from allennlp.modules import Seq2SeqEncoder, Seq2VecEncoder, TextFieldEmbedder, SimilarityFunction
+from allennlp.modules.similarity_functions import CosineSimilarity
+from allennlp.nn import InitializerApplicator, RegularizerApplicator
+from allennlp.nn.util import get_text_field_mask
+from allennlp.training.metrics import CategoricalAccuracy
+
+
+@Model.register("similarity_classifier")
+class SimilarityClassifier(Model):
+    """
+    This ``SimilarityClassifier`` uses a siamese network architecture to perform a binary classification task:
+    are two inputs similar or not?
+    The two input sequences are encoded with a Seq2VecEncoder, the resulting vectors are concatenated andgg
+
+    simply encodes a sequence of allennlp_2 with a ``Seq2VecEncoder``, then
+    predicts a label for the sequence.
+
+    Parameters
+    ----------
+    vocab
+        A Vocabulary, required in order to compute sizes for input/output projections
+        and passed on to the :class:`~allennlp.models.model.Model` class.
+    text_field_embedder
+        Used to embed the input text into a ``TextField``
+    seq2seq_encoder
+        Optional Seq2Seq encoder layer for the input text.
+    seq2vec_encoder
+        Required Seq2Vec encoder layer. If `seq2seq_encoder` is provided, this encoder
+        will pool its output. Otherwise, this encoder will operate directly on the output
+        of the `text_field_embedder`.
+    dropout
+        Dropout percentage to use on the output of the Seq2VecEncoder
+    initializer
+        Used to initialize the model parameters.
+    regularizer
+        Used to regularize the model. Passed on to :class:`~allennlp.models.model.Model`.
+    """
+
+    def __init__(
+            self,
+            vocab: Vocabulary,
+            text_field_embedder: TextFieldEmbedder,
+            seq2vec_encoder: Seq2VecEncoder,
+            seq2seq_encoder: Seq2SeqEncoder = None,
+            dropout: float = None,
+            similarity: SimilarityFunction = None,
+            initializer: Optional[InitializerApplicator] = None,
+            regularizer: Optional[RegularizerApplicator] = None,
+    ) -> None:
+        super().__init__(
+            vocab, regularizer
+        )  # Passing on kwargs does not work because of the 'from_params' machinery
+
+        self._text_field_embedder = text_field_embedder
+
+        if seq2seq_encoder:
+            self._seq2seq_encoder = seq2seq_encoder
+        else:
+            self._seq2seq_encoder = None
+
+        self._seq2vec_encoder = seq2vec_encoder
+
+        if dropout:
+            self._dropout = torch.nn.Dropout(dropout)
+        else:
+            self._dropout = None
+
+        self.similarity = similarity or CosineSimilarity()
+
+        self._accuracy = CategoricalAccuracy()
+        self._loss = torch.nn.CrossEntropyLoss()
+        initializer(self)
+
+    @overrides
+    def forward(
+            self,  # type: ignore
+            tokens1: Dict[str, torch.LongTensor],
+            tokens2: Dict[str, torch.LongTensor],
+            label: torch.Tensor = None,
+    ) -> Dict[str, torch.Tensor]:
+        # pylint: disable=arguments-differ
+        """
+        Parameters
+        ----------
+        tokens : Dict[str, torch.LongTensor]
+            From a ``TextField``
+        tokens1
+            The first input tokens.
+            The dictionary is the output of a ``TextField.as_array()``. It gives names to the tensors created by
+            the ``TokenIndexer``s.
+            In its most basic form, using a ``SingleIdTokenIndexer``, the dictionary is composed of:
+            ``{"tokens": Tensor(batch_size, num_tokens)}``.
+            The keys of the dictionary are defined in the `model.yml` input.
+            The dictionary is designed to be passed on directly to a ``TextFieldEmbedder``, that has a
+            ``TokenEmbedder`` for each key in the dictionary (except you set `allow_unmatched_keys` in the
+            ``TextFieldEmbedder`` to False) and knows how to combine different word/character representations into a
+            single vector per token in your input.
+        tokens2
+            The second input tokens.
+        label
+            A torch tensor indicating if the two set of input tokens are similar or not (dim: ``(batch_size, 2)``).
+
+        Returns
+        -------
+        An output dictionary consisting of:
+        logits
+        class_probabilities
+        loss : :class:`~torch.Tensor`, optional
+            A scalar loss to be optimised.
+        """
+        embedded_texts = []
+        for tokens in [tokens1, tokens2]:
+            embedded_text = self._text_field_embedder(tokens)
+            mask = get_text_field_mask(tokens).float()
+
+            if self._seq2seq_encoder:
+                embedded_text = self._seq2seq_encoder(embedded_text1, mask=mask1)
+
+            embedded_text = self._seq2vec_encoder(embedded_text, mask=mask)
+
+            if self._dropout:
+                embedded_text = self._dropout(embedded_text)
+
+            embedded_texts.append(embedded_text)
+
+        similarity = self.similarity(embedded_texts[0], embedded_texts[1])
+        probs = torch.nn.functional.softmax(similarity, dim=-1)
+
+        print(similarity)
+
+        output_dict = {"similarity": similarity, "probs": probs}
+
+        if label is not None:
+            loss = self._loss(similarity, label.long().view(-1))
+            output_dict["loss"] = loss
+            self._accuracy(similarity, label)
+
+        return output_dict
+
+    @overrides
+    def get_metrics(self, reset: bool = False) -> Dict[str, float]:
+        metrics = {'accuracy': self._accuracy.get_metric(reset)}
+        return metrics
+

--- a/src/biome/allennlp/models/similarity_classifier.py
+++ b/src/biome/allennlp/models/similarity_classifier.py
@@ -55,7 +55,7 @@ class SimilarityClassifier(SequenceClassifier):
             initializer: InitializerApplicator = InitializerApplicator(),
             regularizer: Optional[RegularizerApplicator] = None,
     ) -> None:
-        super().__init__(
+        super(SequenceClassifier, self).__init__(
             vocab, regularizer
         )  # Passing on kwargs does not work because of the 'from_params' machinery
 


### PR DESCRIPTION
This PR adds a `SimilarityClassifier` model taking advantage of two loss terms (see: Deep Learning Face Representation by Joint Identification-Verification, https://arxiv.org/pdf/1406.4773.pdf).
It is fairly similar to the `SequencePairClassifier`.

I also aligned the three classifier model, maybe we could merge the `SequencePairClassifier` and the `SimilarityClassifier` in the future.

Some small fixes are also included.