### PR TITLE
Fix predict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             "urllib3>=1.21.1,<1.25",  # avoids version conflicts
-            "jsonschema~=2.6",  # avoids version conflicts
             "requests<=2.21.0",  # avoid version conflicts
             "allennlp~=0.8.0",
             "cachey",  # Needed to use the Cache class in dask

--- a/src/biome/allennlp/commands/predict/predict.py
+++ b/src/biome/allennlp/commands/predict/predict.py
@@ -129,7 +129,9 @@ def predict(
     try:
         test_dataset = data_source.to_forward_bag()
         npartitions = max(1, round(test_dataset.count().compute() / batch_size))
-        test_dataset = test_dataset.repartition(npartitions=npartitions)
+        # a persist is necessary here, otherwise it fails for npartitions == 1
+        # the reason is that with only 1 partition we pass on a generator to predict_batch_json
+        test_dataset = test_dataset.repartition(npartitions=npartitions).persist()
 
         predictor = _predictor_from_args(
             archive_file=to_local_archive(binary), cuda_device=cuda_device

--- a/src/biome/allennlp/commands/predict/predict.py
+++ b/src/biome/allennlp/commands/predict/predict.py
@@ -2,21 +2,21 @@ import argparse
 import datetime
 import logging
 import time
-from typing import Dict, Iterable, Any, List, Optional
+from typing import List, Optional
 
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common.util import import_submodules
 from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
 
+# TODO centralize configuration
+from elasticsearch import Elasticsearch
+
 from biome.allennlp.models import to_local_archive
 from biome.allennlp.predictors.utils import get_predictor_from_archive
 from biome.data.sinks import store_dataset
 from biome.data.sources import DataSource
 from biome.data.utils import configure_dask_cluster, default_elasticsearch_sink
-
-# TODO centralize configuration
-from elasticsearch import Elasticsearch
 
 logging.basicConfig(level=logging.INFO)
 _logger = logging.getLogger(__name__)

--- a/src/biome/allennlp/commands/predict/predict.py
+++ b/src/biome/allennlp/commands/predict/predict.py
@@ -9,7 +9,6 @@ from allennlp.common.util import import_submodules
 from allennlp.models.archival import load_archive
 from allennlp.predictors import Predictor
 
-from biome.allennlp.dataset_readers import LABEL_TOKEN
 from biome.allennlp.models import to_local_archive
 from biome.allennlp.predictors.utils import get_predictor_from_archive
 from biome.data.sinks import store_dataset
@@ -192,7 +191,7 @@ def register_biome_prediction(
                 project=project,
                 name=name,
                 created_at=datetime.datetime.now(),
-                inputs=[input for input in ds.forward.keys() if input != LABEL_TOKEN],
+                inputs=[input for input in ds.forward.tokens.keys()],
                 **kargs,
             ),
             "doc_as_upsert": True,

--- a/src/biome/allennlp/dataset_readers/__init__.py
+++ b/src/biome/allennlp/dataset_readers/__init__.py
@@ -1,4 +1,2 @@
 from .sequence_classifier_dataset_reader import SequenceClassifierDatasetReader
 from .sequence_pair_classifier_dataset_reader import SequencePairClassifierDatasetReader
-
-LABEL_TOKEN = "label"

--- a/src/biome/allennlp/predictors/default_predictor.py
+++ b/src/biome/allennlp/predictors/default_predictor.py
@@ -1,17 +1,13 @@
-from typing import List
+from typing import List, Dict
 
 from allennlp.common import JsonDict
 from allennlp.common.util import sanitize
-from allennlp.data import Instance, DatasetReader
-from allennlp.models import Model
+from allennlp.data import Instance
 from allennlp.predictors import Predictor
 from overrides import overrides
 
 
 class DefaultBasePredictor(Predictor):
-    def __init__(self, model: Model, reader: DatasetReader) -> None:
-        super(DefaultBasePredictor, self).__init__(model, reader)
-
     @overrides
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:
         instance = self._dataset_reader.text_to_instance(json_dict)

--- a/src/biome/allennlp/predictors/default_predictor.py
+++ b/src/biome/allennlp/predictors/default_predictor.py
@@ -35,6 +35,7 @@ class DefaultBasePredictor(Predictor):
         # This fails: np.array(instances)
 
         # skip examples that failed to be converted to instances! For example (and maybe solely) empty strings
+        # !this results in an empty list if `inputs` is a generator!
         input_and_instances = [
             (input, instance)
             for input, instance in zip(inputs, instances)

--- a/src/biome/allennlp/predictors/default_predictor.py
+++ b/src/biome/allennlp/predictors/default_predictor.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List
 
 from allennlp.common import JsonDict
 from allennlp.common.util import sanitize

--- a/src/biome/allennlp/predictors/utils.py
+++ b/src/biome/allennlp/predictors/utils.py
@@ -3,6 +3,7 @@ from typing import Optional
 from allennlp.data import DatasetReader
 from allennlp.models import Archive
 from allennlp.predictors import Predictor
+from allennlp.common.checks import ConfigurationError
 
 from biome.allennlp.predictors import DefaultBasePredictor
 import logging
@@ -19,11 +20,8 @@ def get_predictor_from_archive(
     predictor_name = predictor_name or model_config.get("type")
     try:
         return Predictor.from_archive(archive, predictor_name)
-    except Exception as e:
-        _logger.warning(
-            "Cannot create predictor {}, using the DefaultBasePredictor. Error: {}".format(
-                predictor_name, e
-            )
-        )
+    except ConfigurationError as e:
+        # If there is no corresponding predictor to the model, we use the DefaultBasePredictor
+        _logger.warning(f"{e}; Using the 'DefaultBasePredictor'!")
         ds_reader = DatasetReader.from_params(dataset_reader_config)
         return DefaultBasePredictor(archive.model, ds_reader)

--- a/src/biome/data/utils.py
+++ b/src/biome/data/utils.py
@@ -8,7 +8,6 @@ from multiprocessing.pool import ThreadPool
 import dask
 import dask.multiprocessing
 from dask.cache import Cache
-from dask.distributed import Client
 from dask.utils import parse_bytes
 from typing import Dict, Any, Union
 from typing import Optional

--- a/src/biome/data/utils.py
+++ b/src/biome/data/utils.py
@@ -119,7 +119,7 @@ def configure_dask_cluster(
                     scheduler_port=8786,  # TODO configurable
                     memory_limit=worker_mem,
                     silence_logs=logging.ERROR,
-                    local_dir=worker_space,
+                    local_directory=worker_space,
                 )
                 return Client(cluster)
         else:


### PR DESCRIPTION
This PR fixes the predict command. The solution is basically to introduce a `DataSource.to_forward_bag` method.

Another big change is that we now use the same instance of the `predictor` for all partitions, instead of initiating a `predictor` in each partition.

The results can be seen here:
- http://ab4062a48abfd11e9af3a02c7f180c77-366616848.eu-west-1.elb.amazonaws.com/explore/prediction_validation_yml_with_balanced
- http://ab4062a48abfd11e9af3a02c7f180c77-366616848.eu-west-1.elb.amazonaws.com/explore/prediction_test_record_yml_with_record_output_3