### PR TITLE
Fix show label on ui

### DIFF
--- a/src/biome/text/commands/explore/explore.py
+++ b/src/biome/text/commands/explore/explore.py
@@ -134,9 +134,10 @@ def explore(
         created_index=es_index,
         # extra metadata must be normalized
         pipeline=pipeline.name,
-        signature=pipeline.reader.signature,
+        signature=pipeline.signature,
+        predict_signature=pipeline.predict_signature,
         # TODO remove when ui is adapted
-        inputs=pipeline.reader.signature,  # backward compatibility
+        inputs=pipeline.predict_signature,  # backward compatibility
         columns=ddf.columns.values.tolist(),
         kind="explore",
     )

--- a/src/biome/text/commands/explore/explore.py
+++ b/src/biome/text/commands/explore/explore.py
@@ -1,18 +1,18 @@
-import argparse
-import datetime
 import logging
 import os
-import re
 
+import argparse
+import datetime
+import re
 from allennlp.commands.subcommand import Subcommand
 from allennlp.common.checks import ConfigurationError
 from biome.data.sources import DataSource
-from ...environment import ES_HOST, BIOME_EXPLORE_ENDPOINT
 from dask_elk.client import DaskElasticClient
 
 # TODO centralize configuration
 from elasticsearch import Elasticsearch
 
+from biome.text.environment import ES_HOST, BIOME_EXPLORE_ENDPOINT
 from biome.text.pipelines.pipeline import Pipeline
 
 logging.basicConfig(level=logging.INFO)
@@ -132,14 +132,10 @@ def explore(
         name=es_index,
         es_hosts=es_host,
         created_index=es_index,
-        # extra metadata must be normalized
-        pipeline=pipeline.name,
-        signature=pipeline.signature,
-        predict_signature=pipeline.predict_signature,
-        # TODO remove when ui is adapted
-        inputs=pipeline.predict_signature,  # backward compatibility
         columns=ddf.columns.values.tolist(),
         kind="explore",
+        # extra metadata must be normalized
+        pipeline=pipeline,
     )
 
     __prepare_es_index(client, es_index, doc_type)
@@ -167,7 +163,9 @@ def get_compatible_doc_type(client: Elasticsearch) -> str:
     return "_doc" if es_version >= 6 else "doc"
 
 
-def register_biome_prediction(name: str, es_hosts: str, created_index: str, **kwargs):
+def register_biome_prediction(
+    name: str, pipeline: Pipeline, es_hosts: str, created_index: str, **kwargs
+):
     """
     Creates a new metadata entry for the incoming prediction
 
@@ -175,13 +173,14 @@ def register_biome_prediction(name: str, es_hosts: str, created_index: str, **kw
     ----------
     name
         A descriptive prediction name
+    pipeline
+        The pipeline used for the prediction batch
     created_index
         The elasticsearch index created for the prediction
     es_hosts
         The elasticsearch host where publish the new entry
     kwargs
         Extra arguments passed as extra metadata info
-
     """
 
     metadata_index = f"{BIOME_METADATA_INDEX}"
@@ -193,12 +192,24 @@ def register_biome_prediction(name: str, es_hosts: str, created_index: str, **kw
         ignore=400,
     )
 
+    predict_signature = [
+        k for k, v in pipeline.signature.items() if not v.get("optional")
+    ]
+    parameters = {
+        **kwargs,
+        "pipeline": pipeline.name,
+        "signature": [k for k in pipeline.signature.keys()],
+        "predict_signature": predict_signature,
+        # TODO remove when ui is adapted
+        "inputs": predict_signature,  # backward compatibility
+    }
+
     es_client.update(
         index=metadata_index,
         doc_type=get_compatible_doc_type(es_client),
         id=created_index,
         body={
-            "doc": dict(name=name, created_at=datetime.datetime.now(), **kwargs),
+            "doc": dict(name=name, created_at=datetime.datetime.now(), **parameters),
             "doc_as_upsert": True,
         },
     )

--- a/src/biome/text/dataset_readers/datasource_reader.py
+++ b/src/biome/text/dataset_readers/datasource_reader.py
@@ -60,7 +60,13 @@ class DataSourceReader(DatasetReader, TextFieldBuilderMixin, CacheableMixin):
 
         Returns
         -------
-            A list of expected inputs
+            A list of expected inputs with information about if input is optional or nor.
+
+            For example, for the signature
+            >>def text_to_instance(a:str,b:str, c:str=None)
+
+            This method will return:
+            >>{"a":{"optional": False},"b":{"optional": False},"c":{"optional": True}}
         """
         return self._signature.copy()
 

--- a/src/biome/text/dataset_readers/datasource_reader.py
+++ b/src/biome/text/dataset_readers/datasource_reader.py
@@ -1,11 +1,11 @@
 import inspect
 import logging
-from typing import Iterable, Optional, Dict, Union
-
+from typing import Iterable, Optional, Dict, Union, List
+from inspect import Parameter
 import pandas
 from allennlp.data import DatasetReader, Instance, Tokenizer, TokenIndexer
-
 from biome.data.sources import DataSource
+
 from biome.text.dataset_readers.mixins import TextFieldBuilderMixin, CacheableMixin
 
 
@@ -43,22 +43,24 @@ class DataSourceReader(DatasetReader, TextFieldBuilderMixin, CacheableMixin):
             as_text_field=as_text_field,
         )
 
-        self._signature = [
-            parameter
-            for parameter in inspect.signature(self.text_to_instance).parameters.keys()
-            if parameter != "self"
-        ]
+        self._signature = {
+            name: dict(optional=value.default != Parameter.empty)
+            for name, value in inspect.signature(
+                self.text_to_instance
+            ).parameters.items()
+            if name != "self"
+        }
 
     logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
     @property
-    def signature(self):
+    def signature(self) -> dict:
         """
         Describe de input signature for the pipeline predictions
 
         Returns
         -------
-            A list of expected input names
+            A list of expected inputs
         """
         return self._signature.copy()
 

--- a/src/biome/text/pipelines/pipeline.py
+++ b/src/biome/text/pipelines/pipeline.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 from tempfile import mktemp
-from typing import cast, Type, Optional
+from typing import cast, Type, Optional, List
 
 import allennlp
 import yaml
@@ -113,6 +113,34 @@ class Pipeline(Predictor):
             The configuration dictionary
         """
         return self.__config.copy()
+
+    @property
+    def signature(self) -> List[str]:
+        """
+        Describe de input signature for the pipeline
+
+        Returns
+        -------
+            A list of expected inputs
+        """
+        return [k for k in self._dataset_reader.signature.keys()]
+
+    @property
+    def predict_signature(self) -> List[str]:
+        """
+        Describe de input signature for the pipeline predictions.
+
+        Similar to `signature` method but just keeping the required values
+
+        Returns
+        -------
+            A list of inputs names
+        """
+        return [
+            k
+            for k, v in self._dataset_reader.signature.items()
+            if not v.get("optional")
+        ]
 
     def predict(self, **inputs) -> dict:
         return self.predict_json(inputs)

--- a/src/biome/text/pipelines/pipeline.py
+++ b/src/biome/text/pipelines/pipeline.py
@@ -1,10 +1,9 @@
 import logging
 import os
-import re
 from tempfile import mktemp
-from typing import cast, Type, Optional, List
 
 import allennlp
+import re
 import yaml
 from allennlp.common import JsonDict, Params
 from allennlp.common.checks import ConfigurationError
@@ -12,6 +11,7 @@ from allennlp.data import DatasetReader, Instance
 from allennlp.models import Archive, Model
 from allennlp.predictors import Predictor
 from overrides import overrides
+from typing import cast, Type, Optional, List
 
 from biome.text.dataset_readers.datasource_reader import DataSourceReader
 from biome.text.models import load_archive
@@ -115,32 +115,15 @@ class Pipeline(Predictor):
         return self.__config.copy()
 
     @property
-    def signature(self) -> List[str]:
+    def signature(self) -> dict:
         """
         Describe de input signature for the pipeline
 
         Returns
         -------
-            A list of expected inputs
+            A dict of expected inputs
         """
-        return [k for k in self._dataset_reader.signature.keys()]
-
-    @property
-    def predict_signature(self) -> List[str]:
-        """
-        Describe de input signature for the pipeline predictions.
-
-        Similar to `signature` method but just keeping the required values
-
-        Returns
-        -------
-            A list of inputs names
-        """
-        return [
-            k
-            for k, v in self._dataset_reader.signature.items()
-            if not v.get("optional")
-        ]
+        return self._dataset_reader.signature
 
     def predict(self, **inputs) -> dict:
         return self.predict_json(inputs)


### PR DESCRIPTION
This PR solves problems with biome-ui showing label value as part of input data.

see 
![Captura de pantalla 2019-10-24 a las 13 23 13](https://user-images.githubusercontent.com/2518789/67481042-84b18d80-f661-11e9-9123-8aca2fec6f92.png)


The reason is that, using general signature as input information, the label field are included. We define a new predict_signature that will drop the optional parameters (and no required for inference)

 