### PR TITLE
Feat/segment sentences

### DIFF
--- a/src/biome/text/dataset_readers/datasource_reader.py
+++ b/src/biome/text/dataset_readers/datasource_reader.py
@@ -29,6 +29,10 @@ class DataSourceReader(DatasetReader, TextFieldBuilderMixin, CacheableMixin):
         Build ``Instance`` fields as ``ListField`` of ``TextField`` or ``TextField``
     skip_empty_tokens
         Should i silently skip empty tokens?
+    max_sequence_length
+        If you want to truncate the text input to a maximum number of characters
+    max_nr_of_sentences
+        Use only the first max_nr_of_sentences when segmenting the text into sentences
     """
 
     def __init__(
@@ -38,6 +42,8 @@ class DataSourceReader(DatasetReader, TextFieldBuilderMixin, CacheableMixin):
         segment_sentences: Union[bool, SentenceSplitter] = False,
         as_text_field: bool = False,
         skip_empty_tokens: bool = False,
+        max_sequence_length: int = None,
+        max_nr_of_sentences: int = None,
     ) -> None:
         DatasetReader.__init__(self, lazy=True)
         TextFieldBuilderMixin.__init__(
@@ -47,6 +53,8 @@ class DataSourceReader(DatasetReader, TextFieldBuilderMixin, CacheableMixin):
             token_indexers=token_indexers,
             segment_sentences=segment_sentences,
             as_text_field=as_text_field,
+            max_sequence_length=max_sequence_length,
+            max_nr_of_sentences=max_nr_of_sentences,
         )
         self._skip_empty_tokens = skip_empty_tokens
 

--- a/src/biome/text/dataset_readers/datasource_reader.py
+++ b/src/biome/text/dataset_readers/datasource_reader.py
@@ -1,9 +1,10 @@
 import inspect
 import logging
 from inspect import Parameter
-from typing import Iterable, Dict
+from typing import Iterable, Dict, Union
 
 from allennlp.data import DatasetReader, Instance, Tokenizer, TokenIndexer
+from allennlp.data.tokenizers import SentenceSplitter
 
 from biome.data.sources import DataSource
 from biome.text.dataset_readers.mixins import TextFieldBuilderMixin, CacheableMixin
@@ -20,18 +21,21 @@ class DataSourceReader(DatasetReader, TextFieldBuilderMixin, CacheableMixin):
     ----------
     tokenizer
         By default we use a WordTokenizer with the SpacyWordSplitter
-
     token_indexers
         By default we use the following dict {'tokens': SingleIdTokenIndexer}
-
+    segment_sentences
+        If True, we will first segment the text into sentences using SpaCy and then tokenize words.
     as_text_field
         Build ``Instance`` fields as ``ListField`` of ``TextField`` or ``TextField``
+    skip_empty_tokens
+        Should i silently skip empty tokens?
     """
 
     def __init__(
         self,
         tokenizer: Tokenizer = None,
         token_indexers: Dict[str, TokenIndexer] = None,
+        segment_sentences: Union[bool, SentenceSplitter] = False,
         as_text_field: bool = False,
         skip_empty_tokens: bool = False,
     ) -> None:
@@ -41,6 +45,7 @@ class DataSourceReader(DatasetReader, TextFieldBuilderMixin, CacheableMixin):
             tokenizer=tokenizer,
             # The token_indexers keys are directly related to the model text_field_embedder configuration
             token_indexers=token_indexers,
+            segment_sentences=segment_sentences,
             as_text_field=as_text_field,
         )
         self._skip_empty_tokens = skip_empty_tokens

--- a/src/biome/text/dataset_readers/mixins.py
+++ b/src/biome/text/dataset_readers/mixins.py
@@ -1,9 +1,10 @@
 import logging
-from typing import Optional, Union, Any, Dict
+from typing import Optional, Union, Any, Dict, List
 
 from allennlp.data import Tokenizer, TokenIndexer
 from allennlp.data.fields import ListField, TextField
-from allennlp.data.tokenizers import WordTokenizer
+from allennlp.data.tokenizers import WordTokenizer, SentenceSplitter
+from allennlp.data.tokenizers.sentence_splitter import SpacySentenceSplitter
 
 
 class CacheableMixin(object):
@@ -33,13 +34,13 @@ class TextFieldBuilderMixin(object):
 
         tokenizer
             The allennlp ``Tokenizer`` for text tokenization in ``TextField``
-
         token_indexers
             The allennlp ``TokenIndexer`` dictionary for ``TextField`` configuration
-
+        segment_sentences
+            If True, we will first segment the text into sentences using SpaCy and then tokenize words.
         as_text_field
             Flag indicating how to generate the ``Field``. If enabled, the output Field
-            will a ``TextField`` with text concatenation, else the result field will be
+            will be a ``TextField`` with text concatenation, else the result field will be
             a ``ListField`` of ``TextField``, one per input data value
     """
 
@@ -47,16 +48,26 @@ class TextFieldBuilderMixin(object):
         self,
         tokenizer: Tokenizer = None,
         token_indexers: Dict[str, TokenIndexer] = None,
+        segment_sentences: Union[bool, SentenceSplitter] = False,
         as_text_field: bool = False,
     ):
         self._tokenizer = tokenizer or WordTokenizer()
         self._token_indexers = token_indexers
+        self._sentence_segmenter = segment_sentences
+        if segment_sentences is True:
+            self._sentence_segmenter = SpacySentenceSplitter()
         self._as_text_field = as_text_field
         self._logger = logging.getLogger(self.__class__.__name__)
 
+        if segment_sentences and not as_text_field:
+            self._logger.warning(
+                "You cannot segment sentences and set as_text_field to false at the same time, "
+                "i will set as_text_field for the single sentences to true."
+            )
+
     @staticmethod
     def _value_as_string(value):
-        # TODO evaluate field value type for stringfy properly
+        # TODO evaluate field value type for stringify properly
         return str(value)
 
     def build_textfield(
@@ -87,12 +98,20 @@ class TextFieldBuilderMixin(object):
         if isinstance(data, dict):
             data = data.values()
 
-        if self._as_text_field:
+        if self._sentence_segmenter:
             text = " ".join(map(str, data))
-            return TextField(
-                self._tokenizer.tokenize(self._value_as_string(text)),
-                self._token_indexers,
+            sentences: List[TextField] = []
+            sentence_splits = self._sentence_segmenter.split_sentences(
+                self._value_as_string(text)
             )
+            for sentence in sentence_splits:
+                word_tokens = self._tokenizer.tokenize(sentence)
+                sentences.append(TextField(word_tokens, self._token_indexers))
+            return ListField(sentences) if sentences else None
+        elif self._as_text_field:
+            text = " ".join(map(str, data))
+            word_tokens = self._tokenizer.tokenize(self._value_as_string(text))
+            return TextField(word_tokens, self._token_indexers)
 
         # text_fields of different lengths are allowed, they will be sorted by the trainer and padded adequately
         text_fields = [
@@ -104,4 +123,4 @@ class TextFieldBuilderMixin(object):
             if value
         ]
 
-        return ListField(text_fields)
+        return ListField(text_fields) if text_fields else None

--- a/src/biome/text/models/sequence_classifier_base.py
+++ b/src/biome/text/models/sequence_classifier_base.py
@@ -146,7 +146,6 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         -------
         A ``Tensor``
         """
-        # TODO: This will probably not work for single field input, we need to check the shape of record 1 and 2.
         mask = get_text_field_mask(
             tokens, num_wrapping_dims=self._num_wrapping_dims
         ).float()

--- a/src/biome/text/models/sequence_classifier_base.py
+++ b/src/biome/text/models/sequence_classifier_base.py
@@ -97,11 +97,7 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
             )
             self._seq2vec_encoder = TimeDistributed(seq2vec_encoder)
             # 3. (Optionally) setup multifield_seq2seq_encoder
-            if multifield_seq2seq_encoder:
-                raise NotImplementedError(
-                    "A multifield_seq2seq still does not work, we need to mask properly!"
-                )
-            self._multifield_seq2seq_encoder = None
+            self._multifield_seq2seq_encoder = multifield_seq2seq_encoder
             # 4. setup multifield_seq2vec_encoder
             self._multifield_seq2vec_encoder = multifield_seq2vec_encoder
             # doc vector dropout
@@ -169,17 +165,21 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         if self._dropout:
             encoded_text = self._dropout(encoded_text)
 
-        # seq2seq encoding for each field vector
-        # TODO: Does not work, we need to mask properly
-        if self._multifield_seq2seq_encoder:
-            encoded_text = self._multifield_seq2seq_encoder(encoded_text)
-
-        # seq2vec encoding for field --> record vector
         if self._multifield_seq2vec_encoder:
-            encoded_text = self._multifield_seq2vec_encoder(encoded_text)
+            # For calculating the mask, we assume that all seq2vec encoders produce a null vector if they only receive
+            # masked input.
+            # The dict key does not matter in this case, you can give an arbitrary name, like 'encoded_text'
+            multifield_mask = get_text_field_mask({"encoded_text": encoded_text})
 
-        if self._multifield_dropout:
-            encoded_text = self._multifield_dropout(encoded_text)
+            # seq2seq encoding for each field vector
+            if self._multifield_seq2seq_encoder:
+                encoded_text = self._multifield_seq2seq_encoder(encoded_text, mask=multifield_mask)
+
+            # seq2vec encoding for field --> record vector
+            encoded_text = self._multifield_seq2vec_encoder(encoded_text, mask=multifield_mask)
+
+            if self._multifield_dropout:
+                encoded_text = self._multifield_dropout(encoded_text)
 
         if self._feed_forward:
             encoded_text = self._feed_forward(encoded_text)

--- a/tests/text/pipelines/sequence_classifier_test.py
+++ b/tests/text/pipelines/sequence_classifier_test.py
@@ -95,6 +95,7 @@ def trainer_yaml(tmpdir):
         },
         "trainer": {
             "type": "default",
+            "cuda_device": -1,
             "num_serialized_models_to_keep": 1,
             "num_epochs": 1,
             "optimizer": {

--- a/tests/text/pipelines/sequence_classifier_test.py
+++ b/tests/text/pipelines/sequence_classifier_test.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest
 from time import sleep
+import pytest
 
 import requests
 from elasticsearch import Elasticsearch
@@ -14,8 +15,112 @@ from biome.text.environment import ES_HOST
 from biome.text.pipelines.sequence_classifier import SequenceClassifier
 from tests import DaskSupportTest
 from tests.test_context import TEST_RESOURCES
+import pandas as pd
+import yaml
 
 BASE_CONFIG_PATH = os.path.join(TEST_RESOURCES, "resources/models/sequence_classifier")
+
+
+@pytest.fixture
+def training_data_yaml(tmpdir):
+    data_file = tmpdir.join("sentences.csv")
+    df = pd.DataFrame(
+        {
+            "tokens": ["Two simple sentences. Split by a dot.", "One simple sentence."],
+            "label": [1, 0],
+        }
+    )
+    df.to_csv(data_file, index=False)
+
+    yaml_file = tmpdir.join("training.yml")
+    yaml_dict = {
+        "source": str(data_file),
+        "mapping": {"tokens": "tokens", "label": "label"},
+    }
+    with yaml_file.open("w") as f:
+        yaml.safe_dump(yaml_dict, f)
+    return str(yaml_file)
+
+
+@pytest.fixture
+def pipeline_yaml(tmpdir):
+    yaml_dict = {
+        "pipeline": {
+            "token_indexers": {
+                "tokens": {
+                    "type": "single_id"
+                }
+            },
+            "segment_sentences": True,
+            "as_text_field": True,
+        },
+        "architecture": {
+            "text_field_embedder": {
+                "tokens": {
+                    "type": "embedding",
+                    "embedding_dim": 2,
+                }
+            },
+            "seq2vec_encoder": {
+                "type": "gru",
+                "input_size": 2,
+                "hidden_size": 2,
+                "bidirectional": False,
+            },
+            "multifield_seq2vec_encoder": {
+                "type": "gru",
+                "input_size": 2,
+                "hidden_size": 2,
+                "bidirectional": False,
+            }
+        }
+    }
+
+    yaml_file = tmpdir.join("pipeline.yml")
+    with yaml_file.open("w") as f:
+        yaml.safe_dump(yaml_dict, f)
+
+    return str(yaml_file)
+
+
+@pytest.fixture
+def trainer_yaml(tmpdir):
+    yaml_dict = {
+        "iterator": {
+            "batch_size": 2,
+            "cache_instances": True,
+            "max_instances_in_memory": 2,
+            "sorting_keys": [["tokens", "num_fields"]],
+            "type": "bucket",
+        },
+        "trainer": {
+            "type": "default",
+            "num_serialized_models_to_keep": 1,
+            "num_epochs": 1,
+            "optimizer": {
+                "type": "adam",
+                "amsgrad": True,
+                "lr": 0.01,
+            }
+        }
+    }
+
+    yaml_file = tmpdir.join("trainer.yml")
+    with yaml_file.open("w") as f:
+        yaml.safe_dump(yaml_dict, f)
+
+    return str(yaml_file)
+
+
+def test_segment_sentences(training_data_yaml, pipeline_yaml, trainer_yaml, tmpdir, tmpdir_factory):
+    pipeline = SequenceClassifier.from_config(pipeline_yaml)
+
+    pipeline.learn(
+        trainer=trainer_yaml,
+        train=training_data_yaml,
+        validation="",
+        output=str(tmpdir.join("output")),
+    )
 
 
 class SequenceClassifierTest(DaskSupportTest):

--- a/tests/text/pipelines/sequence_classifier_test.py
+++ b/tests/text/pipelines/sequence_classifier_test.py
@@ -45,6 +45,7 @@ def training_data_yaml(tmpdir):
 @pytest.fixture
 def pipeline_yaml(tmpdir):
     yaml_dict = {
+        "type": "sequence_classifier",
         "pipeline": {
             "token_indexers": {
                 "tokens": {


### PR DESCRIPTION
This PR implements the possibility to split the input into sentences and put them into a `ListField`. I added a test, that shows the usage.
For this i also implemented the `multifield_mask` that was still missing, so now we can use all kinds of seq2seq/seq2vec for the multifield level.

@dvsrepo @frascuchon There is a TODO comment in the `sequence_classifier_base.py`, line 149 that i do not understand:
>         # TODO: This will probably not work for single field input, we need to check the shape of record 1 and 2.

Should i worry?

I used the `segment_sentences` extensively for the Enron mails, the only issue i found is that it becomes super memory hungry when there are a lot of sentences. So i implemented an option to truncate the number of sentences (`max_nr_of_sentences`) together with an option to truncate the length of a sequence in a TextField (`max_sequence_length`).

As a side note: i would remove the `TextFieldBuilderMixin` mixin and implement its methods directly in the `DataSourceReader`. I found myself having to just pass on parameters through the `DataSourceReader` to the `TextFieldBuilderMixin`, which is generally a bad sign, and to write the same doc string several times. For now we also only mix in the `TextFieldBuilderMixin` in one class, that is the `DataSourceReader` class, which defies a bit the purpose of a mixin class ...  