### PR TITLE
refactor: pipeline API & internal deps

### DIFF
--- a/documentation/docs/documentation/02.tutorials/01.Training_a_text_classifier.md
+++ b/documentation/docs/documentation/02.tutorials/01.Training_a_text_classifier.md
@@ -316,7 +316,7 @@ head:
 
 
 ```python
-pl = Pipeline.from_file("configs/text_classifier.yml")
+pl = Pipeline.from_yaml("configs/text_classifier.yml")
 ```
 
 

--- a/documentation/docs/documentation/tutorials/Training_a_text_classifier.md
+++ b/documentation/docs/documentation/tutorials/Training_a_text_classifier.md
@@ -316,7 +316,7 @@ head:
 
 
 ```python
-pl = Pipeline.from_file("configs/text_classifier.yml")
+pl = Pipeline.from_yaml("configs/text_classifier.yml")
 ```
 
 

--- a/documentation/docs/nav.02.documentation/02.tutorials/01.Training_a_text_classifier.md
+++ b/documentation/docs/nav.02.documentation/02.tutorials/01.Training_a_text_classifier.md
@@ -316,7 +316,7 @@ head:
 
 
 ```python
-pl = Pipeline.from_file("configs/text_classifier.yml")
+pl = Pipeline.from_yaml("configs/text_classifier.yml")
 ```
 
 

--- a/examples/1.text_classifier/text_classifier.py
+++ b/examples/1.text_classifier/text_classifier.py
@@ -8,7 +8,7 @@ if __name__ == "__main__":
     validation = "validation.data.yml"
     training_folder = "experiment"
 
-    pl = Pipeline.from_file(
+    pl = Pipeline.from_yaml(
         "text_classifier.yaml", vocab_path=os.path.join(training_folder, "vocabulary")
     )
 
@@ -16,7 +16,7 @@ if __name__ == "__main__":
 
     trainer_configuration = TrainerConfiguration(**yaml_to_dict("trainer.yml"))
     trainer_configuration.data_bucketing = False
-    trained_pl = pl.train(
+    pl.train(
         output=training_folder,
         trainer=trainer_configuration,
         training=train,
@@ -24,6 +24,7 @@ if __name__ == "__main__":
         extend_vocab=VocabularyConfiguration(sources=[train, validation]),
     )
 
+    trained_pl = Pipeline.from_pretrained(os.path.join(training_folder, "model.tar.gz"))
     trained_pl.predict(text="Header main; This is a test body!!!")
     trained_pl.head.extend_labels(["other"])
     trained_pl.explore(
@@ -32,13 +33,14 @@ if __name__ == "__main__":
 
     trainer_configuration.batch_size = 8
     trainer_configuration.data_bucketing = True
-    trained_pl = trained_pl.train(
+    trained_pl.train(
         output="experiment.v2",
         trainer=trainer_configuration,
         training=train,
         validation=validation,
     )
 
+    trained_pl = Pipeline.from_pretrained(os.path.join("experiment.v2", "model.tar.gz"))
     trained_pl.predict(text="Header main. This is a test body!!!")
 
     pl.head.extend_labels(["yes", "no"])

--- a/examples/2.document_classifier/document_classifier.py
+++ b/examples/2.document_classifier/document_classifier.py
@@ -3,7 +3,7 @@ from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
 
-    pl = Pipeline.from_file("document_classifier.yaml", vocab_path="not_found_folder")
+    pl = Pipeline.from_yaml("document_classifier.yaml", vocab_path="not_found_folder")
     print(f"Pipeline parameters: {pl.trainable_parameter_names}")
     print(f"Trainable parameters: {pl.trainable_parameters}")
     print(
@@ -19,12 +19,12 @@ if __name__ == "__main__":
         training="train.data.yml",
         validation="validation.data.yml",
         verbose=True,
-        restore=False,
         extend_vocab=VocabularyConfiguration(
             sources=["train.data.yml"], min_count={"words": 10}
         ),
     )
 
+    pl = Pipeline.from_pretrained("experiment/model.tar.gz")
     pl.predict(
         document=["Header main. This is a test body!!!", "The next phrase is here"]
     )

--- a/examples/3.email_classifier/email_classifier.py
+++ b/examples/3.email_classifier/email_classifier.py
@@ -3,7 +3,7 @@ from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
 
-    pl = Pipeline.from_file("email_classifier.yaml")
+    pl = Pipeline.from_yaml("email_classifier.yaml")
     pl.head.extend_labels(["a", "b"])
     print(
         pl.predict(
@@ -13,7 +13,7 @@ if __name__ == "__main__":
     )
 
     trainer = TrainerConfiguration(**yaml_to_dict("trainer.yml"))
-    trained_pl = pl.train(
+    pl.train(
         output="experiment",
         trainer=trainer,
         training="train.data.yml",
@@ -21,8 +21,9 @@ if __name__ == "__main__":
         extend_vocab=VocabularyConfiguration(sources=["validation.data.yml"]),
     )
 
-    trained_pl.predict(
+    trained = Pipeline.from_pretrained("experiment/model.tar.gz")
+    trained.predict(
         subject="Header main. This is a test body!!!", body="The next phrase is here"
     )
-    trained_pl.head.extend_labels(["other"])
-    trained_pl.explore(ds_path="validation.data.yml")
+    trained.head.extend_labels(["other"])
+    trained.explore(ds_path="validation.data.yml")

--- a/examples/4.language_model/classifier_from_scratch.py
+++ b/examples/4.language_model/classifier_from_scratch.py
@@ -3,9 +3,9 @@ from biome.text import TrainerConfiguration
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
-    pl = Pipeline.from_file("configs/text_classifier.yml")
+    pl = Pipeline.from_yaml("configs/text_classifier.yml")
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
-    trained_pl = pl.train(
+    pl.train(
         output="experiment_text_classifier",
         trainer=trainer,
         training="configs/train.data.yml",

--- a/examples/4.language_model/finetune_classifier.py
+++ b/examples/4.language_model/finetune_classifier.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
 
     pipe.set_head(TextClassification, pooler={"type": "boe"}, labels=labels)
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
-    trained_pl = pipe.train(
+    pipe.train(
         output="text_classifier_fine_tuned",
         trainer=trainer,
         training="configs/train.data.yml",

--- a/examples/4.language_model/pretrain_lm.py
+++ b/examples/4.language_model/pretrain_lm.py
@@ -5,9 +5,9 @@ if __name__ == "__main__":
     train = "configs/train.data.yml"
     validation = "configs/val.data.yml"
 
-    pl = Pipeline.from_file("configs/language_model.yml")
+    pl = Pipeline.from_yaml("configs/language_model.yml")
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
-    trained_pl = pl.train(
+    pl.train(
         output="configs/experiment_lm",
         trainer=trainer,
         training=train,

--- a/examples/5.ner/train_ner.py
+++ b/examples/5.ner/train_ner.py
@@ -3,9 +3,9 @@ from biome.text import TrainerConfiguration
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
-    pl = Pipeline.from_file("configs/char_gru_token_classifier.yml")
+    pl = Pipeline.from_yaml("configs/char_gru_token_classifier.yml")
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
-    trained_pl = pl.train(
+    pl.train(
         output="experiment",
         trainer=trainer,
         training="configs/train.data.yml",

--- a/src/biome/text/_configuration.py
+++ b/src/biome/text/_configuration.py
@@ -1,11 +1,25 @@
 import datetime
 from typing import Any, Dict, Optional
 
+from allennlp.data import DatasetReader
+from biome.text import constants
+from biome.text._impl_model import AllennlpModel, _BaseModelImpl
 from elasticsearch import Elasticsearch
 
-from biome.text import constants
 from . import helpers
 from .configuration import TrainerConfiguration
+
+_ModelImpl = _BaseModelImpl
+
+
+def __register(impl_class, overrides: bool = False):
+    """Register the impl. class in allennlp components registry"""
+
+    AllennlpModel.register(impl_class.__name__, exist_ok=overrides)(impl_class)
+    DatasetReader.register(impl_class.__name__, exist_ok=overrides)(impl_class)
+
+
+__register(_ModelImpl, overrides=True)
 
 
 class ExploreConfiguration:
@@ -106,12 +120,11 @@ class ElasticsearchExplore:
 class TrainConfiguration:
     """Configures a training run
 
-    # Parameters
+    Parameters
+    ----------
         output: `str`
              The experiment output path
-        vocab: `vocab`
-            The path to an existing vocabulary
-        trainer_path: `str`
+        trainer: `str`
              The trainer file path
         train_cfg: `str`
             The train datasource file path
@@ -121,8 +134,6 @@ class TrainConfiguration:
             The test datasource file path
         verbose: `bool`
             Whether to show verbose logs (default is `False`)
-        extend_vocab: `bool`
-            Extends vocabulary namespaces with training data
     """
 
     def __init__(

--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -1,0 +1,257 @@
+import copy
+import inspect
+import time
+from threading import Thread
+from typing import Any, Dict, List
+from urllib.error import URLError
+
+import uvicorn
+from allennlp.common.util import sanitize
+from biome.text import Pipeline, TrainerConfiguration, helpers
+from biome.text._configuration import (
+    ElasticsearchExplore,
+    ExploreConfiguration,
+    TrainConfiguration,
+    _ModelImpl,
+)
+
+from biome.text.data import DataSource
+from biome.text.errors import http_error_handling
+from biome.text.modules.encoders import TimeDistributedEncoder
+from biome.text.ui import launch_ui
+from dask import dataframe as dd
+from dask_elk.client import DaskElasticClient
+from fastapi import FastAPI
+
+
+def _serve(pipeline: Pipeline, port: int):
+    """Serves an pipeline as rest api"""
+
+    def make_app() -> FastAPI:
+        app = FastAPI()
+
+        @app.post("/predict")
+        async def predict(inputs: Dict[str, Any]):
+            with http_error_handling():
+                return sanitize(pipeline.predict(**inputs))
+
+        @app.post("/explain")
+        async def explain(inputs: Dict[str, Any]):
+            with http_error_handling():
+                return sanitize(pipeline.explain(**inputs))
+
+        @app.get("/_config")
+        async def config():
+            with http_error_handling():
+                return pipeline.config.as_dict()
+
+        @app.get("/_status")
+        async def status():
+            with http_error_handling():
+                return {"ok": True}
+
+        return app
+
+    uvicorn.run(make_app(), host="0.0.0.0", port=port)
+
+
+def _allennlp_configuration(
+    pipeline: Pipeline, config: TrainConfiguration
+) -> Dict[str, Any]:
+    """Creates a allennlp configuration for pipeline train experiment configuration"""
+
+    def trainer_configuration(trainer: TrainerConfiguration) -> Dict[str, Any]:
+        """Creates trainer configuration dict"""
+        __excluded_keys = [
+            "data_bucketing",
+            "batch_size",
+            "cache_instances",
+            "in_memory_batches",
+        ]  # Data iteration attributes
+        return {k: v for k, v in vars(trainer).items() if k not in __excluded_keys}
+
+    def iterator_configuration(
+        pipeline: Pipeline, trainer: TrainerConfiguration
+    ) -> Dict[str, Any]:
+        """Creates a data iterator configuration"""
+
+        def _forward_inputs() -> List[str]:
+            """
+            Calculate the required head.forward arguments. We use this method
+            for automatically generate data iterator sorting keys
+            """
+            required, _ = helpers.split_signature_params_by_predicate(
+                pipeline.head.forward, lambda p: p.default == inspect.Parameter.empty,
+            )
+            return [p.name for p in required] or [None]
+
+        iterator_config = {
+            "batch_size": trainer.batch_size,
+            "max_instances_in_memory": max(
+                trainer.batch_size * trainer.in_memory_batches, trainer.batch_size,
+            ),
+            "cache_instances": trainer.cache_instances,
+            "type": "basic",
+        }
+
+        if trainer.data_bucketing:
+            iterator_config.update(
+                {
+                    "sorting_keys": [
+                        [
+                            _forward_inputs()[0],
+                            "list_num_tokens"
+                            if isinstance(
+                                pipeline.model.encoder, TimeDistributedEncoder
+                            )
+                            else "num_tokens",
+                        ]
+                    ],
+                    "type": "bucket",
+                }
+            )
+
+        return iterator_config
+
+    base_config = {
+        "config": pipeline.config.as_dict(),
+        "type": _ModelImpl.__name__,
+    }
+    allennlp_config = {
+        "trainer": trainer_configuration(config.trainer),
+        "iterator": iterator_configuration(pipeline, config.trainer),
+        "dataset_reader": base_config,
+        "model": base_config,
+        "train_data_path": config.training,
+        "validation_data_path": config.validation,
+        "test_data_path": config.test,
+    }
+    return copy.deepcopy({k: v for k, v in allennlp_config.items() if v})
+
+
+def _explore(
+    pipeline: Pipeline,
+    ds_path: str,
+    config: ExploreConfiguration,
+    elasticsearch: ElasticsearchExplore,
+) -> dd.DataFrame:
+    """
+    Executes a pipeline prediction over a datasource and register results int a elasticsearch index
+
+    Parameters
+    ----------
+    pipeline
+    ds_path
+    config
+    elasticsearch
+
+    Returns
+    -------
+
+    """
+    if config.prediction_cache > 0:
+        # TODO: do it
+        pipeline.init_predictions_cache(config.prediction_cache)
+
+    data_source = DataSource.from_yaml(ds_path)
+    ddf_mapped = data_source.to_mapped_dataframe()
+    # this only makes really sense when we have a predict_batch_json method implemented ...
+    n_partitions = max(1, round(len(ddf_mapped) / config.batch_size))
+
+    # a persist is necessary here, otherwise it fails for n_partitions == 1
+    # the reason is that with only 1 partition we pass on a generator to predict_batch_json
+    ddf_mapped = ddf_mapped.repartition(npartitions=n_partitions).persist()
+
+    apply_func = pipeline.explain if config.explain else pipeline.predict
+
+    ddf_mapped["annotation"] = ddf_mapped[pipeline.inputs].apply(
+        lambda x: sanitize(apply_func(**x.to_dict())), axis=1, meta=(None, object)
+    )
+
+    ddf_source = (
+        data_source.to_dataframe().repartition(npartitions=n_partitions).persist()
+    )
+    ddf_mapped["metadata"] = ddf_source.map_partitions(
+        lambda df: df.to_dict(orient="records")
+    )
+
+    # TODO @dcfidalgo we could calculate base metrics here (F1, recall & precision) using dataframe.
+    #  And include as part of explore metadata
+    #  Does it's simple???
+
+    ddf = DaskElasticClient(
+        host=elasticsearch.es_host, retry_on_timeout=True, http_compress=True
+    ).save(ddf_mapped, index=elasticsearch.es_index, doc_type=elasticsearch.es_doc)
+
+    elasticsearch.create_explore_data_index(force_delete=config.force_delete)
+    elasticsearch.create_explore_data_record(
+        {
+            **(config.metadata or {}),
+            "datasource": ds_path,
+            # TODO this should change when ui is normalized (action detail and action link naming)F
+            "explore_name": elasticsearch.es_index,
+            "model": pipeline.name,
+            "columns": ddf.columns.values.tolist(),
+            "metadata_columns": data_source.to_dataframe().columns.values.tolist(),
+            "pipeline": pipeline.type_name,
+            "output": pipeline.output,
+            "inputs": pipeline.inputs,  # backward compatibility
+            "signature": pipeline.inputs + [pipeline.output],
+            "predict_signature": pipeline.inputs,
+            "labels": pipeline.head.labels,
+            "task": pipeline.head.task_name().as_string(),
+        }
+    )
+    return ddf.persist()
+
+
+def _show_explore(elasticsearch: ElasticsearchExplore) -> None:
+    """Shows explore ui for data prediction exploration"""
+
+    def is_service_up(url: str) -> bool:
+        import urllib.request
+
+        try:
+            status_code = urllib.request.urlopen(url).getcode()
+            return 200 <= status_code < 400
+        except URLError:
+            return False
+
+    def launch_ui_app() -> Thread:
+        process = Thread(
+            target=launch_ui,
+            name="ui",
+            kwargs=dict(es_host=elasticsearch.es_host, port=ui_port),
+        )
+        process.start()
+        return process
+
+    def show_notebook_explore(url: str):
+        """Shows explore ui in a notebook cell"""
+        from IPython.core.display import HTML, display
+
+        iframe = f"<iframe src={url} width=100% height=840></iframe>"
+        display(HTML(iframe))
+
+    def show_browser_explore(url: str):
+        """Shows explore ui in a web browser"""
+        import webbrowser
+
+        webbrowser.open(url)
+
+    ui_port = 9999
+    waiting_seconds = 1
+    url = (
+        f"http://localhost:{ui_port}/projects/default/explore/{elasticsearch.es_index}"
+    )
+
+    if not is_service_up(url):
+        launch_ui_app()
+
+    time.sleep(waiting_seconds)
+    show_func = (
+        show_notebook_explore
+        if helpers.is_running_on_notebook()
+        else show_browser_explore
+    )
+    show_func(url)

--- a/src/biome/text/_pipeline_helper.py
+++ b/src/biome/text/_pipeline_helper.py
@@ -1,0 +1,142 @@
+import datetime
+from typing import Any, Dict, Optional
+
+from elasticsearch import Elasticsearch
+
+from biome.text import constants
+from . import helpers
+from .configuration import TrainerConfiguration
+
+
+class ExploreConfiguration:
+    """Configures an exploration run
+
+    Parameters
+    ----------
+        batch_size: `int`
+            The batch size for indexing predictions (default is `500)
+        prediction_cache_size: `int`
+            The size of the cache for caching predictions (default is `0)
+        explain: `bool`
+            Whether to extract and return explanations of token importance (default is `False`)
+        force_delete: `bool`
+            Whether to delete existing explore with `explore_id` before indexing new items (default is `True)
+        metadata: `kwargs`
+            Additional metadata to index in Elasticsearch
+    """
+
+    def __init__(
+        self,
+        batch_size: int = 500,
+        prediction_cache_size: int = 0,
+        explain: bool = False,
+        force_delete: bool = True,
+        **metadata,
+    ):
+        self.batch_size = batch_size
+        self.prediction_cache = prediction_cache_size
+        self.explain = explain
+        self.force_delete = force_delete
+        self.metadata = metadata
+
+
+class ElasticsearchExplore:
+    """Elasticsearch data exploration class"""
+
+    def __init__(self, es_index: str, es_host: Optional[str] = None):
+        self.es_index = es_index
+        self.es_host = es_host or constants.DEFAULT_ES_HOST
+        if not self.es_host.startswith("http"):
+            self.es_host = f"http://{self.es_host}"
+
+        self.client = Elasticsearch(
+            hosts=es_host, retry_on_timeout=True, http_compress=True
+        )
+        self.es_doc = helpers.get_compatible_doc_type(self.client)
+
+    def create_explore_data_record(self, parameters: Dict[str, Any]):
+        """Creates an exploration data record data exploration"""
+
+        self.client.indices.create(
+            index=constants.BIOME_METADATA_INDEX,
+            body={
+                "settings": {"index": {"number_of_shards": 1, "number_of_replicas": 0}}
+            },
+            params=dict(ignore=400),
+        )
+
+        self.client.update(
+            index=constants.BIOME_METADATA_INDEX,
+            doc_type=constants.BIOME_METADATA_INDEX_DOC,
+            id=self.es_index,
+            body={
+                "doc": dict(
+                    name=self.es_index, created_at=datetime.datetime.now(), **parameters
+                ),
+                "doc_as_upsert": True,
+            },
+        )
+
+    def create_explore_data_index(self, force_delete: bool):
+        """Creates an explore data index if not exists or is forced"""
+        dynamic_templates = [
+            {
+                data_type: {
+                    "match_mapping_type": data_type,
+                    "path_match": path_match,
+                    "mapping": {
+                        "type": "text",
+                        "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
+                    },
+                }
+            }
+            for data_type, path_match in [("*", "*.value"), ("string", "*")]
+        ]
+
+        if force_delete:
+            self.client.indices.delete(index=self.es_index, ignore=[400, 404])
+
+        self.client.indices.create(
+            index=self.es_index,
+            body={"mappings": {self.es_doc: {"dynamic_templates": dynamic_templates}}},
+            ignore=400,
+        )
+
+
+class TrainConfiguration:
+    """Configures a training run
+
+    # Parameters
+        output: `str`
+             The experiment output path
+        vocab: `vocab`
+            The path to an existing vocabulary
+        trainer_path: `str`
+             The trainer file path
+        train_cfg: `str`
+            The train datasource file path
+        validation_cfg: `Optional[str]`
+            The validation datasource file path
+        test_cfg: `Optional[str]`
+            The test datasource file path
+        verbose: `bool`
+            Whether to show verbose logs (default is `False`)
+        extend_vocab: `bool`
+            Extends vocabulary namespaces with training data
+    """
+
+    def __init__(
+        self,
+        output: str,
+        trainer: TrainerConfiguration,
+        train_cfg: str = "",
+        validation_cfg: Optional[str] = None,
+        test_cfg: Optional[str] = None,
+        verbose: bool = False,
+    ):
+        self.output = output
+        self.trainer = trainer
+        self.training = train_cfg
+        self.validation = validation_cfg
+        self.test = test_cfg
+        self.verbose = verbose

--- a/src/biome/text/cli/train.py
+++ b/src/biome/text/cli/train.py
@@ -4,7 +4,8 @@ from typing import Optional
 import click
 from click import Path
 
-from biome.text import Pipeline, VocabularyConfiguration
+from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration
+from biome.text.helpers import yaml_to_dict
 
 
 @click.command("train", help="Train a pipeline")
@@ -27,20 +28,18 @@ def learn(
     _, extension = os.path.splitext(pipeline_path)
     extension = extension[1:].lower()
     pipeline = (
-        Pipeline.from_file(
-            pipeline_path,
-            vocab_config=VocabularyConfiguration(
-                sources=[ds for ds in [training, validation, test] if ds]
-            ),
-        )
+        Pipeline.from_yaml(pipeline_path)
         if extension in ["yaml", "yml"]
         else Pipeline.from_pretrained(pipeline_path)
     )
     pipeline.train(
         output=output,
-        trainer=trainer,
+        trainer=TrainerConfiguration(**yaml_to_dict(trainer)),
         training=training,
         validation=validation,
         test=test,
+        extend_vocab=VocabularyConfiguration(
+            sources=[ds for ds in [training, validation, test] if ds]
+        ),
         verbose=verbose,
     )

--- a/src/biome/text/featurizer.py
+++ b/src/biome/text/featurizer.py
@@ -149,7 +149,7 @@ class InputFeaturizer:
         
         Returns
         -------
-        An `InmutableDict` defining the token indexers of the featurizer
+        An dictionary defining the token indexers of the featurizer
         """
         # fmt: off
         return {

--- a/src/biome/text/featurizer.py
+++ b/src/biome/text/featurizer.py
@@ -152,10 +152,10 @@ class InputFeaturizer:
         An `InmutableDict` defining the token indexers of the featurizer
         """
         # fmt: off
-        return InmutableDict({
+        return {
             feature: TokenIndexer.from_params(Params(config[self.__INDEXER_KEYNAME]))
             for feature, config in self.config.items()
-        })
+        }
         # fmt: on
 
     def build_embedder(self, vocab: Vocabulary) -> Embedder:

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -1,5 +1,4 @@
 import copy
-import datetime
 import glob
 import inspect
 import logging
@@ -19,6 +18,10 @@ from allennlp.common.util import sanitize
 from allennlp.data import DatasetReader, Vocabulary
 from allennlp.models import load_archive
 from allennlp.models.archival import Archive
+from dask import dataframe as dd
+from dask_elk.client import DaskElasticClient
+from fastapi import FastAPI
+
 from biome.text._impl_model import AllennlpModel, _BaseModelImpl
 from biome.text.configuration import (
     PipelineConfiguration,
@@ -32,12 +35,12 @@ from biome.text.helpers import (
     update_method_signature,
 )
 from biome.text.ui import launch_ui
-from dask import dataframe as dd
-from dask_elk.client import DaskElasticClient
-from elasticsearch import Elasticsearch
-from fastapi import FastAPI
-
 from . import constants, helpers
+from ._pipeline_helper import (
+    ElasticsearchExplore,
+    ExploreConfiguration,
+    TrainConfiguration,
+)
 from .model import Model
 from .modules.encoders import TimeDistributedEncoder
 from .modules.heads import TaskHead
@@ -61,181 +64,22 @@ def __register(impl_class, overrides: bool = False):
 __register(__default_impl__, overrides=True)
 
 
-class _ExploreConfiguration:
-    """Configures an exploration run
-
-    # Parameters
-        batch_size: `int`
-            The batch size for indexing predictions (default is `500)
-        prediction_cache_size: `int`
-            The size of the cache for caching predictions (default is `0)
-        explain: `bool`
-            Whether to extract and return explanations of token importance (default is `False`)
-        force_delete: `bool`
-            Whether to delete existing explore with `explore_id` before indexing new items (default is `True)
-        metadata: `kwargs`
-            Additional metadata to index in Elasticsearch
-    """
-
-    def __init__(
-        self,
-        batch_size: int = 500,
-        prediction_cache_size: int = 0,
-        explain: bool = False,
-        force_delete: bool = True,
-        **metadata,
-    ):
-        self.batch_size = batch_size
-        self.prediction_cache = prediction_cache_size
-        self.explain = explain
-        self.force_delete = force_delete
-        self.metadata = metadata
-
-
-class _ElasticsearchExplore:
-    """Elasticsearch data exploration class"""
-
-    def __init__(self, es_index: str, es_host: Optional[str] = None):
-        self.es_index = es_index
-        self.es_host = es_host or constants.DEFAULT_ES_HOST
-        if not self.es_host.startswith("http"):
-            self.es_host = f"http://{self.es_host}"
-
-        self.client = Elasticsearch(
-            hosts=es_host, retry_on_timeout=True, http_compress=True
-        )
-        self.es_doc = helpers.get_compatible_doc_type(self.client)
-
-    def create_explore_data_record(self, parameters: Dict[str, Any]):
-        """Creates an exploration data record data exploration"""
-
-        self.client.indices.create(
-            index=constants.BIOME_METADATA_INDEX,
-            body={
-                "settings": {"index": {"number_of_shards": 1, "number_of_replicas": 0}}
-            },
-            params=dict(ignore=400),
-        )
-
-        self.client.update(
-            index=constants.BIOME_METADATA_INDEX,
-            doc_type=constants.BIOME_METADATA_INDEX_DOC,
-            id=self.es_index,
-            body={
-                "doc": dict(
-                    name=self.es_index, created_at=datetime.datetime.now(), **parameters
-                ),
-                "doc_as_upsert": True,
-            },
-        )
-
-    def create_explore_data_index(self, force_delete: bool):
-        """Creates an explore data index if not exists or is forced"""
-        dynamic_templates = [
-            {
-                data_type: {
-                    "match_mapping_type": data_type,
-                    "path_match": path_match,
-                    "mapping": {
-                        "type": "text",
-                        "fields": {"keyword": {"type": "keyword", "ignore_above": 256}},
-                    },
-                }
-            }
-            for data_type, path_match in [("*", "*.value"), ("string", "*")]
-        ]
-
-        if force_delete:
-            self.client.indices.delete(index=self.es_index, ignore=[400, 404])
-
-        self.client.indices.create(
-            index=self.es_index,
-            body={"mappings": {self.es_doc: {"dynamic_templates": dynamic_templates}}},
-            ignore=400,
-        )
-
-
-class _TrainConfiguration:
-    """Configures a training run
-
-    # Parameters
-        output: `str`
-             The experiment output path
-        vocab: `vocab`
-            The path to an existing vocabulary
-        trainer_path: `str`
-             The trainer file path
-        train_cfg: `str`
-            The train datasource file path
-        validation_cfg: `Optional[str]`
-            The validation datasource file path
-        test_cfg: `Optional[str]`
-            The test datasource file path
-        verbose: `bool`
-            Whether to show verbose logs (default is `False`)
-        extend_vocab: `bool`
-            Extends vocabulary namespaces with training data
-    """
-
-    def __init__(
-        self,
-        output: str,
-        trainer: TrainerConfiguration,
-        train_cfg: str = "",
-        validation_cfg: Optional[str] = None,
-        test_cfg: Optional[str] = None,
-        verbose: bool = False,
-    ):
-        self.output = output
-        self.trainer = trainer
-        self.training = train_cfg
-        self.validation = validation_cfg
-        self.test = test_cfg
-        self.verbose = verbose
-
-
 class Pipeline:
     """Manages NLP models configuration and actions.
 
     Use `Pipeline` for creating new models from a configuration or loading a pre-trained model.
 
     Use instantiated Pipelines for training from scratch, fine-tuning, predicting, serving, or exploring predictions.
-
-    # Parameters
-        pretrained_path: `Optional[str]`
-            The path to the model.tar.gz of a pre-trained `Pipeline`
-        config: `Optional[PipelineConfiguration]`
-            A `PipelineConfiguration` object defining the configuration of the fresh `Pipeline`.
     """
 
     __LOGGER = logging.getLogger(__name__)
     __TRAINING_CACHE_DATA = "instances_data"
 
-    # TODO: Signature makes you think you can pass both a pretrained_path and a config, while only one option possible.
-    def __init__(
-        self,
-        pretrained_path: Optional[str] = None,
-        config: Optional[PipelineConfiguration] = None,
-        **extra_args,
-    ):
-
-        self._binary = pretrained_path
-        self._config = copy.deepcopy(config)
-
-        if self._binary:
-            archive = load_archive(self._binary, **extra_args)
-            self._model = self.__model_from_archive(archive)
-            self._config = self.__config_from_archive(archive)
-        else:
-            self._model = self.__model_from_config(self.config, **extra_args)
-
-        if not isinstance(self._model, __default_impl__):
-            raise TypeError(f"Cannot load model. Wrong format of {self._model}")
-
-        self.__update_prediction_signatures()
+    _model: __default_impl__ = None
+    _config: PipelineConfiguration = None
 
     @classmethod
-    def from_file(cls, path: str, vocab_path: Optional[str] = None) -> "Pipeline":
+    def from_yaml(cls, path: str, vocab_path: Optional[str] = None) -> "Pipeline":
         """Creates a pipeline from a config yaml file path
 
         Parameters
@@ -274,7 +118,7 @@ class Pipeline:
 
         if isinstance(config, str):
             config = PipelineConfiguration.from_params(Params(yaml.safe_load(config)))
-        return cls(config=config, vocab=cls._vocab_from_path(vocab_path))
+        return _EmptyPipeline(config=config, vocab=cls._vocab_from_path(vocab_path))
 
     @classmethod
     def from_pretrained(cls, path: str, **kwargs) -> "Pipeline":
@@ -290,7 +134,7 @@ class Pipeline:
             pipeline: `Pipeline`
                 A configured pipeline
         """
-        return cls(pretrained_path=path)
+        return _PreTrainedPipeline(pretrained_path=path, **kwargs)
 
     def train(
         self,
@@ -302,7 +146,7 @@ class Pipeline:
         verbose: bool = False,
         extend_vocab: Optional[VocabularyConfiguration] = None,
         restore: bool = True,
-    ) -> "Pipeline":
+    ) -> None:
         """Launches a training run with the specified configurations and datasources
 
         Parameters
@@ -325,65 +169,56 @@ class Pipeline:
             If enabled, tries to read previous training status from output folder and
             continues training process from it
 
-        Returns
-        -------
-        pipeline: `Pipeline`
-            A configured pipeline
         """
 
-        def prepare_experiment_folder(output: str, restore: bool) -> None:
-            """If output folder already exists, we automatically recover the generated vocab in this folder.
+        self.__prepare_experiment_folder(output, restore)
+        self._model.cache_data(os.path.join(output, self.__TRAINING_CACHE_DATA))
 
-            Allows reuse the generated vocab if something went wrong in previous executions
-
-            Parameters
-            ----------
-            output
-                Path to the output folder
-            restore: `bool`
-                If False, drops all previous training states
-
-            Returns
-            -------
-            is_recovered
-                True if existing output folder is recovered, False if output folder does not exist.
-            """
-            if not os.path.isdir(output):
-                return
-
-            drop_patterns = [
-                os.path.join(output, "*.json"),
-                os.path.join(output, "**/events.out*"),
-            ]
-
-            if not restore:
-                drop_patterns.append(os.path.join(output, "*.th"))
-                drop_patterns.append(
-                    os.path.join(output, self.__TRAINING_CACHE_DATA, "*")
-                )
-
-            for pattern in drop_patterns:
-                for file in glob.glob(pattern, recursive=True):
-                    os.remove(file)
-
-        prepare_experiment_folder(output, restore)
-        # TODO: we need make deserializable the feature dict (InmutableDict class)
-        #  It fails otherwise
-        # self._model.cache_data(os.path.join(output, self.__TRAINING_CACHE_DATA))
         if extend_vocab:
             self._extend_vocab(vocab_config=extend_vocab)
 
-        return _PipelineHelper.train(
-            self,
-            config=_TrainConfiguration(
-                test_cfg=test,
-                output=output,
-                trainer=trainer,
-                train_cfg=training,
-                validation_cfg=validation,
-                verbose=verbose,
-            ),
+        # The original pipeline keeps unchanged
+        model = copy.deepcopy(self._model)
+        config = TrainConfiguration(
+            test_cfg=test,
+            output=output,
+            trainer=trainer,
+            train_cfg=training,
+            validation_cfg=validation,
+            verbose=verbose,
         )
+
+        model.launch_experiment(
+            params=Params(_allennlp_configuration(self, config,)),
+            serialization_dir=output,
+        )
+
+    def __prepare_experiment_folder(self, output: str, restore: bool) -> None:
+        """Prepare experiment folder depending of if required experiment restore or not
+
+        Parameters
+        ----------
+        output
+            Path to the output folder
+        restore: `bool`
+            If False, drops all previous training states
+
+        """
+        if not os.path.isdir(output):
+            return
+
+        drop_patterns = [
+            os.path.join(output, "*.json"),
+            os.path.join(output, "**/events.out*"),
+        ]
+
+        if not restore:
+            drop_patterns.append(os.path.join(output, "*.th"))
+            drop_patterns.append(os.path.join(output, self.__TRAINING_CACHE_DATA, "*"))
+
+        for pattern in drop_patterns:
+            for file in glob.glob(pattern, recursive=True):
+                os.remove(file)
 
     def predict(self, *args, **kwargs) -> Dict[str, numpy.ndarray]:
         """Predicts over some input data with current state of the model
@@ -397,7 +232,6 @@ class Pipeline:
                 A dictionary containing the predictions and additional information
         """
         # TODO: Paco, what is the best way to document this, given that the signature is dynamic?
-        self._model = self._model.eval()
         return self._model.predict(*args, **kwargs)
 
     def explain(self, *args, **kwargs) -> Dict[str, Any]:
@@ -436,7 +270,8 @@ class Pipeline:
 
         Running this outside a notebook will try to launch the standalone web application.
 
-        # Parameters
+        Parameters
+        ----------
             ds_path: `str`
                 The path to the configuration of a datasource
             explore_id: `Optional[str]`
@@ -452,11 +287,12 @@ class Pipeline:
             force_delete: `bool`
                 Deletes exploration with the same `explore_id` before indexing the new explore items (default is `True)
 
-        # Returns
+        Returns
+        -------
             pipeline: `Pipeline`
                 A configured pipeline
         """
-        config = _ExploreConfiguration(
+        config = ExploreConfiguration(
             batch_size=batch_size,
             prediction_cache_size=prediction_cache_size,
             explain=explain,
@@ -464,13 +300,13 @@ class Pipeline:
             **metadata,
         )
 
-        es_config = _ElasticsearchExplore(
+        es_config = ElasticsearchExplore(
             es_index=explore_id or str(uuid.uuid1()),
             es_host=es_host or constants.DEFAULT_ES_HOST,
         )
 
-        explore_df = _PipelineHelper.explore(self, ds_path, config, es_config)
-        self._show_explore(es_config)
+        explore_df = _explore(self, ds_path, config, es_config)
+        _show_explore(es_config)
 
         return explore_df
 
@@ -482,7 +318,7 @@ class Pipeline:
                 The port to make available the prediction service
         """
         self._model = self._model.eval()
-        return _PipelineHelper.serve(self, port)
+        return _serve(self, port)
 
     def set_head(self, type: Type[TaskHead], **params):
         """Sets a new task head for the pipeline
@@ -529,11 +365,6 @@ class Pipeline:
         return self._config
 
     @property
-    def trained_path(self) -> str:
-        """Path to binary file when load from binary"""
-        return self._binary
-
-    @property
     def type_name(self) -> str:
         """The pipeline name. Equivalent to task head name"""
         return self.head.__class__.__name__
@@ -552,62 +383,6 @@ class Pipeline:
     def trainable_parameter_names(self) -> List[str]:
         """Returns the name of pipeline trainable parameters"""
         return [name for name, p in self._model.named_parameters() if p.requires_grad]
-
-    @staticmethod
-    def __model_from_config(
-        config: PipelineConfiguration, **extra_params
-    ) -> __default_impl__:
-        """Creates a internal base model from pipeline configuration"""
-        return __default_impl__.from_params(Params({"config": config}), **extra_params)
-
-    def _show_explore(self, elasticsearch: _ElasticsearchExplore) -> None:
-        """Shows explore ui for data prediction exploration"""
-
-        def is_service_up(url: str) -> bool:
-            import urllib.request
-
-            try:
-                status_code = urllib.request.urlopen(url).getcode()
-                return 200 <= status_code < 400
-            except URLError:
-                return False
-
-        def launch_ui_app() -> Thread:
-            process = Thread(
-                target=launch_ui,
-                name="ui",
-                kwargs=dict(es_host=elasticsearch.es_host, port=ui_port),
-            )
-            process.start()
-            return process
-
-        def show_notebook_explore(url: str):
-            """Shows explore ui in a notebook cell"""
-            from IPython.core.display import HTML, display
-
-            iframe = f"<iframe src={url} width=100% height=840></iframe>"
-            display(HTML(iframe))
-
-        def show_browser_explore(url: str):
-            """Shows explore ui in a web browser"""
-            import webbrowser
-
-            webbrowser.open(url)
-
-        ui_port = 9999
-        waiting_seconds = 1
-        url = f"http://localhost:{ui_port}/projects/default/explore/{elasticsearch.es_index}"
-
-        if not is_service_up(url):
-            launch_ui_app()
-
-        time.sleep(waiting_seconds)
-        show_func = (
-            show_notebook_explore
-            if helpers.is_running_on_notebook()
-            else show_browser_explore
-        )
-        show_func(url)
 
     @classmethod
     def _vocab_from_path(cls, from_path: str) -> Optional[Vocabulary]:
@@ -635,18 +410,7 @@ class Pipeline:
         )
         return vocab
 
-    @staticmethod
-    def __model_from_archive(archive: Archive) -> __default_impl__:
-        if not isinstance(archive.model, __default_impl__):
-            raise ValueError(f"Wrong pipeline model: {archive.model}")
-        return cast(__default_impl__, archive.model)
-
-    @staticmethod
-    def __config_from_archive(archive: Archive) -> PipelineConfiguration:
-        config = archive.config["model"]["config"]
-        return PipelineConfiguration.from_params(config)
-
-    def __update_prediction_signatures(self):
+    def _update_prediction_signatures(self):
         """For interactive work-flows, fixes the predict signature to the model inputs"""
         new_signature = inspect.Signature(
             [
@@ -696,189 +460,295 @@ class Pipeline:
         self._vocab_extended = True
 
 
-class _PipelineHelper:
-    """Extra pipeline methods"""
+class _EmptyPipeline(Pipeline):
+    """
+    Parameters
+    ----------
+        config: `Optional[PipelineConfiguration]`
+            A `PipelineConfiguration` object defining the configuration of the fresh `Pipeline`.
 
-    __LOGGER = logging.getLogger(__name__)
+    """
 
-    @classmethod
-    def serve(cls, pipeline: Pipeline, port: int):
-        """Serves an pipeline as rest api"""
+    def __init__(self, config: PipelineConfiguration, **extra_args):
+        self._config = config
+        self._model = self.__model_from_config(self._config, **extra_args)
+        if not isinstance(self._model, __default_impl__):
+            raise TypeError(f"Cannot load model. Wrong format of {self._model}")
+        self._update_prediction_signatures()
 
-        def make_app() -> FastAPI:
-            app = FastAPI()
+    @staticmethod
+    def __model_from_config(
+        config: PipelineConfiguration, **extra_params
+    ) -> __default_impl__:
+        """Creates a internal base model from pipeline configuration"""
+        return __default_impl__.from_params(Params({"config": config}), **extra_params)
 
-            @app.post("/predict")
-            async def predict(inputs: Dict[str, Any]):
-                with http_error_handling():
-                    return sanitize(pipeline.predict(**inputs))
 
-            @app.post("/explain")
-            async def explain(inputs: Dict[str, Any]):
-                with http_error_handling():
-                    return sanitize(pipeline.explain(**inputs))
+class _PreTrainedPipeline(Pipeline):
+    """
+    Parameters
+    ----------
 
-            @app.get("/_config")
-            async def config():
-                with http_error_handling():
-                    return pipeline.config.as_dict()
+        pretrained_path: `Optional[str]`
+            The path to the model.tar.gz of a pre-trained `Pipeline`
 
-            @app.get("/_status")
-            async def status():
-                with http_error_handling():
-                    return {"ok": True}
+    """
 
-            return app
+    def __init__(self, pretrained_path: str, **extra_args):
+        self._binary = pretrained_path
+        archive = load_archive(self._binary, **extra_args)
+        self._model = self.__model_from_archive(archive)
+        self._config = self.__config_from_archive(archive)
 
-        uvicorn.run(make_app(), host="0.0.0.0", port=port)
+        if not isinstance(self._model, __default_impl__):
+            raise TypeError(f"Cannot load model. Wrong format of {self._model}")
+        self._update_prediction_signatures()
 
-    @classmethod
-    def train(cls, pipeline: Pipeline, config: _TrainConfiguration):
-        def allennlp_configuration(
-            pipeline: Pipeline, config: _TrainConfiguration
-        ) -> Dict[str, Any]:
-            """Creates a allennlp configuration for pipeline train experiment configuration"""
+    @staticmethod
+    def __model_from_archive(archive: Archive) -> __default_impl__:
+        if not isinstance(archive.model, __default_impl__):
+            raise ValueError(f"Wrong pipeline model: {archive.model}")
+        return cast(__default_impl__, archive.model)
 
-            def trainer_configuration(trainer: TrainerConfiguration) -> Dict[str, Any]:
-                """Creates trainer configuration dict"""
-                __excluded_keys = [
-                    "data_bucketing",
-                    "batch_size",
-                    "cache_instances",
-                    "in_memory_batches",
-                ]  # Data iteration attributes
-                return {
-                    k: v for k, v in vars(trainer).items() if k not in __excluded_keys
+    @staticmethod
+    def __config_from_archive(archive: Archive) -> PipelineConfiguration:
+        config = archive.config["model"]["config"]
+        return PipelineConfiguration.from_params(config)
+
+    @property
+    def trained_path(self) -> str:
+        """Path to binary file when load from binary"""
+        return self._binary
+
+
+def _serve(pipeline: Pipeline, port: int):
+    """Serves an pipeline as rest api"""
+
+    def make_app() -> FastAPI:
+        app = FastAPI()
+
+        @app.post("/predict")
+        async def predict(inputs: Dict[str, Any]):
+            with http_error_handling():
+                return sanitize(pipeline.predict(**inputs))
+
+        @app.post("/explain")
+        async def explain(inputs: Dict[str, Any]):
+            with http_error_handling():
+                return sanitize(pipeline.explain(**inputs))
+
+        @app.get("/_config")
+        async def config():
+            with http_error_handling():
+                return pipeline.config.as_dict()
+
+        @app.get("/_status")
+        async def status():
+            with http_error_handling():
+                return {"ok": True}
+
+        return app
+
+    uvicorn.run(make_app(), host="0.0.0.0", port=port)
+
+
+def _allennlp_configuration(
+    pipeline: Pipeline, config: TrainConfiguration
+) -> Dict[str, Any]:
+    """Creates a allennlp configuration for pipeline train experiment configuration"""
+
+    def trainer_configuration(trainer: TrainerConfiguration) -> Dict[str, Any]:
+        """Creates trainer configuration dict"""
+        __excluded_keys = [
+            "data_bucketing",
+            "batch_size",
+            "cache_instances",
+            "in_memory_batches",
+        ]  # Data iteration attributes
+        return {k: v for k, v in vars(trainer).items() if k not in __excluded_keys}
+
+    def iterator_configuration(
+        pipeline: Pipeline, trainer: TrainerConfiguration
+    ) -> Dict[str, Any]:
+        """Creates a data iterator configuration"""
+
+        def _forward_inputs() -> List[str]:
+            """
+            Calculate the required head.forward arguments. We use this method
+            for automatically generate data iterator sorting keys
+            """
+            required, _ = split_signature_params_by_predicate(
+                pipeline.head.forward, lambda p: p.default == inspect.Parameter.empty,
+            )
+            return [p.name for p in required] or [None]
+
+        iterator_config = {
+            "batch_size": trainer.batch_size,
+            "max_instances_in_memory": max(
+                trainer.batch_size * trainer.in_memory_batches, trainer.batch_size,
+            ),
+            "cache_instances": trainer.cache_instances,
+            "type": "basic",
+        }
+
+        if trainer.data_bucketing:
+            iterator_config.update(
+                {
+                    "sorting_keys": [
+                        [
+                            _forward_inputs()[0],
+                            "list_num_tokens"
+                            if isinstance(
+                                pipeline.model.encoder, TimeDistributedEncoder
+                            )
+                            else "num_tokens",
+                        ]
+                    ],
+                    "type": "bucket",
                 }
+            )
 
-            def iterator_configuration(
-                pipeline: Pipeline, trainer: TrainerConfiguration
-            ) -> Dict[str, Any]:
-                """Creates a data iterator configuration"""
+        return iterator_config
 
-                def _forward_inputs() -> List[str]:
-                    """
-                    Calculate the required head.forward arguments. We use this method
-                    for automatically generate data iterator sorting keys
-                    """
-                    required, _ = split_signature_params_by_predicate(
-                        pipeline.head.forward,
-                        lambda p: p.default == inspect.Parameter.empty,
-                    )
-                    return [p.name for p in required] or [None]
+    base_config = {
+        "config": pipeline.config.as_dict(),
+        "type": __default_impl__.__name__,
+    }
+    allennlp_config = {
+        "trainer": trainer_configuration(config.trainer),
+        "iterator": iterator_configuration(pipeline, config.trainer),
+        "dataset_reader": base_config,
+        "model": base_config,
+        "train_data_path": config.training,
+        "validation_data_path": config.validation,
+        "test_data_path": config.test,
+    }
+    return copy.deepcopy({k: v for k, v in allennlp_config.items() if v})
 
-                iterator_config = {
-                    "batch_size": trainer.batch_size,
-                    "max_instances_in_memory": max(
-                        trainer.batch_size * trainer.in_memory_batches,
-                        trainer.batch_size,
-                    ),
-                    "cache_instances": trainer.cache_instances,
-                    "type": "basic",
-                }
 
-                if trainer.data_bucketing:
-                    iterator_config.update(
-                        {
-                            "sorting_keys": [
-                                [
-                                    _forward_inputs()[0],
-                                    "list_num_tokens"
-                                    if isinstance(
-                                        pipeline.model.encoder, TimeDistributedEncoder
-                                    )
-                                    else "num_tokens",
-                                ]
-                            ],
-                            "type": "bucket",
-                        }
-                    )
+def _explore(
+    pipeline: Pipeline,
+    ds_path: str,
+    config: ExploreConfiguration,
+    elasticsearch: ElasticsearchExplore,
+) -> dd.DataFrame:
+    """
+    Executes a pipeline prediction over a datasource and register results int a elasticsearch index
 
-                return iterator_config
+    Parameters
+    ----------
+    pipeline
+    ds_path
+    config
+    elasticsearch
 
-            base_config = {
-                "config": pipeline.config.as_dict(),
-                "type": __default_impl__.__name__,
-            }
-            allennlp_config = {
-                "trainer": trainer_configuration(config.trainer),
-                "iterator": iterator_configuration(pipeline, config.trainer),
-                "dataset_reader": base_config,
-                "model": base_config,
-                "train_data_path": config.training,
-                "validation_data_path": config.validation,
-                "test_data_path": config.test,
-            }
-            return copy.deepcopy({k: v for k, v in allennlp_config.items() if v})
+    Returns
+    -------
 
-        pipeline._model.launch_experiment(
-            params=Params(allennlp_configuration(pipeline, config)),
-            serialization_dir=config.output,
-        )  # pylint: disable=protected-access,
+    """
+    if config.prediction_cache > 0:
+        # TODO: do it
+        pipeline.init_predictions_cache(config.prediction_cache)
 
-        return pipeline.__class__(
-            pretrained_path=os.path.join(config.output, "model.tar.gz"),
-            config=pipeline.config,
+    data_source = DataSource.from_yaml(ds_path)
+    ddf_mapped = data_source.to_mapped_dataframe()
+    # this only makes really sense when we have a predict_batch_json method implemented ...
+    n_partitions = max(1, round(len(ddf_mapped) / config.batch_size))
+
+    # a persist is necessary here, otherwise it fails for n_partitions == 1
+    # the reason is that with only 1 partition we pass on a generator to predict_batch_json
+    ddf_mapped = ddf_mapped.repartition(npartitions=n_partitions).persist()
+
+    apply_func = pipeline.explain if config.explain else pipeline.predict
+
+    ddf_mapped["annotation"] = ddf_mapped[pipeline.inputs].apply(
+        lambda x: sanitize(apply_func(**x.to_dict())), axis=1, meta=(None, object)
+    )
+
+    ddf_source = (
+        data_source.to_dataframe().repartition(npartitions=n_partitions).persist()
+    )
+    ddf_mapped["metadata"] = ddf_source.map_partitions(
+        lambda df: df.to_dict(orient="records")
+    )
+
+    # TODO @dcfidalgo we could calculate base metrics here (F1, recall & precision) using dataframe.
+    #  And include as part of explore metadata
+    #  Does it's simple???
+
+    ddf = DaskElasticClient(
+        host=elasticsearch.es_host, retry_on_timeout=True, http_compress=True
+    ).save(ddf_mapped, index=elasticsearch.es_index, doc_type=elasticsearch.es_doc)
+
+    elasticsearch.create_explore_data_index(force_delete=config.force_delete)
+    elasticsearch.create_explore_data_record(
+        {
+            **(config.metadata or {}),
+            "datasource": ds_path,
+            # TODO this should change when ui is normalized (action detail and action link naming)F
+            "explore_name": elasticsearch.es_index,
+            "model": pipeline.name,
+            "columns": ddf.columns.values.tolist(),
+            "metadata_columns": data_source.to_dataframe().columns.values.tolist(),
+            "pipeline": pipeline.type_name,
+            "output": pipeline.output,
+            "inputs": pipeline.inputs,  # backward compatibility
+            "signature": pipeline.inputs + [pipeline.output],
+            "predict_signature": pipeline.inputs,
+            "labels": pipeline.head.labels,
+            "task": pipeline.head.task_name().as_string(),
+        }
+    )
+    return ddf.persist()
+
+
+def _show_explore(elasticsearch: ElasticsearchExplore) -> None:
+    """Shows explore ui for data prediction exploration"""
+
+    def is_service_up(url: str) -> bool:
+        import urllib.request
+
+        try:
+            status_code = urllib.request.urlopen(url).getcode()
+            return 200 <= status_code < 400
+        except URLError:
+            return False
+
+    def launch_ui_app() -> Thread:
+        process = Thread(
+            target=launch_ui,
+            name="ui",
+            kwargs=dict(es_host=elasticsearch.es_host, port=ui_port),
         )
+        process.start()
+        return process
 
-    @classmethod
-    def explore(
-        cls,
-        pipeline: Pipeline,
-        ds_path: str,
-        config: _ExploreConfiguration,
-        elasticsearch: _ElasticsearchExplore,
-    ) -> dd.DataFrame:
-        if config.prediction_cache > 0:
-            pipeline.init_predictions_cache(config.prediction_cache)
+    def show_notebook_explore(url: str):
+        """Shows explore ui in a notebook cell"""
+        from IPython.core.display import HTML, display
 
-        data_source = DataSource.from_yaml(ds_path)
-        ddf_mapped = data_source.to_mapped_dataframe()
-        # this only makes really sense when we have a predict_batch_json method implemented ...
-        n_partitions = max(1, round(len(ddf_mapped) / config.batch_size))
+        iframe = f"<iframe src={url} width=100% height=840></iframe>"
+        display(HTML(iframe))
 
-        # a persist is necessary here, otherwise it fails for n_partitions == 1
-        # the reason is that with only 1 partition we pass on a generator to predict_batch_json
-        ddf_mapped = ddf_mapped.repartition(npartitions=n_partitions).persist()
+    def show_browser_explore(url: str):
+        """Shows explore ui in a web browser"""
+        import webbrowser
 
-        apply_func = pipeline.explain if config.explain else pipeline.predict
+        webbrowser.open(url)
 
-        ddf_mapped["annotation"] = ddf_mapped[pipeline.inputs].apply(
-            lambda x: sanitize(apply_func(**x.to_dict())), axis=1, meta=(None, object)
-        )
+    ui_port = 9999
+    waiting_seconds = 1
+    url = (
+        f"http://localhost:{ui_port}/projects/default/explore/{elasticsearch.es_index}"
+    )
 
-        ddf_source = (
-            data_source.to_dataframe().repartition(npartitions=n_partitions).persist()
-        )
-        ddf_mapped["metadata"] = ddf_source.map_partitions(
-            lambda df: df.to_dict(orient="records")
-        )
+    if not is_service_up(url):
+        launch_ui_app()
 
-        # TODO @dcfidalgo we could calculate base metrics here (F1, recall & precision) using dataframe.
-        #  And include as part of explore metadata
-        #  Does it's simple???
-
-        ddf = DaskElasticClient(
-            host=elasticsearch.es_host, retry_on_timeout=True, http_compress=True
-        ).save(ddf_mapped, index=elasticsearch.es_index, doc_type=elasticsearch.es_doc)
-
-        elasticsearch.create_explore_data_index(force_delete=config.force_delete)
-        elasticsearch.create_explore_data_record(
-            {
-                **(config.metadata or {}),
-                "datasource": ds_path,
-                # TODO this should change when ui is normalized (action detail and action link naming)F
-                "explore_name": elasticsearch.es_index,
-                "model": pipeline.name,
-                "columns": ddf.columns.values.tolist(),
-                "metadata_columns": data_source.to_dataframe().columns.values.tolist(),
-                "pipeline": pipeline.type_name,
-                "output": pipeline.output,
-                "inputs": pipeline.inputs,  # backward compatibility
-                "signature": pipeline.inputs + [pipeline.output],
-                "predict_signature": pipeline.inputs,
-                "labels": pipeline.head.labels,
-                "task": pipeline.head.task_name().as_string(),
-            }
-        )
-        return ddf.persist()
+    time.sleep(waiting_seconds)
+    show_func = (
+        show_notebook_explore
+        if helpers.is_running_on_notebook()
+        else show_browser_explore
+    )
+    show_func(url)

--- a/tests/text/pipelines/test_bimpm.py
+++ b/tests/text/pipelines/test_bimpm.py
@@ -178,7 +178,7 @@ def trainer_dict() -> Dict:
 def test_bimpm_train(
     path_to_pipeline_yaml, trainer_dict, path_to_training_data_yaml,
 ):
-    pipeline = Pipeline.from_file(path_to_pipeline_yaml,)
+    pipeline = Pipeline.from_yaml(path_to_pipeline_yaml,)
     pipeline.predict(record1="The one", record2="The other")
 
     pipeline.train(


### PR DESCRIPTION
This PR include several changes over pipeline class definition and its inner dependencies.

The main `Pipeline` can only be initialized using the methods:

- `Pipeline.from_yaml`/`Pipeline.from_config`: for load a "blank" pipeline
- `Pipeline.from_pretrained` : for load already pretrained pipeline

There are to new inner `PIpeline` classes  managing the loading cases: `_BlankPipeline` and `PreTrainedPipeline`

Also, the `train`method in a pipeline doesn't not modify the original pipeline, so you can launch several training processes from the same pipeline. 

```python
    train = "train.data.yml"
    validation = "validation.data.yml"
    training_folder = "experiment"

    pl = Pipeline.from_yaml(
        "text_classifier.yaml", vocab_path=os.path.join(training_folder, "vocabulary")
    )

    trainer_configuration = TrainerConfiguration(**yaml_to_dict("trainer.yml"))
    trainer_configuration.data_bucketing = False
    pl.train(
        output=training_folder,
        trainer=trainer_configuration,
        training=train,
        validation=validation,
        extend_vocab=VocabularyConfiguration(sources=[train, validation]),
    )

    trained_pl = Pipeline.from_pretrained(os.path.join(training_folder, "model.tar.gz"))
    
```
Closes #143 

