### PR TITLE
WIP: Disable lengthy AllenNLP logs

### DIFF
--- a/src/biome/text/commands/learn/learn.py
+++ b/src/biome/text/commands/learn/learn.py
@@ -33,7 +33,14 @@ from biome.text.commands.helpers import BiomeConfig
 from biome.text.models import load_archive
 from biome.data.utils import configure_dask_cluster
 
-logging.getLogger("allennlp.training.tensorboard_writer").setLevel(logging.WARNING)
+logging.getLogger("allennlp.training.tensorboard_writer").disabled = True
+logging.getLogger('allennlp.common.params').disabled = True
+logging.getLogger('allennlp.common.from_params').disabled = True
+logging.getLogger('allennlp.nn.initializers').disabled = True
+logging.getLogger('allennlp.training.trainer_pieces').disabled = True
+logging.getLogger('allennlp.common.registrable').disabled = True
+# logging.getLogger('allennlp.modules.token_embedders.embedding').setLevel(logging.INFO)
+# logging.getLogger('urllib3.connectionpool').disabled = True
 
 _logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -144,7 +151,7 @@ def learn(
     test_cfg: Optional[str] = None,
     workers: int = 1,
 ) -> Model:
-
+    _logger.info('Starting up learning process.')
     if not model_binary and not model_spec:
         raise ConfigurationError("Missing parameter --spec/--binary")
 

--- a/src/biome/text/commands/learn/learn.py
+++ b/src/biome/text/commands/learn/learn.py
@@ -33,6 +33,9 @@ from biome.text.commands.helpers import BiomeConfig
 from biome.text.models import load_archive
 from biome.data.utils import configure_dask_cluster
 
+logger = logging.getLogger("allennlp")
+logger.setLevel(logging.INFO)
+
 for logger_name in [
        "allennlp.training.tensorboard_writer",
        "allennlp.common.params",

--- a/src/biome/text/commands/learn/learn.py
+++ b/src/biome/text/commands/learn/learn.py
@@ -33,14 +33,16 @@ from biome.text.commands.helpers import BiomeConfig
 from biome.text.models import load_archive
 from biome.data.utils import configure_dask_cluster
 
-logging.getLogger("allennlp.training.tensorboard_writer").disabled = True
-logging.getLogger('allennlp.common.params').disabled = True
-logging.getLogger('allennlp.common.from_params').disabled = True
-logging.getLogger('allennlp.nn.initializers').disabled = True
-logging.getLogger('allennlp.training.trainer_pieces').disabled = True
-logging.getLogger('allennlp.common.registrable').disabled = True
-# logging.getLogger('allennlp.modules.token_embedders.embedding').setLevel(logging.INFO)
-# logging.getLogger('urllib3.connectionpool').disabled = True
+for logger_name in [
+       "allennlp.training.tensorboard_writer",
+       "allennlp.common.params",
+       "allennlp.common.from_params",
+       "allennlp.nn.initializers",
+       "allennlp.training.trainer_pieces",
+       "allennlp.common.registrable",
+   ]:
+       logger = logging.getLogger(logger_name)
+       logger.setLevel(logging.WARNING)
 
 _logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 


### PR DESCRIPTION
This an attempt to reduce some of the larger and less relevant AllenNLP logs. This has two main limitations (and its related to one of the pitches for the coming cycle):

- Completely disables this logs, even for file logging stderr and stdout. I would argue that errors will still be raised, and we have the config.json with all the parameters. But of course best solution would be to dump all logs into file and minimize those shown in the training process.

- This is not configurable: users cannot say "I want all logs" when launching the command. I guess default is disable_logs, but users can enable this feature.

Could we discuss this briefly? I in any case would like to have this as a first attempt, even with the above limitations.