### PR TITLE
Feature/seperate df from mapped df

### DIFF
--- a/src/biome/text/dataset_readers/datasource_reader.py
+++ b/src/biome/text/dataset_readers/datasource_reader.py
@@ -106,23 +106,5 @@ class DataSourceReader(DatasetReader, TextFieldBuilderMixin, CacheableMixin):
 
         return (instance for idx, instance in instances.iteritems() if instance)
 
-    def text_to_instance_with_data_filter(
-        self, data: Union[dict, "pandas.Series", "dask.dataframe.Series"]
-    ) -> Optional[Instance]:
-        """
-        The method just adjust the data to the text_to_field input parameters and then
-        calls the official text_to_instance method
-
-        Parameters
-        ----------
-        data
-            The incoming data
-        """
-        if not isinstance(data, Dict):
-            data = data.to_dict()
-
-        inputs = {str(k): v for k, v in data.items() if k in self._signature}
-        return self.text_to_instance(**inputs)
-
     def text_to_instance(self, **inputs) -> Instance:
         raise NotImplementedError

--- a/src/biome/text/dataset_readers/datasource_reader.py
+++ b/src/biome/text/dataset_readers/datasource_reader.py
@@ -96,8 +96,10 @@ class DataSourceReader(DatasetReader, TextFieldBuilderMixin, CacheableMixin):
             self.logger.debug("Read data set from {}".format(file_path))
             dataset = data_source.to_mapped_dataframe()
             instances = dataset.apply(
-                self.text_to_instance_with_data_filter, axis=1, meta=(None, "object")
-            ).dropna()
+                lambda x: self.text_to_instance(**x.to_dict()),
+                axis=1,
+                meta=(None, "object"),
+            )
 
             # cache instances of the data set
             self.set(file_path, instances)
@@ -105,7 +107,7 @@ class DataSourceReader(DatasetReader, TextFieldBuilderMixin, CacheableMixin):
         return (instance for idx, instance in instances.iteritems() if instance)
 
     def text_to_instance_with_data_filter(
-        self, data: Union[dict, pandas.Series, "dask.dataframe.Series"]
+        self, data: Union[dict, "pandas.Series", "dask.dataframe.Series"]
     ) -> Optional[Instance]:
         """
         The method just adjust the data to the text_to_field input parameters and then

--- a/src/biome/text/dataset_readers/sequence_classifier_dataset_reader.py
+++ b/src/biome/text/dataset_readers/sequence_classifier_dataset_reader.py
@@ -32,7 +32,14 @@ class SequenceClassifierDatasetReader(DataSourceReader):
         fields = {}
 
         tokens_field = self.build_textfield(tokens)
-        label_field = LabelField(label) if label else None
+        label_field = None
+        # TODO: This is ugly as f***, should go into a decorator that checks/transforms the input
+        if label is not None:
+            # skipp example
+            if str(label).strip() == "":
+                return None
+            else:
+                label_field = LabelField(str(label).strip())
 
         if tokens_field:
             fields["tokens"] = tokens_field

--- a/src/biome/text/dataset_readers/sequence_pair_classifier_dataset_reader.py
+++ b/src/biome/text/dataset_readers/sequence_pair_classifier_dataset_reader.py
@@ -25,7 +25,14 @@ class SequencePairClassifierDatasetReader(DataSourceReader):
 
         record1_field = self.build_textfield(record1)
         record2_field = self.build_textfield(record2)
-        label_field = LabelField(label) if label else None
+        label_field = None
+        # TODO: This is ugly as f***, should go into a decorator that checks/transforms the input
+        if label is not None:
+            # skipp example
+            if str(label).strip() == "":
+                return None
+            else:
+                label_field = LabelField(str(label).strip())
 
         if record1_field:
             fields["record1"] = record1_field

--- a/src/biome/text/pipelines/pipeline.py
+++ b/src/biome/text/pipelines/pipeline.py
@@ -7,6 +7,7 @@ import re
 import yaml
 from allennlp.common import JsonDict, Params
 from allennlp.common.checks import ConfigurationError
+from allennlp.common.util import sanitize
 from allennlp.data import DatasetReader, Instance
 from allennlp.models import Archive, Model
 from allennlp.predictors import Predictor
@@ -156,12 +157,26 @@ class Pipeline(Predictor):
         return self.reader.text_to_instance_with_data_filter(json_dict)
 
     @overrides
-    def predict_json(self, inputs: JsonDict) -> JsonDict:
-        from allennlp.common.util import sanitize
+    def predict_json(self, inputs: JsonDict) -> Optional[JsonDict]:
+        """Predict an input with the pipeline's model.
 
+        Parameters
+        ----------
+        inputs
+            The input features/tokens in form of a json dict
+
+        Returns
+        -------
+        output
+            The model's prediction in form of a dict.
+            Returns None if the input could not be transformed to an instance.
+        """
         instance = self._json_to_instance(inputs)
-        output = self.model.forward_on_instance(instance)
-        return sanitize(output)
+        if instance is None:
+            return None
+        else:
+            output = self.model.forward_on_instance(instance)
+            return sanitize(output)
 
     @staticmethod
     def __to_snake_case(name):

--- a/src/biome/text/pipelines/pipeline.py
+++ b/src/biome/text/pipelines/pipeline.py
@@ -154,7 +154,7 @@ class Pipeline(Predictor):
 
     @overrides
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:
-        return self.reader.text_to_instance_with_data_filter(json_dict)
+        return self.reader.text_to_instance(**json_dict)
 
     @overrides
     def predict_json(self, inputs: JsonDict) -> Optional[JsonDict]:

--- a/src/biome/text/predictors/default_predictor.py
+++ b/src/biome/text/predictors/default_predictor.py
@@ -9,7 +9,7 @@ from overrides import overrides
 
 from biome.text.dataset_readers.datasource_reader import DataSourceReader
 
-
+# TODO: This class is deprecated and is not used at the moment! Should be removed in the near future!
 class DefaultBasePredictor(Predictor):
     def __init__(self, model: Model, dataset_reader: DataSourceReader):
         super(DefaultBasePredictor, self).__init__(model, dataset_reader)

--- a/tests/resources/models/sequence_classifier/model.yml
+++ b/tests/resources/models/sequence_classifier/model.yml
@@ -2,14 +2,14 @@ type: biome.text.model_instances.sequence_classifier.SequenceClassifier
 
 architecture:
   seq2vec_encoder:
-    hidden_size: 150
-    input_size: 300
-    num_layers: 3
+    hidden_size: 10
+    input_size: 10
+    num_layers: 1
     dropout: 0.6
     type: gru
   text_field_embedder:
     tokens:
-      embedding_dim: 300
+      embedding_dim: 10
       type: embedding
 
 pipeline:

--- a/tests/resources/models/sequence_classifier/model.yml
+++ b/tests/resources/models/sequence_classifier/model.yml
@@ -5,7 +5,7 @@ architecture:
     hidden_size: 10
     input_size: 10
     num_layers: 1
-    dropout: 0.6
+    dropout: 0.0
     type: gru
   text_field_embedder:
     tokens:

--- a/tests/resources/models/sequence_classifier/trainer.yml
+++ b/tests/resources/models/sequence_classifier/trainer.yml
@@ -7,7 +7,7 @@ iterator:
     - num_tokens
   type: bucket
 trainer:
-  num_epochs: 10
+  num_epochs: 1
   optimizer:
     amsgrad: 'true'
     type: adam

--- a/tests/text/dataset_readers/test_dataset_reader.py
+++ b/tests/text/dataset_readers/test_dataset_reader.py
@@ -155,7 +155,6 @@ class SequenceClassifierDatasetReaderTest(DaskSupportTest):
                 dataset, expected_length, expected_inputs, ["1", "2", "3"]
             )
 
-    @pytest.mark.xfail
     def test_reader_csv_with_leading_and_trailing_spaces_in_examples(self):
         expectedDatasetLength = 2
         expected_inputs = ["Dufils", "Anne", "Pierre", "Jousseaume", "Thierry"]

--- a/tests/text/dataset_readers/test_dataset_reader.py
+++ b/tests/text/dataset_readers/test_dataset_reader.py
@@ -213,7 +213,7 @@ class SequenceClassifierDatasetReaderTest(DaskSupportTest):
             format="csv",
             path=local_data_path,
             sep=";",
-            forward={
+            mapping={
                 "tokens": ["name"],
                 "target": {
                     "gold_label": "category of institution",
@@ -308,9 +308,9 @@ class SequenceClassifierDatasetReaderTest(DaskSupportTest):
                 {
                     "format": "json",
                     "path": JSON_PATH,
-                    "forward": {
+                    "mapping": {
                         "tokens": ["reviewText"],
-                        "target": {"gold_label": "overall"},
+                        "label": "overall",
                     },
                 }
             )
@@ -324,7 +324,7 @@ class SequenceClassifierDatasetReaderTest(DaskSupportTest):
                 {
                     "format": "json",
                     "path": JSON_WITH_EMPTY_VALUES,
-                    "forward": {"tokens": ["reviewText"], "label": "overall"},
+                    "mapping": {"tokens": ["reviewText"], "label": "overall"},
                 }
             )
         )

--- a/tests/text/pipelines/sequence_classifier_test.py
+++ b/tests/text/pipelines/sequence_classifier_test.py
@@ -7,6 +7,7 @@ from time import sleep
 import requests
 from elasticsearch import Elasticsearch
 
+from biome.data.utils import ENV_ES_HOSTS
 from biome.text.commands.explore.explore import explore
 from biome.text.commands.serve.serve import serve
 from biome.text.environment import ES_HOST

--- a/tests/text/pipelines/sequence_classifier_test.py
+++ b/tests/text/pipelines/sequence_classifier_test.py
@@ -7,7 +7,6 @@ from time import sleep
 import requests
 from elasticsearch import Elasticsearch
 
-from biome.data.utils import ENV_ES_HOSTS
 from biome.text.commands.explore.explore import explore
 from biome.text.commands.serve.serve import serve
 from biome.text.environment import ES_HOST


### PR DESCRIPTION
This adopts biome-text to the new `to_mapped_dataframe` method introduced in [this PR](https://github.com/recognai/biome-data/pull/13).

It also applies a str transformation to the labels and skips examples when label is an empty string. The implementation is awful and i will improve this in a separate PR soon.
The prediction also returns a None now, if the example could not be transformed to an instance.

It also makes the pipeline tests faster by simplifying the model and trainer.