### PR TITLE
Fix concat non string values on reader

### DIFF
--- a/src/biome/allennlp/dataset_readers/mixins.py
+++ b/src/biome/allennlp/dataset_readers/mixins.py
@@ -74,7 +74,7 @@ class TextFieldBuilderMixin(object):
         if self._as_text_field:
             text = data
             if isinstance(data, dict):
-                text = " ".join(data.values())
+                text = " ".join(map(str, data.values()))
             return TextField(self._tokenizer.tokenize(text), self._token_indexers)
 
         text_fields = [


### PR DESCRIPTION
`TextFieldBuilderMixin`: when some token data is not of type `str`, the `str.join` fails.