### PR TITLE
fix mask for the encoding after the pooling over the TextFields

### DIFF
--- a/src/biome/text/modules/heads/doc_classification.py
+++ b/src/biome/text/modules/heads/doc_classification.py
@@ -90,9 +90,9 @@ class DocumentClassification(ClassificationHead):
         embedded_text = self.backbone.forward(document, mask, num_wrapping_dims=1)
         embedded_text = self.tokens_pooler(embedded_text, mask=mask)
 
-        mask = get_text_field_mask(
-            {self.forward_arg_name: embedded_text}
-        )  # Add an extra dimension to tensor mask
+        # Here we need to mask the TextFields that only contain the padding token -> last dimension only contains False
+        # Those fields were added to possibly equalize the batch.
+        mask = torch.sum(mask, -1) > 0
         embedded_text = self.encoder(embedded_text, mask=mask)
         embedded_text = self.pooler(embedded_text, mask=mask)
 


### PR DESCRIPTION
This PR concerns the mask in the `DocumentationClassification` after reducing the dimension by means of the `tokens_pooler`.

I stumbled across this one while designing the new BiMpm for records. The method we used so far (`get_text_field_mask`) only checks if the value of the tensor is `!= 0`, which is designed for TextField tensors with token ids. For tensors coming out of an embedder/encoder this is not reliable!

The new approach just checks if all tokens in a TextField are padding tokens and masks this TextField accordingly.