### PR TITLE
feat: empty model pipelines

### DIFF
--- a/src/biome/text/commands/explore/explore.py
+++ b/src/biome/text/commands/explore/explore.py
@@ -1,35 +1,25 @@
 import argparse
-import datetime
 import logging
 import os
 import re
-import warnings
-from typing import Type, Union, List
 
-import dask.dataframe as dd
-import pandas as pd
 from allennlp.commands.subcommand import Subcommand
-from allennlp.common.checks import ConfigurationError
-from allennlp.interpret import SaliencyInterpreter
+
+from biome.text.constants import BIOME_METADATA_INDEX, EXPLORE_APP_ENDPOINT
+from biome.text.environment import ES_HOST
+from biome.text.helpers import get_compatible_doc_type
+from biome.text.pipelines import explore as pipeline_explore
+from biome.text.pipelines.explore import ElasticsearchConfig, ExploreConfig
+from biome.text.pipelines.pipeline import Pipeline
 
 # TODO centralize configuration
-from elasticsearch import Elasticsearch
 
-from biome.data.sources import DataSource
-from biome.text.environment import ES_HOST, BIOME_EXPLORE_ENDPOINT
-from biome.text.interpreters import IntegratedGradient as DefaultInterpreterClass
-from biome.text.pipelines.pipeline import Pipeline
-from dask_elk.client import DaskElasticClient
+# TODO: Remove (Just backward compatibility)
+__alias__ = [get_compatible_doc_type, BIOME_METADATA_INDEX, EXPLORE_APP_ENDPOINT]
 
 
 logging.basicConfig(level=logging.INFO)
 __LOGGER = logging.getLogger(__name__)
-
-BIOME_METADATA_INDEX = ".biome"
-
-# This is the biome explore UI endpoint, used for show information
-# about explorations once the data is persisted
-EXPLORE_APP_ENDPOINT = os.getenv(BIOME_EXPLORE_ENDPOINT, "http://localhost:8080")
 
 
 class BiomeExplore(Subcommand):
@@ -105,6 +95,7 @@ def explore_with_args(args: argparse.Namespace) -> None:
     )
 
 
+# TODO: Remove (Just backward compatibility)
 def explore(
     binary: str,
     source_path: str,
@@ -116,247 +107,25 @@ def explore(
     force_delete: bool = True,
     **prediction_metadata,
 ) -> None:
-    """
-    Read a data source and tries to apply a model predictions to the whole data source. The
-    results will be persisted into an elasticsearch index for further data exploration
-
-    Parameters
-    ----------
-    binary
-        The model.tar.gz file
-    source_path
-        The input data source
-    es_host
-        The elasticsearch host where publish the data
-    es_index
-        The elasticsearch index where publish the data
-    batch_size
-        The batch size for model predictions
-    prediction_cache_size
-        Size of the prediction cache in number of items
-    interpret: bool
-        If true, include interpret information for every prediction
-    force_delete: bool
-        If true, force delete elastic index before explore data creation
-    prediction_metadata: keyed arguments
-        Extra arguments included as prediction metadata
-    """
-    pipeline = Pipeline.load(binary)
-
-    if not isinstance(pipeline, Pipeline):
-        raise ConfigurationError(
-            f"Cannot load a biome Pipeline from {binary}"
-            "\nPlease, be sure your pipeline class is registered as an allennlp.predictos.Predictor"
-            "\nwith the same name that your model."
-        )
-
-    if prediction_cache_size > 0:
-        pipeline.init_prediction_cache(prediction_cache_size)
-
-    client = Elasticsearch(hosts=es_host, retry_on_timeout=True, http_compress=True)
-    doc_type = get_compatible_doc_type(client)
-
-    ds = DataSource.from_yaml(source_path)
-    ddf_mapped = ds.to_mapped_dataframe()
-    # this only makes really sense when we have a predict_batch_json method implemented ...
-    n_partitions = max(1, round(len(ddf_mapped) / batch_size))
-
-    # a persist is necessary here, otherwise it fails for n_partitions == 1
-    # the reason is that with only 1 partition we pass on a generator to predict_batch_json
-    ddf_mapped = ddf_mapped.repartition(npartitions=n_partitions).persist()
-    ddf_mapped_columns = ddf_mapped.columns
-
-    ddf_mapped["annotation"] = ddf_mapped[ddf_mapped_columns].apply(
-        lambda x: pipeline.predict_json(x.to_dict()), axis=1, meta=(None, object)
-    )
-
-    if interpret:
-        # TODO we should apply the same mechanism for the model predictions. Creating a new pipeline
-        #  for every partition
-        ddf_mapped["interpretations"] = ddf_mapped[ddf_mapped_columns].map_partitions(
-            _interpret_dataframe, binary_path=binary, meta=(None, object)
-        )
-
-    ddf_source = ds.to_dataframe()
-    ddf_source = ddf_source.repartition(npartitions=n_partitions).persist()
-
-    # We are sure that both data frames are aligned!
-    # A 100% safe way would be to set_index of both data frames on a meaningful column.
-    # The main problem are multiple csv files (read_csv("*.csv")), where the index starts from 0 for each file ...
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        ddf = dd.concat([ddf_source, ddf_mapped], axis=1)
-
-    # TODO @dcfidalgo we could calculate base metrics here (F1, recall & precision) using dataframe.
-    #  And include as part of explore metadata
-    #  Does it's simple???
-
-    ddf = DaskElasticClient(
-        host=es_host, retry_on_timeout=True, http_compress=True
-    ).save(ddf, index=es_index, doc_type=doc_type)
-
-    merged_metadata = {
-        **dict(
-            datasource=source_path,
-            # TODO this should change when ui is normalized (action detail and action link naming)F
-            explore_name=es_index,
-            model=binary,
-            columns=ddf.columns.values.tolist(),
+    pipeline_explore.pipeline_predictions(
+        Pipeline.load(binary),
+        source_path=source_path,
+        # TODO use the /elastic explorer UI proxy as default elasticsearch endpoint
+        es_config=ElasticsearchConfig(es_host=es_host, es_index=es_index),
+        config=ExploreConfig(
+            batch_size=batch_size,
+            prediction_cache_size=prediction_cache_size,
+            interpret=interpret,
+            force_delete=force_delete,
+            **prediction_metadata,
         ),
-        **(prediction_metadata or {}),
-    }
-
-    register_biome_prediction(
-        name=es_index,
-        pipeline=pipeline,
-        es_hosts=es_host,
-        created_index=es_index,
-        **merged_metadata,
-    )
-
-    __prepare_es_index(client, es_index, doc_type, force_delete=force_delete)
-    ddf.persist()
-    # TODO: The explore APP endpoint returns localhost:8080, running biome ui defaults to
-    __LOGGER.info(
-        "Data annotated successfully. You can explore your data here: %s",
-        f"{EXPLORE_APP_ENDPOINT}/explore/{es_index}",
     )
 
 
-def _interpret_dataframe(
-    df: pd.DataFrame,
-    binary_path: str,
-    interpreter_klass: Type = DefaultInterpreterClass,
-) -> pd.Series:
-    """
-    Apply a model interpretation to every partition dataframe
-
-    Parameters
-    ----------
-    df: pd.DataFrame
-        The partition DataFrame
-    binary_path: str
-        The model binary path
-    interpreter_klass: Type
-        The used interpreted class
-
-    Returns
-    -------
-
-    A pandas Series representing the interpretations
-
-    """
-
-    def interpret_row(
-        row: pd.Series, interpreter: SaliencyInterpreter
-    ) -> Union[dict, List[dict]]:
-        """Interpret a incoming dataframe row"""
-        data = row.to_dict()
-        interpretation = interpreter.saliency_interpret_from_json(data)
-        if len(interpretation) == 0:
-            return {}
-        if len(interpretation) == 1:
-            return interpretation[0]
-        return interpretation
-
-    pipeline = Pipeline.load(binary_path)
-    interpreter = interpreter_klass(pipeline)
-    return df.apply(interpret_row, interpreter=interpreter, axis=1)
-
-
-def get_compatible_doc_type(client: Elasticsearch) -> str:
-    """
-    Find a compatible name for doc type by checking the cluster info
-    Parameters
-    ----------
-    client
-        The elasticsearch client
-
-    Returns
-    -------
-        A compatible name for doc type in function of cluster version
-    """
-
-    es_version = int(client.info()["version"]["number"].split(".")[0])
-    return "_doc" if es_version >= 6 else "doc"
-
-
+# TODO: Remove (Just backward compatibility)
 def register_biome_prediction(
-    name: str, pipeline: Pipeline, es_hosts: str, created_index: str, **kwargs
-):
-    """
-    Creates a new metadata entry for the incoming prediction
-
-    Parameters
-    ----------
-    name
-        A descriptive prediction name
-    pipeline
-        The pipeline used for the prediction batch
-    created_index
-        The elasticsearch index created for the prediction
-    es_hosts
-        The elasticsearch host where publish the new entry
-    kwargs
-        Extra arguments passed as extra metadata info
-    """
-
-    metadata_index = f"{BIOME_METADATA_INDEX}"
-    es_client = Elasticsearch(hosts=es_hosts, retry_on_timeout=True, http_compress=True)
-
-    es_client.indices.create(
-        index=metadata_index,
-        body={"settings": {"index": {"number_of_shards": 1, "number_of_replicas": 0}}},
-        params=dict(ignore=400),
-    )
-
-    predict_signature = [
-        k for k, v in pipeline.signature.items() if not v.get("optional")
-    ]
-    parameters = {
-        **kwargs,
-        "pipeline": pipeline.name,
-        "signature": list(pipeline.signature.keys()),
-        "predict_signature": predict_signature,
-        # TODO remove when ui is adapteds
-        "inputs": predict_signature,  # backward compatibility
-    }
-
-    es_client.update(
-        index=metadata_index,
-        doc_type=get_compatible_doc_type(es_client),
-        id=created_index,
-        body={
-            "doc": dict(name=name, created_at=datetime.datetime.now(), **parameters),
-            "doc_as_upsert": True,
-        },
-    )
-    del es_client
-
-
-def __prepare_es_index(
-    es_client: Elasticsearch, index: str, doc_type: str, force_delete: bool
-):
-    # TODO: Define wide index template
-    dynamic_templates = [
-        {
-            data_type: {
-                "match_mapping_type": data_type,
-                "path_match": path_match,
-                "mapping": {
-                    "type": "text",
-                    "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
-                },
-            }
-        }
-        for data_type, path_match in [("*", "*.value"), ("string", "*")]
-    ]
-
-    if force_delete:
-        es_client.indices.delete(index=index, ignore=[400, 404])
-
-    es_client.indices.create(
-        index=index,
-        body={"mappings": {doc_type: {"dynamic_templates": dynamic_templates}}},
-        ignore=400,
+    name: str, created_index: str, es_hosts: str, pipeline: Pipeline, **extra_args: dict
+) -> None:
+    pipeline_explore.register_biome_prediction(
+        name, pipeline, ElasticsearchConfig(es_hosts, created_index), **extra_args
     )

--- a/src/biome/text/constants.py
+++ b/src/biome/text/constants.py
@@ -1,0 +1,8 @@
+import os
+
+from .environment import BIOME_EXPLORE_ENDPOINT
+
+BIOME_METADATA_INDEX = ".biome"
+# This is the biome explore UI endpoint, used for show information
+# about explorations once the data is persisted
+EXPLORE_APP_ENDPOINT = os.getenv(BIOME_EXPLORE_ENDPOINT, "http://localhost:8080")

--- a/src/biome/text/dataset_readers/datasource_reader.py
+++ b/src/biome/text/dataset_readers/datasource_reader.py
@@ -10,7 +10,10 @@ from allennlp.data.tokenizers import WordTokenizer, SentenceSplitter
 from allennlp.data.tokenizers.sentence_splitter import SpacySentenceSplitter
 from biome.data.sources import DataSource
 from biome.text.dataset_readers.mixins import CacheableMixin
-from biome.text.dataset_readers.text_transforms import RmSpacesTransforms, TextTransforms
+from biome.text.dataset_readers.text_transforms import (
+    RmSpacesTransforms,
+    TextTransforms,
+)
 from dask.dataframe import Series as DaskSeries
 
 
@@ -59,7 +62,7 @@ class DataSourceReader(DatasetReader, CacheableMixin):
         DatasetReader.__init__(self, lazy=True)
 
         self._tokenizer = tokenizer or WordTokenizer()
-        self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer}
+        self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
         self._sentence_segmenter = segment_sentences
         if segment_sentences is True:
             self._sentence_segmenter = SpacySentenceSplitter()

--- a/src/biome/text/dataset_readers/mixins.py
+++ b/src/biome/text/dataset_readers/mixins.py
@@ -17,4 +17,3 @@ class CacheableMixin:
     def set(key, data):
         """ Set an cache entry """
         CacheableMixin._cache[key] = data
-

--- a/src/biome/text/dataset_readers/text_transforms.py
+++ b/src/biome/text/dataset_readers/text_transforms.py
@@ -84,4 +84,3 @@ class Html2TextTransforms(RmSpacesTransforms):
     def html_to_text(text: str) -> str:
         """Extract text from a html doc with BeautifulSoup4"""
         return BeautifulSoup(text, "lxml").get_text()
-

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -1,0 +1,18 @@
+from elasticsearch import Elasticsearch
+
+
+def get_compatible_doc_type(client: Elasticsearch) -> str:
+    """
+    Find a compatible name for doc type by checking the cluster info
+    Parameters
+    ----------
+    client
+        The elasticsearch client
+
+    Returns
+    -------
+        A compatible name for doc type in function of cluster version
+    """
+
+    es_version = int(client.info()["version"]["number"].split(".")[0])
+    return "_doc" if es_version >= 6 else "doc"

--- a/src/biome/text/models/sequence_classifier_base.py
+++ b/src/biome/text/models/sequence_classifier_base.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 import torch
 from allennlp.data import Vocabulary
@@ -254,3 +254,7 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         self, *inputs
     ) -> Dict[str, torch.Tensor]:  # pylint: disable=arguments-differ
         raise NotImplementedError
+
+    def extend_labels(self, labels: List[str]):
+        self.vocab.add_tokens_to_namespace(labels, namespace="labels")
+        self._output_layer = Linear(self._classifier_input_dim, self.num_classes)

--- a/src/biome/text/models/sequence_classifier_base.py
+++ b/src/biome/text/models/sequence_classifier_base.py
@@ -3,7 +3,13 @@ from typing import Dict, Optional, List
 import torch
 from allennlp.data import Vocabulary
 from allennlp.models.model import Model
-from allennlp.modules import TextFieldEmbedder, Seq2VecEncoder, Seq2SeqEncoder, FeedForward, TimeDistributed
+from allennlp.modules import (
+    TextFieldEmbedder,
+    Seq2VecEncoder,
+    Seq2SeqEncoder,
+    FeedForward,
+    TimeDistributed,
+)
 from allennlp.nn import RegularizerApplicator, InitializerApplicator
 from allennlp.nn.util import get_text_field_mask
 from allennlp.training.metrics import CategoricalAccuracy
@@ -83,7 +89,9 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         # dropout for encoded vector
         self._dropout = Dropout(dropout) if dropout else None
         # loss function for training
-        self._loss = torch.nn.CrossEntropyLoss(weight=self._get_loss_weights(loss_weights))
+        self._loss = torch.nn.CrossEntropyLoss(
+            weight=self._get_loss_weights(loss_weights)
+        )
         # default value for wrapping dimensions for masking = 0 (single field)
         self._num_wrapping_dims = 0
 
@@ -91,14 +99,18 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
             # 1. setup num_wrapping_dims to 1
             self._num_wrapping_dims = 1
             # 2. Wrap the seq2vec and seq2seq encoders in TimeDistributed to account for the extra dimension num_fields
-            self._seq2seq_encoder = TimeDistributed(seq2seq_encoder) if seq2seq_encoder else None
+            self._seq2seq_encoder = (
+                TimeDistributed(seq2seq_encoder) if seq2seq_encoder else None
+            )
             self._seq2vec_encoder = TimeDistributed(seq2vec_encoder)
             # 3. (Optionally) setup multifield_seq2seq_encoder
             self._multifield_seq2seq_encoder = multifield_seq2seq_encoder
             # 4. setup multifield_seq2vec_encoder
             self._multifield_seq2vec_encoder = multifield_seq2vec_encoder
             # doc vector dropout
-            self._multifield_dropout = Dropout(multifield_dropout) if multifield_dropout else None
+            self._multifield_dropout = (
+                Dropout(multifield_dropout) if multifield_dropout else None
+            )
         else:
             # token sequence level encoders
             self._seq2seq_encoder = seq2seq_encoder
@@ -113,7 +125,9 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         if self._feed_forward:
             self._classifier_input_dim = self._feed_forward.get_output_dim()
         elif self._multifield_seq2vec_encoder:
-            self._classifier_input_dim = self._multifield_seq2vec_encoder.get_output_dim()
+            self._classifier_input_dim = (
+                self._multifield_seq2vec_encoder.get_output_dim()
+            )
         else:
             self._classifier_input_dim = self._seq2vec_encoder.get_output_dim()
 
@@ -123,7 +137,9 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
 
         self._initializer(self)
 
-    def _get_loss_weights(self, loss_weights: Dict[str, float] = None) -> Optional[torch.Tensor]:
+    def _get_loss_weights(
+        self, loss_weights: Dict[str, float] = None
+    ) -> Optional[torch.Tensor]:
         """Helper function to get the weights for the class labels in the CrossEntropyLoss function"""
         if loss_weights is None:
             return None
@@ -135,10 +151,14 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
             try:
                 weights.append(loss_weights.pop(label))
             except KeyError as error:
-                raise KeyError(f"Could not find {label} in the specified loss_weights") from error
+                raise KeyError(
+                    f"Could not find {label} in the specified loss_weights"
+                ) from error
 
         if loss_weights:
-            raise ValueError(f"Could not find the labels {list(loss_weights.keys())} in the vocabulary")
+            raise ValueError(
+                f"Could not find the labels {list(loss_weights.keys())} in the vocabulary"
+            )
 
         return torch.tensor(weights)
 
@@ -173,9 +193,13 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         -------
         A ``Tensor``
         """
-        mask = get_text_field_mask(tokens, num_wrapping_dims=self._num_wrapping_dims).float()
+        mask = get_text_field_mask(
+            tokens, num_wrapping_dims=self._num_wrapping_dims
+        ).float()
 
-        embedded_text = self._text_field_embedder(tokens, mask=mask, num_wrapping_dims=self._num_wrapping_dims)
+        embedded_text = self._text_field_embedder(
+            tokens, mask=mask, num_wrapping_dims=self._num_wrapping_dims
+        )
 
         # seq2seq encoding for each token in field
         if self._seq2seq_encoder:
@@ -195,10 +219,14 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
 
             # seq2seq encoding for each field vector
             if self._multifield_seq2seq_encoder:
-                encoded_text = self._multifield_seq2seq_encoder(encoded_text, mask=multifield_mask)
+                encoded_text = self._multifield_seq2seq_encoder(
+                    encoded_text, mask=multifield_mask
+                )
 
             # seq2vec encoding for field --> record vector
-            encoded_text = self._multifield_seq2vec_encoder(encoded_text, mask=multifield_mask)
+            encoded_text = self._multifield_seq2vec_encoder(
+                encoded_text, mask=multifield_mask
+            )
 
             if self._multifield_dropout:
                 encoded_text = self._multifield_dropout(encoded_text)
@@ -208,7 +236,9 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
 
         return encoded_text
 
-    def output_layer(self, encoded_text: torch.Tensor, label) -> Dict[str, torch.Tensor]:
+    def output_layer(
+        self, encoded_text: torch.Tensor, label
+    ) -> Dict[str, torch.Tensor]:
         """
         Returns
         -------
@@ -235,5 +265,7 @@ class SequenceClassifierBase(BiomeClassifierMixin, Model):
         return output_dict
 
     @overrides
-    def forward(self, *inputs) -> Dict[str, torch.Tensor]:  # pylint: disable=arguments-differ
+    def forward(
+        self, *inputs
+    ) -> Dict[str, torch.Tensor]:  # pylint: disable=arguments-differ
         raise NotImplementedError

--- a/src/biome/text/pipelines/defs.py
+++ b/src/biome/text/pipelines/defs.py
@@ -1,0 +1,33 @@
+from elasticsearch import Elasticsearch
+
+from biome.text import helpers
+
+
+class ElasticsearchConfig:
+    """ Elasticsearch configuration data class"""
+
+    def __init__(self, es_host: str, es_index: str):
+        self.es_host = es_host or "localhost:9200"
+        self.es_index = es_index
+        self.client = Elasticsearch(
+            hosts=es_host, retry_on_timeout=True, http_compress=True
+        )
+        self.es_doc = helpers.get_compatible_doc_type(self.client)
+
+
+class ExploreConfig:
+    """Explore configuration data class"""
+
+    def __init__(
+        self,
+        batch_size: int = 500,
+        prediction_cache_size: int = 0,
+        interpret: bool = False,
+        force_delete: bool = True,
+        **metadata,
+    ):
+        self.batch_size = batch_size
+        self.prediction_cache = prediction_cache_size
+        self.interpret = interpret
+        self.force_delete = force_delete
+        self.metadata = metadata

--- a/src/biome/text/pipelines/explore.py
+++ b/src/biome/text/pipelines/explore.py
@@ -95,6 +95,7 @@ def pipeline_predictions(
         "Data annotated successfully. You can explore your data here: %s",
         f"{constants.EXPLORE_APP_ENDPOINT}/projects/default/explore/{es_config.es_index}",
     )
+
     return ddf
 
 

--- a/src/biome/text/pipelines/explore.py
+++ b/src/biome/text/pipelines/explore.py
@@ -1,0 +1,212 @@
+import datetime
+import logging
+import warnings
+from typing import Type, Union, List
+
+import pandas as pd
+from allennlp.interpret import SaliencyInterpreter
+from dask import dataframe as dd
+from dask_elk.client import DaskElasticClient
+
+from biome.data import DataSource
+from biome.text import Pipeline
+from biome.text import constants
+from biome.text.interpreters import IntegratedGradient as DefaultInterpreterClass
+from biome.text.pipelines.defs import ExploreConfig, ElasticsearchConfig
+
+__LOGGER = logging.getLogger(__name__)
+
+
+def pipeline_predictions(
+    pipeline: Pipeline,
+    source_path: str,
+    config: ExploreConfig,
+    es_config: ElasticsearchConfig,
+) -> dd.DataFrame:
+    """
+    Read a data source and tries to apply a model predictions to the whole data source. The
+    results will be persisted into an elasticsearch index for further data exploration
+
+    """
+
+    if config.prediction_cache > 0:
+        pipeline.init_prediction_cache(config.prediction_cache)
+
+    ds = DataSource.from_yaml(source_path)
+    ddf_mapped = ds.to_mapped_dataframe()
+    # this only makes really sense when we have a predict_batch_json method implemented ...
+    n_partitions = max(1, round(len(ddf_mapped) / config.batch_size))
+
+    # a persist is necessary here, otherwise it fails for n_partitions == 1
+    # the reason is that with only 1 partition we pass on a generator to predict_batch_json
+    ddf_mapped = ddf_mapped.repartition(npartitions=n_partitions).persist()
+    ddf_mapped_columns = ddf_mapped.columns
+
+    ddf_mapped["annotation"] = ddf_mapped[ddf_mapped_columns].apply(
+        lambda x: pipeline.predict_json(x.to_dict()), axis=1, meta=(None, object)
+    )
+
+    if config.interpret:
+        # TODO we should apply the same mechanism for the model predictions. Creating a new pipeline
+        #  for every partition
+        ddf_mapped["interpretations"] = ddf_mapped[ddf_mapped_columns].map_partitions(
+            _interpret_dataframe, pipeline=pipeline, meta=(None, object)
+        )
+
+    ddf_source = ds.to_dataframe()
+    ddf_source = ddf_source.repartition(npartitions=n_partitions).persist()
+
+    # We are sure that both data frames are aligned!
+    # A 100% safe way would be to set_index of both data frames on a meaningful column.
+    # The main problem are multiple csv files (read_csv("*.csv")), where the index starts from 0 for each file ...
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ddf = dd.concat([ddf_source, ddf_mapped], axis=1)
+
+    # TODO @dcfidalgo we could calculate base metrics here (F1, recall & precision) using dataframe.
+    #  And include as part of explore metadata
+    #  Does it's simple???
+
+    ddf = DaskElasticClient(
+        host=es_config.es_host, retry_on_timeout=True, http_compress=True
+    ).save(ddf, index=es_config.es_index, doc_type=es_config.es_doc)
+
+    merged_metadata = {
+        **dict(
+            datasource=source_path,
+            # TODO this should change when ui is normalized (action detail and action link naming)F
+            explore_name=es_config.es_index,
+            model=pipeline.name,
+            columns=ddf.columns.values.tolist(),
+        ),
+        **(config.metadata or {}),
+    }
+
+    register_biome_prediction(
+        name=es_config.es_index,
+        pipeline=pipeline,
+        es_config=es_config,
+        **merged_metadata,
+    )
+
+    __prepare_es_index(es_config, force_delete=config.force_delete)
+    ddf = ddf.persist()
+    __LOGGER.info(
+        "Data annotated successfully. You can explore your data here: %s",
+        f"{constants.EXPLORE_APP_ENDPOINT}/projects/default/explore/{es_config.es_index}",
+    )
+    return ddf
+
+
+def register_biome_prediction(
+    name: str, pipeline: Pipeline, es_config: ElasticsearchConfig, **kwargs
+):
+    """
+    Creates a new metadata entry for the incoming prediction
+
+    Parameters
+    ----------
+    name
+        A descriptive prediction name
+    pipeline
+        The pipeline used for the prediction batch
+    es_config:
+        The Elasticsearch configuration data
+    kwargs
+        Extra arguments passed as extra metadata info
+    """
+
+    metadata_index = constants.BIOME_METADATA_INDEX
+
+    es_config.client.indices.create(
+        index=metadata_index,
+        body={"settings": {"index": {"number_of_shards": 1, "number_of_replicas": 0}}},
+        params=dict(ignore=400),
+    )
+
+    predict_signature = [
+        k for k, v in pipeline.signature.items() if not v.get("optional")
+    ]
+    parameters = {
+        **kwargs,
+        "pipeline": pipeline.name,
+        "signature": list(pipeline.signature.keys()),
+        "predict_signature": predict_signature,
+        # TODO remove when ui is adapted
+        "inputs": predict_signature,  # backward compatibility
+    }
+
+    es_config.client.update(
+        index=metadata_index,
+        doc_type=es_config.es_doc,
+        id=es_config.es_index,
+        body={
+            "doc": dict(name=name, created_at=datetime.datetime.now(), **parameters),
+            "doc_as_upsert": True,
+        },
+    )
+
+
+def _interpret_dataframe(
+    df: pd.DataFrame,
+    pipeline: Pipeline,
+    interpreter_klass: Type = DefaultInterpreterClass,
+) -> pd.Series:
+    """
+    Apply a model interpretation to every partition dataframe
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        The partition DataFrame
+    binary_path: str
+        The model binary path
+    interpreter_klass: Type
+        The used interpreted class
+
+    Returns
+    -------
+
+    A pandas Series representing the interpretations
+
+    """
+
+    def interpret_row(
+        row: pd.Series, interpreter: SaliencyInterpreter
+    ) -> Union[dict, List[dict]]:
+        """Interpret a incoming dataframe row"""
+        data = row.to_dict()
+        interpretation = interpreter.saliency_interpret_from_json(data)
+        if len(interpretation) == 0:
+            return {}
+        if len(interpretation) == 1:
+            return interpretation[0]
+        return interpretation
+
+    interpreter = interpreter_klass(pipeline)
+    return df.apply(interpret_row, interpreter=interpreter, axis=1)
+
+
+def __prepare_es_index(es_config: ElasticsearchConfig, force_delete: bool):
+    dynamic_templates = [
+        {
+            data_type: {
+                "match_mapping_type": data_type,
+                "path_match": path_match,
+                "mapping": {
+                    "type": "text",
+                    "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+                },
+            }
+        }
+        for data_type, path_match in [("*", "*.value"), ("string", "*")]
+    ]
+
+    if force_delete:
+        es_config.client.indices.delete(index=es_config.es_index, ignore=[400, 404])
+
+    es_config.client.indices.create(
+        index=es_config.es_index,
+        body={"mappings": {es_config.es_doc: {"dynamic_templates": dynamic_templates}}},
+        ignore=400,
+    )

--- a/src/biome/text/pipelines/pipeline.py
+++ b/src/biome/text/pipelines/pipeline.py
@@ -92,7 +92,9 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
         self.__binary_path = None
         self.__prediction_logger = None
 
-    def init_prediction_logger(self, output_dir: str, max_bytes: int = 20000000, backup_count: int = 20):
+    def init_prediction_logger(
+        self, output_dir: str, max_bytes: int = 20000000, backup_count: int = 20
+    ):
         """Initialize the prediction logger.
 
         If initialized we will log all predictions to a file called *predictions.json* in the `output_folder`.
@@ -114,7 +116,9 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
         # This flag avoids logging messages to be propagated to the parent loggers
         predictions_logger.propagate = False
         file_handler = RotatingFileHandler(
-            os.path.join(output_dir, self.PREDICTION_FILE_NAME), maxBytes=max_bytes, backupCount=backup_count
+            os.path.join(output_dir, self.PREDICTION_FILE_NAME),
+            maxBytes=max_bytes,
+            backupCount=backup_count,
         )
         file_handler.setLevel(logging.INFO)
         predictions_logger.addHandler(file_handler)
@@ -260,7 +264,9 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
         return self.reader.text_to_instance(**json_dict)
 
     @overrides
-    def predictions_to_labeled_instances(self, instance: Instance, outputs: Dict[str, numpy.ndarray]) -> List[Instance]:
+    def predictions_to_labeled_instances(
+        self, instance: Instance, outputs: Dict[str, numpy.ndarray]
+    ) -> List[Instance]:
 
         new_instance = deepcopy(instance)
         label = numpy.argmax(outputs["logits"])
@@ -269,7 +275,9 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
         return [new_instance]
 
     @overrides
-    def get_gradients(self, instances: List[Instance]) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    def get_gradients(
+        self, instances: List[Instance]
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
         """
         Gets the gradients of the loss with respect to the model inputs.
 
@@ -347,7 +355,9 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
         output = self._predict_hashable_json(hashable_dict)
 
         if self.__prediction_logger:
-            self.__prediction_logger.info(json.dumps(dict(inputs=inputs, annotation=output)))
+            self.__prediction_logger.info(
+                json.dumps(dict(inputs=inputs, annotation=output))
+            )
 
         return output
 
@@ -381,7 +391,9 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
             Save up to max_size most recent items.
         """
         if hasattr(self._predict_hashable_json, "cache_info"):
-            warnings.warn("Prediction cache already initiated!", category=RuntimeWarning)
+            warnings.warn(
+                "Prediction cache already initiated!", category=RuntimeWarning
+            )
             return
 
         decorated_func = lru_cache(maxsize=max_size)(self._predict_hashable_json)
@@ -423,16 +435,24 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
                 text_field_embedder=BasicTextFieldEmbedder(
                     token_embedders={
                         "tokens": Embedding.from_params(
-                            vocab=vocab, params=Params({"embedding_dim": 64, "trainable": True})
+                            vocab=vocab,
+                            params=Params({"embedding_dim": 64, "trainable": True}),
                         )
                     }
                 ),
                 seq2vec_encoder=PytorchSeq2VecWrapper(
-                    LSTM(input_size=64, hidden_size=32, bidirectional=True, batch_first=True)
+                    LSTM(
+                        input_size=64,
+                        hidden_size=32,
+                        bidirectional=True,
+                        batch_first=True,
+                    )
                 ),
                 vocab=vocab,
             ),
-            reader=cls.reader_class()(token_indexers={"tokens": SingleIdTokenIndexer()}),
+            reader=cls.reader_class()(
+                token_indexers={"tokens": SingleIdTokenIndexer()}
+            ),
         )
 
     @classmethod
@@ -462,7 +482,12 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
         # Creating an empty pipeline
         model = pipeline_class(
             model=None,
-            reader=cast(DataSourceReader, DatasetReader.from_params(Params(Pipeline.__get_reader_params(data, name)))),
+            reader=cast(
+                DataSourceReader,
+                DatasetReader.from_params(
+                    Params(Pipeline.__get_reader_params(data, name))
+                ),
+            ),
         )
         # Include pipeline configuration
         config = cls.yaml_to_dict(path)
@@ -510,7 +535,9 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
 
     @classmethod
     def __get_pipeline_name_from_config(cls, config: Dict[str, Any]):
-        pipeline_type = config.get(cls.TYPE_FIELD, cls.__get_model_params(config).get(cls.TYPE_FIELD))
+        pipeline_type = config.get(
+            cls.TYPE_FIELD, cls.__get_model_params(config).get(cls.TYPE_FIELD)
+        )
         if not pipeline_type:
             raise ConfigurationError(
                 "Cannot load the pipeline: No pipeline type found in file."
@@ -591,20 +618,23 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
         -------
 
         """
-        raise ConfigurationError("Cannot load sequence classifier without pipeline configuration")
+        raise ConfigurationError(
+            "Cannot load sequence classifier without pipeline configuration"
+        )
 
     def __del__(self):
         if hasattr(self._predict_hashable_json, "cache_info"):
             # pylint: disable=no-member
-            self._LOGGER.info("Cache statistics: %s", self._predict_hashable_json.cache_info())
+            self._LOGGER.info(
+                "Cache statistics: %s", self._predict_hashable_json.cache_info()
+            )
 
     def extend_labels(self, *labels: List[str]) -> None:
         """Allow extend prediction labels to pipeline"""
         if not isinstance(self.model, SequenceClassifierBase):
             warnings.warn(f"Model {self.model} is not updatable")
-
         else:
-            cast(SequenceClassifierBase, self.model).extend_labels(*labels)
+            cast(SequenceClassifierBase, self.model).extend_labels(labels)
 
     def get_output_labels(self) -> List[str]:
         """Output model labels"""

--- a/src/biome/text/pipelines/pipeline.py
+++ b/src/biome/text/pipelines/pipeline.py
@@ -189,7 +189,12 @@ class Pipeline(Generic[Architecture, Reader], Predictor):
         -------
             The fully qualified pipeline class name
         """
-        return f"{self.__module__}.{self.__class__.__name__}::{self.__binary_path or 'empty'}"
+        model_name = (
+            os.path.basename(os.path.dirname(self.__binary_path))
+            if self.__binary_path
+            else "empty"
+        )
+        return f"{self.__module__}.{self.__class__.__name__}::{model_name}"
 
     @property
     def config(self) -> dict:

--- a/src/biome/text/pipelines/sequence_classifier.py
+++ b/src/biome/text/pipelines/sequence_classifier.py
@@ -7,7 +7,9 @@ from ..dataset_readers import SequenceClassifierReader
 from ..models import SequenceClassifier
 
 
-class SequenceClassifierPipeline(Pipeline[SequenceClassifier, SequenceClassifierReader]):
+class SequenceClassifierPipeline(
+    Pipeline[SequenceClassifier, SequenceClassifierReader]
+):
 
     # pylint: disable=arguments-differ
     def predict(self, features: Union[dict, str, List[str]]):

--- a/src/biome/text/pipelines/sequence_classifier.py
+++ b/src/biome/text/pipelines/sequence_classifier.py
@@ -2,12 +2,12 @@ from typing import Union, List
 
 from allennlp.predictors import Predictor
 
-from biome.text.dataset_readers.datasource_reader import DataSourceReader
 from .pipeline import Pipeline
+from ..dataset_readers import SequenceClassifierReader
 from ..models import SequenceClassifier
 
 
-class SequenceClassifierPipeline(Pipeline[SequenceClassifier, DataSourceReader]):
+class SequenceClassifierPipeline(Pipeline[SequenceClassifier, SequenceClassifierReader]):
 
     # pylint: disable=arguments-differ
     def predict(self, features: Union[dict, str, List[str]]):

--- a/tests/text/dataset_readers/test_text_transforms.py
+++ b/tests/text/dataset_readers/test_text_transforms.py
@@ -1,5 +1,9 @@
 from allennlp.common import Params
-from biome.text.dataset_readers.text_transforms import TextTransforms, RmSpacesTransforms, Html2TextTransforms
+from biome.text.dataset_readers.text_transforms import (
+    TextTransforms,
+    RmSpacesTransforms,
+    Html2TextTransforms,
+)
 import pytest
 
 
@@ -35,8 +39,7 @@ def test_html_to_text():
         </body>
     </html>
     """
-    assert text_transforms(html_doc) == "Hello @ViewBag.PersonName,\nThis is a\nmessage & text"
-
-
-
-
+    assert (
+        text_transforms(html_doc)
+        == "Hello @ViewBag.PersonName,\nThis is a\nmessage & text"
+    )


### PR DESCRIPTION
This PR include features for dummy classification pipeline initialization and pipeline output label extension.  This could be usefull for:

- Test pipeline transformations
- Extends labels for data annotation extension.

```python
from biome.text.pipelines import SequenceClassifierPipeline

pipe = SequenceClassifierPipeline.empty_pipeline(labels=["a"])
pipe.predict(features=["Nothing to annotate", "Buu"])
# {'logits': [-0.13027368485927582],
# 'classes': {'a': 1.0},
# 'max_class': 'a',
# 'max_class_prob': 1.0}
pipe.extend_labels("b", "c", "deee")
pipe.predict(features=["Nothing to annotate", "Buu"])
# {'logits': [-0.11618376523256302,
#  0.06386509537696838,
#  0.08324498683214188,
#  -0.005092177540063858],
# 'classes': {'a': 0.2204838991165161,
#  'b': 0.26398006081581116,
#  'c': 0.2691458463668823,
#  'deee': 0.24639014899730682},
# 'max_class': 'c',
# 'max_class_prob': 0.2691458463668823}
pipe.get_output_labels()
# ['a', 'b', 'c', 'deee']
```
