### PR TITLE
remove workers argument

### DIFF
--- a/src/biome/text/commands/learn/learn.py
+++ b/src/biome/text/commands/learn/learn.py
@@ -103,10 +103,6 @@ class BiomeLearn(Subcommand):
         )
 
         subparser.add_argument(
-            "--workers", type=int, default=1, help="Workers for dask local cluster"
-        )
-
-        subparser.add_argument(
             "-v",
             "--verbose",
             action="store_true",
@@ -136,6 +132,5 @@ def learn_from_args(args: argparse.Namespace):
         train=args.train,
         validation=args.validation,
         test=args.test,
-        workers=args.workers,
         verbose=args.verbose,
     )


### PR DESCRIPTION
in the pylint commit we removed the worker argument from the pipeline learn command, but passed it on in the learn cli command.