### PR TITLE
allow arbitrary reader in pipeline if explicitly specified

### DIFF
--- a/src/biome/text/pipelines/pipeline.py
+++ b/src/biome/text/pipelines/pipeline.py
@@ -338,7 +338,7 @@ class Pipeline(Predictor):
     def __get_reader_params(cls, data: dict, name: Optional[str] = None) -> dict:
         # TODO dataset_reader will not be supported as part of configuration definition
         config = data.get(cls.PIPELINE_FIELD, data.get("dataset_reader"))
-        if name:
+        if name and not config.get(cls.TYPE_FIELD):
             config[cls.TYPE_FIELD] = name
         return copy.deepcopy(config)
 


### PR DESCRIPTION
With this small PR, we are able to use arbitrary registered `DatasetReader`s for `Pipeline`s. If in the pipeline config yaml no DatasetReader type is specified, the default type for the pipeline is taken. If a type is explicitly specified in the yaml, use this one instead.

This is particularly useful in the DZBank project.