### PR TITLE
make class names of the dataset readers consistent

### DIFF
--- a/src/biome/text/dataset_readers/__init__.py
+++ b/src/biome/text/dataset_readers/__init__.py
@@ -1,2 +1,2 @@
-from .sequence_classifier_dataset_reader import SequenceClassifierDatasetReader
-from .sequence_pair_classifier_dataset_reader import SequencePairClassifierDatasetReader
+from .sequence_classifier_dataset_reader import SequenceClassifierReader
+from .sequence_pair_classifier_dataset_reader import SequencePairClassifierReader

--- a/src/biome/text/dataset_readers/sequence_classifier_dataset_reader.py
+++ b/src/biome/text/dataset_readers/sequence_classifier_dataset_reader.py
@@ -7,7 +7,7 @@ from biome.text.dataset_readers.datasource_reader import DataSourceReader
 
 
 @DatasetReader.register("sequence_classifier")
-class SequenceClassifierDatasetReader(DataSourceReader):
+class SequenceClassifierReader(DataSourceReader):
     """
     A DatasetReader for the SequenceClassifier model.
     """
@@ -50,4 +50,4 @@ class SequenceClassifierDatasetReader(DataSourceReader):
 
 
 # Register an alias for this reader
-DatasetReader.register("bert_for_classification")(SequenceClassifierDatasetReader)
+DatasetReader.register("bert_for_classification")(SequenceClassifierReader)

--- a/src/biome/text/dataset_readers/sequence_pair_classifier_dataset_reader.py
+++ b/src/biome/text/dataset_readers/sequence_pair_classifier_dataset_reader.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 @DatasetReader.register("sequence_pair_classifier")
-class SequencePairClassifierDatasetReader(DataSourceReader):
+class SequencePairClassifierReader(DataSourceReader):
     """
     A DatasetReader for the SequencePairClassifier model.
     """
@@ -47,4 +47,4 @@ class SequencePairClassifierDatasetReader(DataSourceReader):
 
 
 # Register an alias for this reader
-DatasetReader.register("similarity_classifier")(SequencePairClassifierDatasetReader)
+DatasetReader.register("similarity_classifier")(SequencePairClassifierReader)

--- a/src/biome/text/pipelines/sequence_classifier.py
+++ b/src/biome/text/pipelines/sequence_classifier.py
@@ -4,7 +4,7 @@ import allennlp
 from allennlp.predictors import Predictor
 
 import biome
-from biome.text.dataset_readers import SequenceClassifierDatasetReader
+from biome.text.dataset_readers import SequenceClassifierReader
 from biome.text.dataset_readers.datasource_reader import DataSourceReader
 from .pipeline import Pipeline
 
@@ -12,7 +12,7 @@ from .pipeline import Pipeline
 class SequenceClassifier(Pipeline):
     @classmethod
     def reader_class(cls) -> Type[DataSourceReader]:
-        return SequenceClassifierDatasetReader
+        return SequenceClassifierReader
 
     @classmethod
     def model_class(cls) -> Type[allennlp.models.Model]:

--- a/src/biome/text/pipelines/sequence_pair_classifier.py
+++ b/src/biome/text/pipelines/sequence_pair_classifier.py
@@ -4,7 +4,7 @@ import allennlp
 from allennlp.predictors import Predictor
 
 import biome
-from biome.text.dataset_readers import SequencePairClassifierDatasetReader
+from biome.text.dataset_readers import SequencePairClassifierReader
 from biome.text.dataset_readers.datasource_reader import DataSourceReader
 from .pipeline import Pipeline
 
@@ -12,7 +12,7 @@ from .pipeline import Pipeline
 class SequencePairClassifier(Pipeline):
     @classmethod
     def reader_class(cls) -> Type[DataSourceReader]:
-        return SequencePairClassifierDatasetReader
+        return SequencePairClassifierReader
 
     @classmethod
     def model_class(cls) -> Type[allennlp.models.Model]:

--- a/src/biome/text/pipelines/similarity_classifier.py
+++ b/src/biome/text/pipelines/similarity_classifier.py
@@ -4,7 +4,7 @@ import allennlp
 from allennlp.predictors import Predictor
 
 import biome
-from biome.text.dataset_readers import SequencePairClassifierDatasetReader
+from biome.text.dataset_readers import SequencePairClassifierReader
 from biome.text.dataset_readers.datasource_reader import DataSourceReader
 from .pipeline import Pipeline
 
@@ -12,7 +12,7 @@ from .pipeline import Pipeline
 class SimilarityClassifier(Pipeline):
     @classmethod
     def reader_class(cls) -> Type[DataSourceReader]:
-        return SequencePairClassifierDatasetReader
+        return SequencePairClassifierReader
 
     @classmethod
     def model_class(cls) -> Type[allennlp.models.Model]:

--- a/tests/text/dataset_readers/test_biome_dataset_reader.py
+++ b/tests/text/dataset_readers/test_biome_dataset_reader.py
@@ -2,7 +2,7 @@ import os
 from typing import Iterable
 
 from allennlp.data.fields import TextField, LabelField
-from biome.text.dataset_readers import SequenceClassifierDatasetReader
+from biome.text.dataset_readers import SequenceClassifierReader
 
 from tests.test_context import TEST_RESOURCES
 from tests.test_support import DaskSupportTest
@@ -10,7 +10,7 @@ from tests.test_support import DaskSupportTest
 TOKENS_FIELD = "tokens"
 LABEL_FIELD = "label"
 
-reader = SequenceClassifierDatasetReader(as_text_field=True)
+reader = SequenceClassifierReader(as_text_field=True)
 
 
 class BiomeDatasetReaderTest(DaskSupportTest):

--- a/tests/text/dataset_readers/test_dataset_reader.py
+++ b/tests/text/dataset_readers/test_dataset_reader.py
@@ -6,7 +6,7 @@ import pytest
 import yaml
 from allennlp.data import DatasetReader
 from allennlp.data.fields import TextField, LabelField
-from biome.text.dataset_readers import SequenceClassifierDatasetReader
+from biome.text.dataset_readers import SequenceClassifierReader
 from tests.test_context import TEST_RESOURCES, create_temp_configuration
 
 from tests.test_support import DaskSupportTest
@@ -30,13 +30,13 @@ JSON_WITH_EMPTY_VALUES = os.path.abspath(
 TOKENS_FIELD = "tokens"
 LABEL_FIELD = "label"
 
-reader = SequenceClassifierDatasetReader(as_text_field=True)
+reader = SequenceClassifierReader(as_text_field=True)
 
 
 class SequenceClassifierDatasetReaderTest(DaskSupportTest):
     def test_dataset_reader_registration(self):
         dataset_reader = DatasetReader.by_name("sequence_classifier")
-        self.assertEqual(SequenceClassifierDatasetReader, dataset_reader)
+        self.assertEqual(SequenceClassifierReader, dataset_reader)
 
     def test_read_input_csv(self):
         expected_length = 9

--- a/tests/text/dataset_readers/test_datasourcereader_children.py
+++ b/tests/text/dataset_readers/test_datasourcereader_children.py
@@ -8,8 +8,8 @@ from allennlp.data.tokenizers import WordTokenizer
 from allennlp.models import Model, BertForClassification
 
 from biome.text.dataset_readers import (
-    SequenceClassifierDatasetReader,
-    SequencePairClassifierDatasetReader,
+    SequenceClassifierReader,
+    SequencePairClassifierReader,
 )
 from biome.text.models import (
     SequenceClassifier,
@@ -23,21 +23,21 @@ import_submodules("biome.text")
 @pytest.mark.parametrize(
     "name, model, dataset_reader",
     [
-        ("sequence_classifier", SequenceClassifier, SequenceClassifierDatasetReader),
+        ("sequence_classifier", SequenceClassifier, SequenceClassifierReader),
         (
             "bert_for_classification",
             BertForClassification,
-            SequenceClassifierDatasetReader,
+            SequenceClassifierReader,
         ),
         (
             "sequence_pair_classifier",
             SequencePairClassifier,
-            SequencePairClassifierDatasetReader,
+            SequencePairClassifierReader,
         ),
         (
             "similarity_classifier",
             SimilarityClassifier,
-            SequencePairClassifierDatasetReader,
+            SequencePairClassifierReader,
         ),
     ],
 )
@@ -51,24 +51,24 @@ def test_name_consistency(name, model, dataset_reader):
     "dataset_reader, model, text_input",
     [
         (
-            SequenceClassifierDatasetReader,
-            SequenceClassifier,
-            {"tokens": "a", "label": "b"},
+                SequenceClassifierReader,
+                SequenceClassifier,
+                {"tokens": "a", "label": "b"},
         ),
         (
-            SequenceClassifierDatasetReader,
-            BertForClassification,
-            {"tokens": "a", "label": "b"},
+                SequenceClassifierReader,
+                BertForClassification,
+                {"tokens": "a", "label": "b"},
         ),
         (
-            SequencePairClassifierDatasetReader,
-            SequencePairClassifier,
-            {"record1": "a", "record2": "b", "label": "c"},
+                SequencePairClassifierReader,
+                SequencePairClassifier,
+                {"record1": "a", "record2": "b", "label": "c"},
         ),
         (
-            SequencePairClassifierDatasetReader,
-            SimilarityClassifier,
-            {"record1": "a", "record2": "b", "label": "c"},
+                SequencePairClassifierReader,
+                SimilarityClassifier,
+                {"record1": "a", "record2": "b", "label": "c"},
         ),
     ],
 )

--- a/tests/text/dataset_readers/test_parallel_dataset_reader.py
+++ b/tests/text/dataset_readers/test_parallel_dataset_reader.py
@@ -3,7 +3,7 @@ from typing import Iterable
 
 from allennlp.data import DatasetReader
 from allennlp.data.fields import TextField, LabelField
-from biome.text.dataset_readers import SequenceClassifierDatasetReader
+from biome.text.dataset_readers import SequenceClassifierReader
 from tests.test_context import TEST_RESOURCES, create_temp_configuration
 
 from tests.test_support import DaskSupportTest
@@ -14,13 +14,13 @@ JSON_PATH = os.path.join(TEST_RESOURCES, "resources/data/dataset_source.jsonl")
 TOKENS_FIELD = "tokens"
 LABEL_FIELD = "label"
 
-reader = SequenceClassifierDatasetReader(as_text_field=True)
+reader = SequenceClassifierReader(as_text_field=True)
 
 
 class ParallelDatasetReaderTest(DaskSupportTest):
     def test_dataset_reader_registration(self):
         dataset_reader = DatasetReader.by_name("sequence_classifier")
-        self.assertEqual(SequenceClassifierDatasetReader, dataset_reader)
+        self.assertEqual(SequenceClassifierReader, dataset_reader)
 
     def test_read_csv(self):
         expected_length = 9


### PR DESCRIPTION
Small PR to Rename our dataset/datasource reader classes in a more consistent way.