### PR TITLE
pass on the verbose argument from the learn cli command to the pipeline

### DIFF
--- a/src/biome/text/commands/learn/learn.py
+++ b/src/biome/text/commands/learn/learn.py
@@ -131,4 +131,5 @@ def learn_from_args(args: argparse.Namespace):
         validation=args.validation,
         test=args.test,
         workers=args.workers,
+        verbose=args.verbose,
     )

--- a/src/biome/text/pipelines/pipeline.py
+++ b/src/biome/text/pipelines/pipeline.py
@@ -392,6 +392,7 @@ class Pipeline(Predictor):
         test: Optional[str] = None,
         vocab: Optional[str] = None,
         workers: int = 1,
+        verbose: bool = False,
     ):
         """
         Launch a learning process for loaded model configuration.
@@ -415,6 +416,8 @@ class Pipeline(Predictor):
             The test datasource configuration
         workers: int
             Number of workers used for local dask cluster. Obsolete
+        verbose
+            Turn on verbose logs
         """
 
         kwargs = dict(
@@ -424,6 +427,7 @@ class Pipeline(Predictor):
             trainer_path=trainer,
             train_cfg=train,
             validation_cfg=validation,
+            verbose=verbose,
         )
 
         if self.__binary_path:


### PR DESCRIPTION
With this PR the verbose argument from the `biome learn` cli command is passed on to the `pipeline.learn` method.