### PR TITLE
basic support for textfield interpret classifiers in explore ui

### DIFF
--- a/src/biome/text/interpreters/__init__.py
+++ b/src/biome/text/interpreters/__init__.py
@@ -1,0 +1,1 @@
+from .integrated_gradient import IntegratedGradient

--- a/src/biome/text/interpreters/integrated_gradient.py
+++ b/src/biome/text/interpreters/integrated_gradient.py
@@ -25,7 +25,7 @@ class IntegratedGradient(IntegratedGradient):
         # Convert inputs to labeled instances
         labeled_instances = self.predictor.json_to_labeled_instances(inputs)
 
-        instances_with_grads = dict()
+        instances_with_grads : List = []
         for idx, instance in enumerate(labeled_instances):
             # Run integrated gradients
             grads = self._integrate_gradients(instance)
@@ -35,7 +35,7 @@ class IntegratedGradient(IntegratedGradient):
             # TODO: We might move this responsibility to the Predictor 
             # or pass the order of fields when calling interpret.
             grads = self._pack_with_field_tokens(instance, grads)
-            instances_with_grads['instance_' + str(idx + 1)] = grads
+            instances_with_grads.append(grads)
 
         return sanitize(instances_with_grads)
 

--- a/src/biome/text/interpreters/integrated_gradient.py
+++ b/src/biome/text/interpreters/integrated_gradient.py
@@ -1,0 +1,87 @@
+# pylint: disable=protected-access
+import math
+from typing import List, Dict, Any
+
+import numpy
+
+import operator
+
+from allennlp.common.util import JsonDict, sanitize
+from allennlp.data import Instance
+from allennlp.interpret.saliency_interpreters.integrated_gradient import IntegratedGradient
+from allennlp.interpret.saliency_interpreters.saliency_interpreter import SaliencyInterpreter
+from allennlp.nn import util
+
+@SaliencyInterpreter.register('biome-integrated-gradient')
+class IntegratedGradient(IntegratedGradient):
+    """
+    Interprets the prediction using Integrated Gradients (https://arxiv.org/abs/1703.01365)
+    """
+    def saliency_interpret_from_json(self, inputs: JsonDict) -> JsonDict:
+        def normalize_gradient(grad):
+            embedding_grad = numpy.sum(grad, axis=1)
+            norm = numpy.linalg.norm(embedding_grad, ord=1)
+            return [math.fabs(e) / norm for e in embedding_grad]
+        # Convert inputs to labeled instances
+        labeled_instances = self.predictor.json_to_labeled_instances(inputs)
+
+        instances_with_grads = dict()
+        for idx, instance in enumerate(labeled_instances):
+            # Run integrated gradients
+            grads = self._integrate_gradients(instance)
+
+            # Normalize results
+            grads = [ normalize_gradient(grad[0]) for grad in grads ]
+            # TODO: We might move this responsibility to the Predictor 
+            # or pass the order of fields when calling interpret.
+            grads = self._pack_with_field_tokens(instance, grads)
+            instances_with_grads['instance_' + str(idx + 1)] = grads
+
+        return sanitize(instances_with_grads)
+
+    def _pack_with_field_tokens(self, instance: Instance, grads):
+        # We assume keys are ordered in the same way fields are processed
+        list_keys = list(instance.fields.keys())
+        list_keys.remove('label')
+        output : Dict = {}
+        for idx, key in enumerate(list_keys):
+            output[key] = [
+                {'token': token, 'grad': grad}
+                for token, grad in zip(instance[key].tokens, grads[idx])
+            ]
+        return output
+
+    def _integrate_gradients(self, instance: Instance) -> Dict[str, numpy.ndarray]:
+        """
+        Returns integrated gradients for the given :class:`~allennlp.data.instance.Instance`
+        """
+        ig_grads: List[Any] = []
+
+        # List of Embedding inputs
+        embeddings_list: List[numpy.ndarray] = []
+
+        # Use 10 terms in the summation approximation of the integral in integrated grad
+        steps = 10
+
+        # Exclude the endpoint because we do a left point integral approximation
+        for alpha in numpy.linspace(0, 1.0, num=steps, endpoint=False):
+            # Hook for modifying embedding value
+            handle = self._register_forward_hook(alpha, embeddings_list)
+
+            grads = self.predictor.get_gradients([instance])[0]
+            handle.remove()
+
+            # Running sum of gradients
+            if ig_grads == []:
+                ig_grads = grads
+            else:
+                for idx, grad in enumerate(grads):
+                    ig_grads[idx] += grad
+
+        # Average of each gradient term
+        ig_grads = [v/steps for v in ig_grads]
+
+        # Element-wise multiply average gradient by the input
+        multiply = lambda a,b: map(operator.mul, a,b)
+
+        return list(multiply(ig_grads, embeddings_list))

--- a/src/biome/text/models/base_model_classifier.py
+++ b/src/biome/text/models/base_model_classifier.py
@@ -245,13 +245,17 @@ class BaseModelClassifier(Model, metaclass=ABCMeta):
 
             max_classes.append(label)
             max_classes_prob.append(label_prob)
-
-        return {
+      
+        return_dict = {
             "logits": output_dict.get("logits"),
             "classes": output_map_probs,
             "max_class": max_classes,
             "max_class_prob": max_classes_prob,
         }
+        # having loss == None in dict (when no label is present) fails
+        if "loss" in output_dict.keys():
+            return_dict["loss"] = output_dict.get("loss")
+        return return_dict
 
     @overrides
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:

--- a/src/biome/text/pipelines/pipeline.py
+++ b/src/biome/text/pipelines/pipeline.py
@@ -1,18 +1,22 @@
 import logging
 import os
 from tempfile import mktemp
+from copy import deepcopy
 
 import allennlp
 import re
 import yaml
+import numpy
 from allennlp.common import JsonDict, Params
 from allennlp.common.checks import ConfigurationError
 from allennlp.common.util import sanitize
 from allennlp.data import DatasetReader, Instance
 from allennlp.models import Archive, Model
 from allennlp.predictors import Predictor
+from allennlp.data.fields import LabelField
+from allennlp.data.dataset import Batch
 from overrides import overrides
-from typing import cast, Type, Optional, List
+from typing import cast, Type, Optional, List, Dict, Tuple, Any
 
 from biome.text.dataset_readers.datasource_reader import DataSourceReader
 from biome.text.models import load_archive
@@ -155,6 +159,82 @@ class Pipeline(Predictor):
     @overrides
     def _json_to_instance(self, json_dict: JsonDict) -> Instance:
         return self.reader.text_to_instance(**json_dict)
+
+    @overrides
+    def predictions_to_labeled_instances(
+        self, instance: Instance, outputs: Dict[str, numpy.ndarray]
+    ) -> List[Instance]:
+     
+        new_instance = deepcopy(instance)
+        label = numpy.argmax(outputs["logits"])   
+        new_instance.add_field("label", LabelField(int(label), skip_indexing=True))
+
+        return [new_instance]
+
+    @overrides
+    def get_gradients(self,
+                      instances: List[Instance]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """
+        Gets the gradients of the loss with respect to the model inputs.
+
+        Parameters
+        ----------
+        instances: List[Instance]
+
+        Returns
+        -------
+        Tuple[Dict[str, Any], Dict[str, Any]]
+        The first item is a Dict of gradient entries for each input.
+        The keys have the form  ``{grad_input_1: ..., grad_input_2: ... }``
+        up to the number of inputs given. The second item is the model's output.
+
+        Notes
+        -----
+        Takes a ``JsonDict`` representing the inputs of the model and converts
+        them to :class:`~allennlp.data.instance.Instance`s, sends these through
+        the model :func:`forward` function after registering hooks on the embedding
+        layer of the model. Calls :func:`backward` on the loss and then removes the
+        hooks.
+        """
+        embedding_gradients: List[Tensor] = []
+        hooks: List[RemovableHandle] = self._register_embedding_gradient_hooks(embedding_gradients)
+
+        dataset = Batch(instances)
+        dataset.index_instances(self._model.vocab)
+        outputs = self._model.decode(self._model.forward(**dataset.as_tensor_dict()))
+
+        loss = outputs['loss']
+        self._model.zero_grad()
+        loss.backward()
+
+        for hook in hooks:
+            hook.remove()
+        
+        embedding_gradients.reverse()
+
+        grads = [
+            grad.detach().cpu().numpy() 
+            for grad in embedding_gradients
+        ]
+        return grads, outputs
+
+    @overrides
+    def json_to_labeled_instances(self, inputs: JsonDict) -> List[Instance]:
+        """
+        Converts incoming json to a :class:`~allennlp.data.instance.Instance`,
+        runs the model on the newly created instance, and adds labels to the
+        :class:`~allennlp.data.instance.Instance`s given by the model's output.
+        Returns
+        -------
+        List[instance]
+        A list of :class:`~allennlp.data.instance.Instance`
+        """
+        # pylint: disable=assignment-from-no-return
+        instance = self._json_to_instance(inputs)
+        outputs = self._model.forward_on_instance(instance)
+        new_instances = self.predictions_to_labeled_instances(instance, outputs)
+        return new_instances
+
 
     @overrides
     def predict_json(self, inputs: JsonDict) -> Optional[JsonDict]:

--- a/tests/text/models/base_classifier.py
+++ b/tests/text/models/base_classifier.py
@@ -38,7 +38,7 @@ class BasePairClassifierTest(DaskSupportTest):
 
     def model_workflow(self):
         self.check_train(SequencePairClassifier)
-        self.check_predict()
+        self.check_explore()
         self.check_serve()
         self.check_predictor()
 
@@ -55,7 +55,7 @@ class BasePairClassifierTest(DaskSupportTest):
         self.assertTrue(archive.model is not None)
         self.assertIsInstance(archive.model, cls_type)
 
-    def check_predict(self):
+    def check_explore(self):
         index = self.__class__.__name__.lower()
         es_host = os.getenv(ES_HOST, "http://localhost:9200")
         explore(
@@ -63,6 +63,7 @@ class BasePairClassifierTest(DaskSupportTest):
             source_path=self.validation_data,
             es_host=es_host,
             es_index=index,
+            interpret=True,  # Enable interpret
         )
 
         client = Elasticsearch(hosts=es_host, http_compress=True)

--- a/tests/text/models/test_sequence_pair_classifier.py
+++ b/tests/text/models/test_sequence_pair_classifier.py
@@ -15,6 +15,6 @@ class SequencePairClassifierTest(BasePairClassifierTest):
 
     def test_model_workflow(self):
         self.check_train(SequencePairClassifier)
-        self.check_predict()
+        self.check_explore()
         self.check_serve()
         self.check_predictor()

--- a/tests/text/models/test_similarity_classifier.py
+++ b/tests/text/models/test_similarity_classifier.py
@@ -17,6 +17,6 @@ class SimilarityClassifierTest(BasePairClassifierTest):
 
     def test_model_workflow(self):
         self.check_train(SimilarityClassifier)
-        self.check_predict()
+        self.check_explore()
         self.check_serve()
         self.check_predictor()

--- a/tests/text/pipelines/sequence_classifier_test.py
+++ b/tests/text/pipelines/sequence_classifier_test.py
@@ -28,7 +28,7 @@ class SequenceClassifierTest(unittest.TestCase):
 
     def test_model_workflow(self):
         self.check_train()
-        self.check_predict()
+        self.check_explore()
         self.check_serve()
         self.check_predictor()
 
@@ -49,7 +49,7 @@ class SequenceClassifierTest(unittest.TestCase):
         prediction = classifier.predict("mike Farrys")
         self.assertTrue("logits" in prediction, f"Not in {prediction}")
 
-    def check_predict(self):
+    def check_explore(self):
         index = self.name
         es_host = os.getenv(ES_HOST, "http://localhost:9200")
         explore(
@@ -57,11 +57,12 @@ class SequenceClassifierTest(unittest.TestCase):
             source_path=self.validation_data,
             es_host=es_host,
             es_index=index,
+            interpret=True,  # Enable interpret
         )
 
         client = Elasticsearch(hosts=es_host, http_compress=True)
         data = client.search(index)
-        self.assertIn("hits", data, msg=f"Must exists hits in es response {data}")
+        self.assertIn("hits", data, msg=f"Must exist hits in es response {data}")
         self.assertTrue(len(data["hits"]) > 0, "No data indexed")
 
     def check_serve(self):


### PR DESCRIPTION
This PR introduces basic support for IntegratedGradient-based interpretation of classifiers based on text fields. It includes:
- overriding predictor get_gradients from allennlp predictor to make it return lists instead of a dict.

- extending IntegratedGradientInterpreter from allen to deal with lists and pack results with field names and tokens.

- add interpretation when running `explore` command (currently not working).

It is still based on the assumption that we have an ordered list of fields with the same order in which fields are passed through the embedding layers. If we move the responsibility to the pipeline of each model we could ensure this.
