### PR TITLE
Use ListField instead of TextField for sequence pair classification problems

### DIFF
--- a/src/biome/allennlp/models/sequence_pair_classifier.py
+++ b/src/biome/allennlp/models/sequence_pair_classifier.py
@@ -1,19 +1,155 @@
 import logging
 from typing import Dict, Optional
+
+from allennlp.training.metrics import CategoricalAccuracy, F1Measure
 from overrides import overrides
 
 import torch
+from allennlp.data import Vocabulary
+from allennlp.modules import (
+    Seq2SeqEncoder,
+    Seq2VecEncoder,
+    TextFieldEmbedder,
+    FeedForward,
+)
+from allennlp.nn import InitializerApplicator, RegularizerApplicator
 from allennlp.models.model import Model
 from allennlp.nn.util import get_text_field_mask
 from torch.nn.functional import softmax
+from allennlp.modules.time_distributed import TimeDistributed
 
 from . import SequenceClassifier
 
 logger = logging.getLogger(__name__)
 
-
 @Model.register("sequence_pair_classifier")
 class SequencePairClassifier(SequenceClassifier):
+    """
+    This ``SequencePairClassifier`` uses a siamese network architecture to perform a classification task between a pair
+    of records or documents.
+
+    The classifier can be configured to take into account the hierarchical structure of documents and multi-field records.
+
+    A record/document can be (1) single-field (single sentence): composed of a sequence of
+    tokens, or (2) multi-field (multi-sentence): a sequence of fields with each of the fields containing a sequence of
+    tokens. In the case of multi-field a doc_seq2vec_encoder and optionally a doc_seq2seq_encoder should be configured,
+    for encoding each of the fields into a single vector encoding the full record/doc must be configured.
+
+    The sequences are encoded into two single vectors, the resulting vectors are concatenated and fed to a
+    linear classification layer.
+
+    Parameters
+    ----------
+    vocab
+        A Vocabulary, required in order to compute sizes for input/output projections
+        and passed on to the :class:`~allennlp.models.model.Model` class.
+    text_field_embedder
+        Used to embed the input text into a ``TextField``
+    seq2seq_encoder
+        Optional Seq2Seq encoder layer for the input text.
+    seq2vec_encoder
+        Required Seq2Vec encoder layer. If `seq2seq_encoder` is provided, this encoder
+        will pool its output. Otherwise, this encoder will operate directly on the output
+        of the `text_field_embedder`.
+    doc_seq2vec_encoder
+        Required Seq2Vec encoder layer. If `seq2seq_encoder` is provided, this encoder
+        will pool its output. Otherwise, this encoder will operate directly on the output
+        of the `seq2vec_encoder`.
+    doc_seq2seq_encoder
+        Optional Seq2Seq encoder layer for the encoded fields/sentences.
+    dropout
+        Dropout percentage to use on the output of the Seq2VecEncoder
+    doc_dropout
+        Dropout percentage to use on the output of the doc Seq2VecEncoder
+    feed_forward
+        A feed forward layer applied to the encoded inputs.
+    initializer
+        Used to initialize the model parameters.
+    regularizer
+        Used to regularize the model. Passed on to :class:`~allennlp.models.model.Model`.
+    """
+    @overrides
+    def __init__(
+        self,
+        vocab: Vocabulary,
+        text_field_embedder: TextFieldEmbedder,
+        seq2vec_encoder: Seq2VecEncoder,
+        seq2seq_encoder: Seq2SeqEncoder = None,
+        doc_seq2vec_encoder: Seq2VecEncoder = None,
+        doc_seq2seq_encoder: Seq2SeqEncoder = None,
+        feed_forward: Optional[FeedForward] = None,
+        dropout: float = None,
+        doc_dropout: float = None,
+        initializer: Optional[InitializerApplicator] = None,
+        regularizer: Optional[RegularizerApplicator] = None,
+    ) -> None:
+        super(SequenceClassifier, self).__init__(
+            vocab, regularizer
+        )  # Passing on kwargs does not work because of the 'from_params' machinery
+        self._initializer = initializer or InitializerApplicator()
+
+        self._text_field_embedder = text_field_embedder
+
+        # token sequence level encoders
+        self._seq2seq_encoder = seq2seq_encoder # can be None
+        self._seq2vec_encoder = seq2vec_encoder
+
+        # default value for wrapping dimensions for masking = 0 (single field)
+        self._num_wrapping_dims = 0
+
+        # doc level encoders
+        if doc_seq2vec_encoder:
+            # If we want to use multi-field input we need to:
+
+            # 1. setup num_wrapping_dims to 1
+            self._num_wrapping_dims = 1
+
+            # 2. Wrap the seq2vec and seq2seq encoders in TimeDistributed to account for the extra dimension num_fields
+            self._seq2vec_encoder = TimeDistributed(seq2vec_encoder)
+            self._seq2seq_encoder = TimeDistributed(seq2seq_encoder) if seq2seq_encoder else None
+
+            # 3. setup doc_seq2vec_encoder
+            self._doc_seq2vec_encoder = doc_seq2vec_encoder
+
+            # 4. (Optionally) setup doc_seq2seq_encoder
+            self._doc_seq2seq_encoder = TimeDistributed(doc_seq2seq_encoder) if doc_seq2seq_encoder else None
+
+        # token vector dropout
+        self._dropout = torch.nn.Dropout(dropout) if dropout else None
+
+        # doc vector dropout
+        self._doc_dropout = torch.nn.Dropout(doc_dropout) if dropout else None
+
+        self._feed_forward = feed_forward
+
+        if self._feed_forward:
+            self._classifier_input_dim = self._feed_forward.get_output_dim()
+        else:
+            self._classifier_input_dim = self._doc_seq2vec_encoder.get_output_dim() if self._doc_seq2vec_encoder else self._seq2vec_encoder.get_input_dim()
+
+        # Due to the concatenation of the two input vectors
+        self._classifier_input_dim *= 2
+
+        self._num_labels = vocab.get_vocab_size(namespace="labels")
+        self._classification_layer = torch.nn.Linear(
+            self._classifier_input_dim, self._num_labels
+        )
+
+        # metrics
+        self._accuracy = CategoricalAccuracy()
+        self._metrics = {
+            label: F1Measure(index)
+            for index, label in self.vocab.get_index_to_token_vocabulary(
+            "labels"
+        ).items()
+        }
+
+        # loss function for training
+        self._loss = torch.nn.CrossEntropyLoss()
+
+        self._initializer(self)
+        print(self)
+
     @overrides
     def forward(
         self,  # type: ignore
@@ -57,32 +193,44 @@ class SequencePairClassifier(SequenceClassifier):
         """
         encoded_texts = []
         for tokens in [record1, record2]:
-            # TODO dynamic num_wrapping_dims calculation from tokens tensor shape
-            mask = get_text_field_mask(tokens, num_wrapping_dims=1).float()
+            # TODO: This will probably not work for single field input, we need to check the shape of record 1 and 2.
+            mask = get_text_field_mask(tokens, num_wrapping_dims=self._num_wrapping_dims).float()
+
             embedded_text = self._text_field_embedder(tokens, mask=mask)
 
-            if self._pre_encoder:
-                embedded_text = self._pre_encoder(embedded_text)
-
+            # seq2seq encoding for each token in field
             if self._seq2seq_encoder:
                 embedded_text = self._seq2seq_encoder(embedded_text, mask=mask)
 
-            encoded_text = self._encoder(embedded_text, mask=mask)
+            # seq2vec encoding for tokens --> field vector
+            encoded_text = self._seq2vec_encoder(embedded_text, mask=mask)
 
-            # apply dropout to encoded vector
             if self._dropout:
                 encoded_text = self._dropout(encoded_text)
 
+            # seq2seq encoding for each field vector
+            # TODO: we need to mask properly
+            if self._doc_seq2seq_encoder:
+                encoded_text = self._doc_seq2seq_encoder(encoded_text, mask=mask)
+
+            if self._doc_dropout:
+                encoded_text = self._doc_dropout(encoded_text)
+
+            # seq2vec encoding for field --> record vector
+            encoded_text = self._doc_seq2vec_encoder(encoded_text)
+
+            if self._feed_forward:
+                encoded_text = self._feed_forward(encoded_text)
+
             encoded_texts.append(encoded_text)
 
-        aggregated_records = torch.cat(encoded_texts, dim=-1)
+        combined_records = torch.cat(encoded_texts, dim=-1)
 
-        decoded_text = self._decoder(aggregated_records)
+        logits = self._classification_layer(combined_records)
 
-        logits = self._output_layer(decoded_text)
-        class_probabilities = softmax(logits, dim=1)
+        probs = torch.nn.functional.softmax(logits, dim=-1)
 
-        output_dict = {"logits": logits, "class_probabilities": class_probabilities}
+        output_dict = {"logits": logits, "class_probabilities": probs}
 
         if label is not None:
             loss = self._loss(logits, label.long())

--- a/src/biome/allennlp/models/sequence_pair_classifier.py
+++ b/src/biome/allennlp/models/sequence_pair_classifier.py
@@ -19,8 +19,6 @@ from allennlp.training.metrics import CategoricalAccuracy, F1Measure
 
 from . import SequenceClassifier
 
-from biome.allennlp.models.utils import compute_and_set_layer_input_dim
-
 logger = logging.getLogger(__name__)
 
 @Model.register("sequence_pair_classifier")

--- a/src/biome/allennlp/models/sequence_pair_classifier.py
+++ b/src/biome/allennlp/models/sequence_pair_classifier.py
@@ -14,12 +14,13 @@ logger = logging.getLogger(__name__)
 
 @Model.register("sequence_pair_classifier")
 class SequencePairClassifier(SequenceClassifier):
-
     @overrides
-    def forward(self,  # type: ignore
-                record1: Dict[str, torch.Tensor],
-                record2: Dict[str, torch.Tensor],
-                label: torch.Tensor = None) -> Dict[str, torch.Tensor]:
+    def forward(
+        self,  # type: ignore
+        record1: Dict[str, torch.Tensor],
+        record2: Dict[str, torch.Tensor],
+        label: torch.Tensor = None,
+    ) -> Dict[str, torch.Tensor]:
         # pylint: disable=arguments-differ
         """
         Parameters
@@ -56,8 +57,9 @@ class SequencePairClassifier(SequenceClassifier):
         """
         encoded_texts = []
         for tokens in [record1, record2]:
-            embedded_text = self._text_field_embedder(tokens)
-            mask = get_text_field_mask(tokens).float()
+            # TODO dynamic num_wrapping_dims calculation from tokens tensor shape
+            mask = get_text_field_mask(tokens, num_wrapping_dims=1).float()
+            embedded_text = self._text_field_embedder(tokens, mask=mask)
 
             if self._pre_encoder:
                 embedded_text = self._pre_encoder(embedded_text)


### PR DESCRIPTION
This PR is a work in progress for testing behaviour using `ListField` of `TextField` for tokens values instead of joining them into a single `TextField` 

This new Instance format requires some minimal changes in `SequencePairClassifier.forward` method. The main one is to calculate tensor mask and the pass through the embedder...
```python
mask = get_text_field_mask(tokens, num_wrapping_dims=1).float()
embedded_text = self._text_field_embedder(tokens, mask=mask)
```
...adding a new parameter `num_wrapping_dims` that I have no idea what it's mean. ;-)

Also, for the training process, we need adapt the trainer iterator configuration to this new Instance format, since the field used for sorting batches was `num_tokens`, calculated by `TextField` and no available for `ListField`. Instead of that, using the field `num_fields`  should works:

```yaml
iterator:
  batch_size: 128
  cache_instances: 'true'
  max_instances_in_memory: 200000
  sorting_keys:
  - - record1
    # - num_tokens
    # Using ListField the field num_tokens is not available anymore. Instead of that, use num_fields field
    - num_fields  
  type: bucket

```


@dvsrepo  The training process is not working because how model calculates the tensor mask, probably related to the way I find the value for `num_wrapping_dims` param.

```console
INFO:allennlp.training.trainer:Training
  0%|          | 0/1 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "/usr/local/anaconda3/envs/biome/bin/biome", line 11, in <module>
    load_entry_point('biome-text', 'console_scripts', 'biome')()
  File "/Users/frascuchon/recognai/biome/biome-text/src/biome/__main__.py", line 71, in main
    args.func(args)
  File "/Users/frascuchon/recognai/biome/biome-text/src/biome/allennlp/commands/learn/learn.py", line 128, in learn_from_args
    workers=args.workers,
  File "/Users/frascuchon/recognai/biome/biome-text/src/biome/allennlp/commands/learn/learn.py", line 195, in learn
    force=True,
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/allennlp/commands/train.py", line 252, in train_model
    metrics = trainer.train()
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/allennlp/training/trainer.py", line 478, in train
    train_metrics = self._train_epoch(epoch)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/allennlp/training/trainer.py", line 320, in _train_epoch
    loss = self.batch_loss(batch_group, for_training=True)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/allennlp/training/trainer.py", line 261, in batch_loss
    output_dict = self.model(**batch)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/Users/frascuchon/recognai/biome/biome-text/src/biome/allennlp/models/sequence_pair_classifier.py", line 62, in forward
    embedded_text = self._text_field_embedder(tokens, mask=mask)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/allennlp/modules/text_field_embedders/basic_text_field_embedder.py", line 131, in forward
    token_vectors = embedder(*tensors, **forward_params_values)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/allennlp/modules/token_embedders/token_characters_encoder.py", line 35, in forward
    return self._dropout(self._encoder(self._embedding(token_characters), mask))
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/allennlp/modules/time_distributed.py", line 51, in forward
    reshaped_outputs = self._module(*reshaped_inputs, **reshaped_kwargs)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/torch/nn/modules/module.py", line 493, in __call__
    result = self.forward(*input, **kwargs)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/allennlp/modules/seq2vec_encoders/pytorch_seq2vec_wrapper.py", line 73, in forward
    self.sort_and_run_forward(self._module, inputs, mask, hidden_state)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/allennlp/modules/encoder_base.py", line 96, in sort_and_run_forward
    sort_batch_by_length(inputs, sequence_lengths)
  File "/usr/local/anaconda3/envs/biome/lib/python3.6/site-packages/allennlp/nn/util.py", line 168, in sort_batch_by_length
    sorted_tensor = tensor.index_select(0, permutation_index)
RuntimeError: invalid argument 3: Index is supposed to be 1-dimensional at /Users/distiller/project/conda/conda-bld/pytorch_1556653492823/work/aten/src/TH/generic/THTensorEvenMoreMath.cpp:166
```
