### PR TITLE
Feat: Implement loss weights for the SequenceClassifier and SequencePairClassifier

### DIFF
--- a/src/biome/text/models/sequence_classifier_base.py
+++ b/src/biome/text/models/sequence_classifier_base.py
@@ -143,7 +143,10 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         weights = []
         for i in range(self.vocab.get_vocab_size(namespace="labels")):
             label = self.vocab.get_token_from_index(i, namespace="labels")
-            weights.append(loss_weights[label])
+            try:
+                weights.append(loss_weights[label])
+            except KeyError as error:
+                raise KeyError(f"Could not find {label} in the specified loss_weights") from error
 
         return torch.tensor(weights)
 

--- a/src/biome/text/models/sequence_classifier_base.py
+++ b/src/biome/text/models/sequence_classifier_base.py
@@ -150,7 +150,7 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
                 raise KeyError(f"Could not find {label} in the specified loss_weights") from error
 
         if loss_weights:
-            raise ValueError(f"Could not find the labels {loss_weights.keys()} in the vocabulary")
+            raise ValueError(f"Could not find the labels {list(loss_weights.keys())} in the vocabulary")
 
         return torch.tensor(weights)
 

--- a/src/biome/text/models/sequence_classifier_base.py
+++ b/src/biome/text/models/sequence_classifier_base.py
@@ -54,6 +54,9 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         Used to regularize the model. Passed on to :class:`~allennlp.models.model.Model`.
     accuracy
         The accuracy you want to use. By default, we choose a categorical top-1 accuracy.
+    loss_weights
+        A dict with the labels and the corresponding weights.
+        These weights will be used in the CrossEntropyLoss function.
     """
 
     @property
@@ -75,6 +78,7 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         initializer: Optional[InitializerApplicator] = None,
         regularizer: Optional[RegularizerApplicator] = None,
         accuracy: Optional[CategoricalAccuracy] = None,
+        loss_weights: Dict[str, float] = None,
     ) -> None:
         # Passing on kwargs does not work because of the 'from_params' machinery
         super().__init__(accuracy=accuracy, vocab=vocab, regularizer=regularizer)
@@ -85,7 +89,7 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         # dropout for encoded vector
         self._dropout = Dropout(dropout) if dropout else None
         # loss function for training
-        self._loss = torch.nn.CrossEntropyLoss()
+        self._loss = torch.nn.CrossEntropyLoss(weight=self._get_loss_weights(loss_weights))
         # default value for wrapping dimensions for masking = 0 (single field)
         self._num_wrapping_dims = 0
 
@@ -130,6 +134,18 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         self._output_layer = Linear(self._classifier_input_dim, self.num_classes)
 
         self._initializer(self)
+
+    def _get_loss_weights(self, loss_weights: Dict[str, float] = None) -> Optional[torch.Tensor]:
+        """Helper function to get the weights for the class labels in the CrossEntropyLoss function"""
+        if loss_weights is None:
+            return None
+
+        weights = []
+        for i in range(self.vocab.get_vocab_size(namespace="labels")):
+            label = self.vocab.get_token_from_index(i, namespace="labels")
+            weights.append(loss_weights[label])
+
+        return torch.tensor(weights)
 
     @property
     def num_classes(self):

--- a/src/biome/text/models/sequence_classifier_base.py
+++ b/src/biome/text/models/sequence_classifier_base.py
@@ -140,13 +140,17 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         if loss_weights is None:
             return None
 
+        loss_weights = loss_weights.copy()  # So the popping does not change the input
         weights = []
         for i in range(self.vocab.get_vocab_size(namespace="labels")):
             label = self.vocab.get_token_from_index(i, namespace="labels")
             try:
-                weights.append(loss_weights[label])
+                weights.append(loss_weights.pop(label))
             except KeyError as error:
                 raise KeyError(f"Could not find {label} in the specified loss_weights") from error
+
+        if loss_weights:
+            raise ValueError(f"Could not find the labels {loss_weights.keys()} in the vocabulary")
 
         return torch.tensor(weights)
 

--- a/tests/text/models/base_classifier.py
+++ b/tests/text/models/base_classifier.py
@@ -12,9 +12,13 @@ from biome.text.commands.explore.explore import explore
 from biome.text.commands.serve.serve import serve
 from biome.text.environment import ES_HOST
 from biome.text.models import load_archive
+from biome.text.models import SequenceClassifierBase
 from biome.text.predictors.utils import get_predictor_from_archive
 from tests.test_context import TEST_RESOURCES
 from tests.test_support import DaskSupportTest
+from allennlp.modules import TextFieldEmbedder
+from allennlp.modules import Seq2VecEncoder
+import torch
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -22,6 +26,24 @@ logging.basicConfig(level=logging.DEBUG)
 BASE_CONFIG_PATH = os.path.join(
     TEST_RESOURCES, "resources/models/sequence_pair_classifier"
 )
+
+
+def test_loss_weights(tokens_labels_vocab):
+    encoder = Seq2VecEncoder()
+    encoder.get_output_dim = lambda: 1
+    model = SequenceClassifierBase(
+        vocab=tokens_labels_vocab,
+        text_field_embedder=TextFieldEmbedder(),
+        seq2vec_encoder=encoder,
+        loss_weights={"label0": 0.0, "label1": 1.0},
+    )
+
+    input_tensor = torch.tensor([[1.0, 1.0]])
+    class_tensor0 = torch.tensor([0], dtype=torch.long)
+    class_tensor1 = torch.tensor([1], dtype=torch.long)
+
+    assert model._loss(input=input_tensor, target=class_tensor0) == torch.tensor(0)
+    assert model._loss(input=input_tensor, target=class_tensor1) == -torch.log(torch.tensor(0.5))
 
 
 class BasePairClassifierTest(DaskSupportTest):

--- a/tests/text/models/conftest.py
+++ b/tests/text/models/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+from allennlp.data.fields import TextField, LabelField
+from allennlp.data.tokenizers import WordTokenizer
+from allennlp.data.token_indexers import SingleIdTokenIndexer
+from allennlp.data.vocabulary import Vocabulary
+
+
+@pytest.fixture
+def tokens_labels_vocab():
+    text = "The grass is green and the sky is blue. What can you do?"
+    text_field = TextField(WordTokenizer().tokenize(text), token_indexers={"tokens": SingleIdTokenIndexer()})
+
+    vocab = Vocabulary.from_instances([text_field, LabelField("label0"), LabelField("label1")])
+
+    return vocab
+
+
+


### PR DESCRIPTION
This PR adds a `loss_weights` parameter that allows one to give different weights to the labels in the CrossEntropyLoss function.

One has to specify the label name and its corresponding weight in the model config file. An example would be:
```yaml
architecture:
  type: sequence_classifier
  loss_weights:
    'my_first_label': 0.2
    'my_second_label': 0.8
  text_field_embedder:
...
```