### PR TITLE
better vocab extension/creation api definition

### DIFF
--- a/examples/1.text_classifier/text_classifier.py
+++ b/examples/1.text_classifier/text_classifier.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     validation = "validation.data.yml"
     training_folder = "experiment"
 
-    pl = Pipeline.from_file("text_classifier.yaml")
+    pl = Pipeline.from_file("text_classifier.yaml", vocab_path=os.path.join(training_folder, "vocabulary"))
 
     print(pl.predict(text="Header main. This is a test body!!!"))
 

--- a/examples/1.text_classifier/text_classifier.py
+++ b/examples/1.text_classifier/text_classifier.py
@@ -8,7 +8,9 @@ if __name__ == "__main__":
     validation = "validation.data.yml"
     training_folder = "experiment"
 
-    pl = Pipeline.from_file("text_classifier.yaml", vocab_path=os.path.join(training_folder, "vocabulary"))
+    pl = Pipeline.from_file(
+        "text_classifier.yaml", vocab_path=os.path.join(training_folder, "vocabulary")
+    )
 
     print(pl.predict(text="Header main. This is a test body!!!"))
 

--- a/examples/1.text_classifier/text_classifier.py
+++ b/examples/1.text_classifier/text_classifier.py
@@ -8,13 +8,7 @@ if __name__ == "__main__":
     validation = "validation.data.yml"
     training_folder = "experiment"
 
-    pl = Pipeline.from_file(
-        "text_classifier.yaml",
-        vocab_config=VocabularyConfiguration(
-            from_path=os.path.join(training_folder, "vocabulary"),
-            sources=[train, validation],
-        ),
-    )
+    pl = Pipeline.from_file("text_classifier.yaml")
 
     print(pl.predict(text="Header main. This is a test body!!!"))
 
@@ -25,7 +19,7 @@ if __name__ == "__main__":
         trainer=trainer_configuration,
         training=train,
         validation=validation,
-        extend_vocab=False,
+        extend_vocab=VocabularyConfiguration(sources=[train, validation]),
     )
 
     trained_pl.predict(text="Header main; This is a test body!!!")

--- a/examples/2.document_classifier/document_classifier.py
+++ b/examples/2.document_classifier/document_classifier.py
@@ -1,4 +1,4 @@
-from biome.text import Pipeline, TrainerConfiguration
+from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
@@ -31,6 +31,8 @@ if __name__ == "__main__":
         trainer=trainer,
         training="train.data.yml",
         validation="validation.data.yml",
+        extend_vocab=True,
+        restore=False,
     )
 
     trained_pl.predict(

--- a/examples/2.document_classifier/document_classifier.py
+++ b/examples/2.document_classifier/document_classifier.py
@@ -3,7 +3,7 @@ from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
 
-    pl = Pipeline.from_file("document_classifier.yaml")
+    pl = Pipeline.from_file("document_classifier.yaml", vocab_path="not_found_folder")
     print(f"Pipeline parameters: {pl.trainable_parameter_names}")
     print(f"Trainable parameters: {pl.trainable_parameters}")
     print(

--- a/examples/2.document_classifier/document_classifier.py
+++ b/examples/2.document_classifier/document_classifier.py
@@ -20,7 +20,9 @@ if __name__ == "__main__":
         validation="validation.data.yml",
         verbose=True,
         restore=False,
-        extend_vocab=VocabularyConfiguration(sources=["train.data.yml"], min_count={"words": 10}),
+        extend_vocab=VocabularyConfiguration(
+            sources=["train.data.yml"], min_count={"words": 10}
+        ),
     )
 
     pl.predict(

--- a/examples/2.document_classifier/document_classifier.py
+++ b/examples/2.document_classifier/document_classifier.py
@@ -13,35 +13,20 @@ if __name__ == "__main__":
     )
 
     trainer = TrainerConfiguration(**yaml_to_dict("trainer.yml"))
-    trained_pl = pl.train(
+    pl.train(
         output="experiment",
         trainer=trainer,
         training="train.data.yml",
         validation="validation.data.yml",
         verbose=True,
-    )
-
-    trained_pl.predict(
-        document=["Header main. This is a test body!!!", "The next phrase is here"]
-    )
-    trained_pl.explore(ds_path="validation.data.yml")
-
-    trained_pl = trained_pl.train(
-        output="experiment.v2",
-        trainer=trainer,
-        training="train.data.yml",
-        validation="validation.data.yml",
-        extend_vocab=True,
         restore=False,
+        extend_vocab=VocabularyConfiguration(sources=["train.data.yml"], min_count={"words": 10}),
     )
 
-    trained_pl.predict(
+    pl.predict(
         document=["Header main. This is a test body!!!", "The next phrase is here"]
     )
+    pl.explore(ds_path="validation.data.yml")
 
-    pl.head.extend_labels(["yes", "no"])
-    pl.explore(
-        explore_id="test-document-explore", ds_path="validation.data.yml",
-    )
-
-    # pl.serve()
+    trained_pl = Pipeline.from_pretrained("experiment/model.tar.gz")
+    trained_pl.explore(ds_path="validation.data.yml")

--- a/examples/3.email_classifier/email_classifier.py
+++ b/examples/3.email_classifier/email_classifier.py
@@ -1,4 +1,4 @@
-from biome.text import Pipeline, TrainerConfiguration
+from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
@@ -18,6 +18,7 @@ if __name__ == "__main__":
         trainer=trainer,
         training="train.data.yml",
         validation="validation.data.yml",
+        extend_vocab=VocabularyConfiguration(sources=["validation.data.yml"]),
     )
 
     trained_pl.predict(
@@ -25,18 +26,3 @@ if __name__ == "__main__":
     )
     trained_pl.head.extend_labels(["other"])
     trained_pl.explore(ds_path="validation.data.yml")
-
-    trained_pl = trained_pl.train(
-        output="experiment.v2",
-        trainer=trainer,
-        training="train.data.yml",
-        validation="validation.data.yml",
-    )
-
-    trained_pl.predict(
-        subject="Header main. This is a test body!!!", body="The next phrase is here"
-    )
-
-    pl.head.extend_labels(["yes", "no"])
-    pl.explore(ds_path="validation.data.yml", explain=True)
-    # pl.serve()

--- a/examples/4.language_model/classifier_from_scratch.py
+++ b/examples/4.language_model/classifier_from_scratch.py
@@ -1,4 +1,4 @@
-from biome.text import Pipeline
+from biome.text import Pipeline, VocabularyConfiguration
 from biome.text import TrainerConfiguration
 from biome.text.helpers import yaml_to_dict
 
@@ -10,4 +10,8 @@ if __name__ == "__main__":
         trainer=trainer,
         training="configs/train.data.yml",
         validation="configs/val.data.yml",
+        extend_vocab=VocabularyConfiguration(
+            sources=["configs/train.data.yml"],
+            min_count={"words": 12}
+        ),
     )

--- a/examples/4.language_model/classifier_from_scratch.py
+++ b/examples/4.language_model/classifier_from_scratch.py
@@ -11,7 +11,6 @@ if __name__ == "__main__":
         training="configs/train.data.yml",
         validation="configs/val.data.yml",
         extend_vocab=VocabularyConfiguration(
-            sources=["configs/train.data.yml"],
-            min_count={"words": 12}
+            sources=["configs/train.data.yml"], min_count={"words": 12}
         ),
     )

--- a/examples/4.language_model/pretrain_lm.py
+++ b/examples/4.language_model/pretrain_lm.py
@@ -5,14 +5,12 @@ if __name__ == "__main__":
     train = "configs/train.data.yml"
     validation = "configs/val.data.yml"
 
-    pl = Pipeline.from_file(
-        "configs/language_model.yml",
-        vocab_config=VocabularyConfiguration(sources=[train, validation]),
-    )
+    pl = Pipeline.from_file( "configs/language_model.yml")
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
     trained_pl = pl.train(
         output="configs/experiment_lm",
         trainer=trainer,
         training=train,
         validation=validation,
+        extend_vocab=VocabularyConfiguration(sources=[train, validation], min_count= { "words": 12}),
     )

--- a/examples/4.language_model/pretrain_lm.py
+++ b/examples/4.language_model/pretrain_lm.py
@@ -5,12 +5,14 @@ if __name__ == "__main__":
     train = "configs/train.data.yml"
     validation = "configs/val.data.yml"
 
-    pl = Pipeline.from_file( "configs/language_model.yml")
+    pl = Pipeline.from_file("configs/language_model.yml")
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
     trained_pl = pl.train(
         output="configs/experiment_lm",
         trainer=trainer,
         training=train,
         validation=validation,
-        extend_vocab=VocabularyConfiguration(sources=[train, validation], min_count= { "words": 12}),
+        extend_vocab=VocabularyConfiguration(
+            sources=[train, validation], min_count={"words": 12}
+        ),
     )

--- a/examples/5.ner/train_ner.py
+++ b/examples/5.ner/train_ner.py
@@ -1,4 +1,4 @@
-from biome.text import Pipeline
+from biome.text import Pipeline, VocabularyConfiguration
 from biome.text import TrainerConfiguration
 from biome.text.helpers import yaml_to_dict
 
@@ -10,4 +10,5 @@ if __name__ == "__main__":
         trainer=trainer,
         training="configs/train.data.yml",
         validation="configs/validation.data.yml",
+        extend_vocab=VocabularyConfiguration(sources=["configs/train.data.yml"]),
     )

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -221,8 +221,6 @@ class VocabularyConfiguration:
 
     Parameters
     ----------
-    from_path: `Optional[str]`
-        If provided, try to load model vocab from specified folder path
     sources : `List[str]`
         Datasource paths to be used for data creation
     min_count : `Dict[str, int]`, optional (default=None)
@@ -241,8 +239,7 @@ class VocabularyConfiguration:
 
     def __init__(
         self,
-        from_path: Optional[str] = None,
-        sources: List[str] = None,
+        sources: List[str],
         min_count: Dict[str, int] = None,
         max_vocab_size: Union[int, Dict[str, int]] = None,
         pretrained_files: Optional[Dict[str, str]] = None,
@@ -250,8 +247,7 @@ class VocabularyConfiguration:
         tokens_to_add: Dict[str, List[str]] = None,
         min_pretrained_embeddings: Dict[str, int] = None,
     ):
-        self.from_path = from_path
-        self.sources = sources or []
+        self.sources = sources
         self.pretrained_files = pretrained_files
         self.min_count = min_count
         self.max_vocab_size = max_vocab_size

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -216,7 +216,7 @@ class Pipeline:
         self,
         pretrained_path: Optional[str] = None,
         config: Optional[PipelineConfiguration] = None,
-        **extra_args
+        **extra_args,
     ):
 
         self._binary = pretrained_path
@@ -255,9 +255,7 @@ class Pipeline:
 
     @classmethod
     def from_config(
-        cls,
-        config: Union[str, PipelineConfiguration],
-        vocab_path: Optional[str] = None
+        cls, config: Union[str, PipelineConfiguration], vocab_path: Optional[str] = None
     ) -> "Pipeline":
         """Creates a pipeline from a `PipelineConfiguration` object
 

--- a/tests/text/pipelines/test_bimpm.py
+++ b/tests/text/pipelines/test_bimpm.py
@@ -3,7 +3,7 @@ from typing import Dict
 import pandas as pd
 import pytest
 import yaml
-from biome.text import TrainerConfiguration
+from biome.text import TrainerConfiguration, VocabularyConfiguration
 from biome.text import Pipeline
 
 
@@ -178,7 +178,10 @@ def trainer_dict() -> Dict:
 def test_bimpm_train(
     path_to_pipeline_yaml, trainer_dict, path_to_training_data_yaml,
 ):
-    pipeline = Pipeline.from_file(path_to_pipeline_yaml)
+    pipeline = Pipeline.from_file(
+        path_to_pipeline_yaml,
+        vocab_config=VocabularyConfiguration(sources=[path_to_training_data_yaml]),
+    )
     pipeline.predict(record1="The one", record2="The other")
 
     pipeline.train(

--- a/tests/text/pipelines/test_bimpm.py
+++ b/tests/text/pipelines/test_bimpm.py
@@ -178,10 +178,7 @@ def trainer_dict() -> Dict:
 def test_bimpm_train(
     path_to_pipeline_yaml, trainer_dict, path_to_training_data_yaml,
 ):
-    pipeline = Pipeline.from_file(
-        path_to_pipeline_yaml,
-        vocab_config=VocabularyConfiguration(sources=[path_to_training_data_yaml]),
-    )
+    pipeline = Pipeline.from_file(path_to_pipeline_yaml,)
     pipeline.predict(record1="The one", record2="The other")
 
     pipeline.train(
@@ -190,4 +187,5 @@ def test_bimpm_train(
         training=path_to_training_data_yaml,
         validation=path_to_training_data_yaml,
         restore=False,
+        extend_vocab=VocabularyConfiguration(sources=[path_to_training_data_yaml]),
     )


### PR DESCRIPTION
This PR brings discussion from #139, and define a set of rules for vocab creation/extension:

- `from_file`/`from_config` pipeline methods can load an already created vocab or creates/extends a vocab from provided datasources.
- No vocab param is passed to `Pipeline.train` method.
- The vocab extension pipeline is disabled as default.

```python

    pipeline = Pipeline.from_file(
        "text_classifier.yaml",
        vocab_config=VocabularyConfiguration(
            from_path=os.path.join(training_folder, "vocabulary"),
        ),
    )

    trained_pl = pipeline.train(
        output=training_folder,
        trainer=trainer_configuration,
        training=train,
        validation=validation,
        extend_vocab=True,
    )


```



Closes #139 