### PR TITLE
Feat/entity classifier

### DIFF
--- a/src/biome/text/dataset_readers/entity_classifier_reader.py
+++ b/src/biome/text/dataset_readers/entity_classifier_reader.py
@@ -1,0 +1,78 @@
+from typing import Union, List, Optional, Tuple
+
+from allennlp.data import Instance
+from biome.text.dataset_readers.datasource_reader import DataSourceReader
+
+
+class EntityClassifierReader(DataSourceReader):
+    def text_to_instance(
+        self,
+        kind: str,
+        context: Union[str, List[List[str]]],
+        position: Tuple[int, int],
+        entities: List[Tuple[int, int, str]] = None,
+        column_header: str = None,
+        label: str = None,
+    ) -> Optional[Instance]:
+        """
+
+        Parameters
+        ----------
+        kind
+            A string defining the kind of the context: either "tabular" or "textual"
+        context
+            Either a text or a list of lists representing a table.
+        position
+            In the case of a textual context, it is the char_start and char_end position of the entity to be classified.
+            In the case of a tabular context, it is the cell and row position.
+        entities
+            A list of labels provided for the rest of the context tokens. Each entity is represented as a tuple:
+            (char_start/cell position in the context, char_end/row position in the context, label)
+            TODO: to be implemented
+        column_header
+            In a tabular context, this is the column header of the entity to be classified.
+        label
+            The label value
+
+        Returns
+        -------
+        instance
+        """
+        if kind == "textual":
+            # TODO: ask paco, is the end position inclusive or exclusive?
+            entity = context[position[0] : position[1]]
+        elif kind == "tabular":
+            entity = context[0][position[0]]
+        else:
+            raise ValueError(
+                f"'{kind}' is not a valid value for the 'kind' argument. "
+                f"It has to be one of the following choices: ['textual', 'tabular']"
+            )
+
+        # For now we just pass on the input values as dict.
+        # Once we have proper EntityClassifier model this will likely change
+        token_dict = {
+            "kind": kind,
+            "context": self._value_as_string(context),
+            "entity": entity,
+        }
+        # For now we force as_text_field to False
+        if self._as_text_field:
+            self._logger.warning(
+                "For the EntityClassifier we set 'as_text_field' automatically to False."
+            )
+            self._as_text_field = False
+
+        # add column header if provided
+        if column_header:
+            token_dict.update({"column_header": column_header})
+
+        fields = {}
+
+        tokens_field = self.build_textfield(token_dict)
+        if tokens_field:
+            fields["tokens"] = tokens_field
+        if label is not None:
+            fields["label"] = label
+
+        return Instance(fields) if fields else None

--- a/src/biome/text/pipelines/entity_classifier.py
+++ b/src/biome/text/pipelines/entity_classifier.py
@@ -1,6 +1,7 @@
 from typing import Union, List, Tuple
 
 from allennlp.predictors import Predictor
+from allennlp.data import DatasetReader
 
 from .pipeline import Pipeline
 from biome.text.dataset_readers.entity_classifier_reader import EntityClassifierReader
@@ -41,3 +42,4 @@ class EntityClassifierPipeline(Pipeline[SequenceClassifier, EntityClassifierRead
 
 
 Predictor.register("entity_classifier")(EntityClassifierPipeline)
+DatasetReader.register("entity_classifier")(EntityClassifierReader)

--- a/src/biome/text/pipelines/entity_classifier.py
+++ b/src/biome/text/pipelines/entity_classifier.py
@@ -1,0 +1,43 @@
+from typing import Union, List, Tuple
+
+from allennlp.predictors import Predictor
+
+from .pipeline import Pipeline
+from biome.text.dataset_readers.entity_classifier_reader import EntityClassifierReader
+from biome.text.models.sequence_classifier import SequenceClassifier
+
+
+class EntityClassifierPipeline(Pipeline[SequenceClassifier, EntityClassifierReader]):
+    # pylint: disable=arguments-differ
+    def predict(
+        self,
+        kind: str,
+        context: Union[str, List[List[str]]],
+        position: Tuple[int, int],
+        column_header: str = None,
+    ):
+        """
+        This methods just define the api use for the model
+
+        Parameters
+        ----------
+        kind
+            A string defining the kind of the context: either "tabular" or "textual"
+        context
+            Either a text or a list of lists representing a table.
+        position
+            In the case of a textual context, it is the char_start and char_end position of the entity to be classified.
+            In the case of a tabular context, it is the cell and row position.
+        column_header
+            In a tabular context, this is the column header of the entity to be classified.
+
+        Returns
+        -------
+            The prediction result
+        """
+        return super(EntityClassifierPipeline, self).predict(
+            kind=kind, context=context, position=position, column_header=column_header
+        )
+
+
+Predictor.register("entity_classifier")(EntityClassifierPipeline)

--- a/tests/text/dataset_readers/test_entity_classifier_reader.py
+++ b/tests/text/dataset_readers/test_entity_classifier_reader.py
@@ -1,0 +1,32 @@
+from biome.text.dataset_readers.entity_classifier_reader import EntityClassifierReader
+
+
+def test_text_to_instance():
+    reader = EntityClassifierReader(as_text_field=True)
+
+    json_dict = {
+        "kind": "textual",
+        "context": "this is a test",
+        "position": (5, 7),
+        "label": "verb"
+    }
+    instance = reader.text_to_instance(**json_dict)
+    # we force as_text_field to False for the EntityClassifier
+    assert not reader._as_text_field
+    assert instance.fields["tokens"][0][0].text == "textual"
+    assert instance.fields["tokens"][1][0].text == "this"
+    assert instance.fields["tokens"][2][0].text == "is"
+    assert instance.fields["label"] == "verb"
+
+    json_dict = {
+        "kind": "tabular",
+        "context": [["this", "is", "a", "test"], ["test"]],
+        "position": (3, 0),
+        "label": "noun"
+    }
+    instance = reader.text_to_instance(**json_dict)
+    assert instance.fields["tokens"][0][0].text == "tabular"
+    assert instance.fields["tokens"][1][0].text == "this"
+    assert instance.fields["tokens"][2][0].text == "test"
+    assert instance.fields["label"] == "noun"
+

--- a/tests/text/pipelines/test_entity_classifier.py
+++ b/tests/text/pipelines/test_entity_classifier.py
@@ -1,0 +1,12 @@
+from biome.text.pipelines.entity_classifier import EntityClassifierPipeline
+from biome.text.dataset_readers.entity_classifier_reader import EntityClassifierReader
+from inspect import signature
+
+
+def test_predict_signature():
+    predict_signature = signature(EntityClassifierPipeline.predict)
+    reader_signature = signature(EntityClassifierReader.text_to_instance)
+
+    for key, value in predict_signature.parameters.items():
+        assert key in reader_signature.parameters
+        assert reader_signature.parameters[key].annotation == value.annotation


### PR DESCRIPTION
This PR introduces the `EntityClassifier` pipeline.

For now it just duplicates functionality, using the `SequenceClassifier` as model. Compared to using the `SequenceClassifierReader`, a data source yaml for the `EntityClassifierReader` could look like this:
```yaml
source: myfile.csv
mapping:
    kind: kind
    context: context
    position: position
    column_header: column_header
    label: label
```

@frascuchon I treated the `end char position` as exclusive, please tell me if this is correct.

@frascuchon @dvsrepo Still to discuss: 
* How to avoid identity mappings (see yaml above)
* I am pretty sure the reader will change substantially once we have a dedicated model for the `EntityClassifer`
