### PR TITLE
rename `BackboneEncoder` -> `ModelBackbone`

### DIFF
--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -22,7 +22,7 @@ from allennlp.training import Trainer
 from allennlp.training.util import evaluate
 from dask.dataframe import Series as DaskSeries
 
-from .backbone import BackboneEncoder
+from .backbone import ModelBackbone
 from .configuration import PipelineConfiguration
 from .data import DataSource
 from .errors import MissingArgumentError
@@ -98,7 +98,7 @@ class PipelineModel(allennlp.models.Model, allennlp.data.DatasetReader):
         return cls(
             name=config.name,
             head=config.head.compile(
-                backbone=BackboneEncoder(
+                backbone=ModelBackbone(
                     vocab=vocab
                     or vocabulary.empty_vocab(featurizer=config.features.compile()),
                     tokenizer=config.tokenizer.compile(),

--- a/src/biome/text/backbone.py
+++ b/src/biome/text/backbone.py
@@ -12,8 +12,23 @@ from .tokenizer import Tokenizer
 from .vocabulary import Vocabulary
 
 
-class BackboneEncoder(torch.nn.Module):
-    """Backbone Encoder definition. All models used in pipelines must configure this model class"""
+class ModelBackbone(torch.nn.Module):
+    """The backbone of the model.
+
+     It is composed of a tokenizer, featurizer and an encoder.
+     This component of the model can be pretrained and used with different task heads.
+
+     Parameters
+     ----------
+     vocab : `Vocabulary`
+        The vocabulary of the pipeline
+    tokenizer : `Tokenizer`
+        Tokenizes the input depending on its type (str, List[str], Dict[str, Any])
+    featurizer : `InputFeaturizer`
+        Defines the input features of the tokens, indexes and embeds them.
+    encoder : Encoder
+        Outputs an encoded sequence of the tokens
+    """
 
     def __init__(
         self,
@@ -22,7 +37,7 @@ class BackboneEncoder(torch.nn.Module):
         featurizer: InputFeaturizer,
         encoder: Optional[Encoder] = None,
     ):
-        super(BackboneEncoder, self).__init__()
+        super(ModelBackbone, self).__init__()
 
         self.vocab = vocab
         self.tokenizer = tokenizer

--- a/src/biome/text/modules/heads/bimpm_classification.py
+++ b/src/biome/text/modules/heads/bimpm_classification.py
@@ -11,7 +11,7 @@ from allennlp.modules.bimpm_matching import BiMpmMatching
 from allennlp.nn import InitializerApplicator, util
 from overrides import overrides
 
-from biome.text.backbone import BackboneEncoder
+from biome.text.backbone import ModelBackbone
 from biome.text.modules.encoders import TimeDistributedEncoder
 from biome.text.modules.heads.classification.defs import ClassificationHead
 from biome.text.modules.specs import (
@@ -37,7 +37,7 @@ class BiMpm(ClassificationHead):
 
     Parameters
     ----------
-    backbone : ``BackboneEncoder``
+    backbone : `ModelBackbone`
         Takes care of the embedding
     labels : `List[str]`
         List of labels
@@ -70,7 +70,7 @@ class BiMpm(ClassificationHead):
 
     def __init__(
         self,
-        backbone: BackboneEncoder,
+        backbone: ModelBackbone,
         labels: List[str],
         matcher_word: BiMpmMatchingSpec,
         encoder: Seq2SeqEncoderSpec,

--- a/src/biome/text/modules/heads/classification/defs.py
+++ b/src/biome/text/modules/heads/classification/defs.py
@@ -6,7 +6,7 @@ from allennlp.data import Instance
 from allennlp.data.fields import LabelField, MultiLabelField
 from allennlp.training.metrics import CategoricalAccuracy, F1Measure
 
-from biome.text.backbone import BackboneEncoder
+from biome.text.backbone import ModelBackbone
 from biome.text.vocabulary import vocabulary
 from ..defs import TaskHead, TaskName, TaskOutput
 
@@ -15,7 +15,7 @@ class ClassificationHead(TaskHead):
     """Base abstract class for classification problems"""
 
     def __init__(
-        self, backbone: BackboneEncoder, labels: List[str], multilabel: bool = False
+        self, backbone: ModelBackbone, labels: List[str], multilabel: bool = False
     ):
         super(ClassificationHead, self).__init__(backbone)
         vocabulary.set_labels(self.backbone.vocab, labels)

--- a/src/biome/text/modules/heads/defs.py
+++ b/src/biome/text/modules/heads/defs.py
@@ -6,7 +6,7 @@ import torch
 from allennlp.common import Registrable
 from allennlp.data import Instance, Vocabulary
 
-from biome.text.backbone import BackboneEncoder
+from biome.text.backbone import ModelBackbone
 from biome.text.modules.specs import ComponentSpec
 from biome.text.vocabulary import vocabulary
 
@@ -58,7 +58,7 @@ class TaskName(Enum):
 class TaskHead(torch.nn.Module, Registrable):
     """Base task head class"""
 
-    def __init__(self, backbone: BackboneEncoder):
+    def __init__(self, backbone: ModelBackbone):
         super(TaskHead, self).__init__()
         self.backbone = backbone
 

--- a/src/biome/text/modules/heads/doc_classification.py
+++ b/src/biome/text/modules/heads/doc_classification.py
@@ -10,7 +10,7 @@ from allennlp.modules.seq2vec_encoders import BagOfEmbeddingsEncoder
 from allennlp.nn.util import get_text_field_mask
 from captum.attr import IntegratedGradients
 
-from biome.text.backbone import BackboneEncoder
+from biome.text.backbone import ModelBackbone
 from biome.text.modules.encoders import TimeDistributedEncoder
 from biome.text.modules.specs import (
     ComponentSpec,
@@ -34,7 +34,7 @@ class DocumentClassification(ClassificationHead):
 
     def __init__(
         self,
-        backbone: BackboneEncoder,
+        backbone: ModelBackbone,
         pooler: Seq2VecEncoderSpec,
         labels: List[str],
         tokens_pooler: Optional[Seq2VecEncoderSpec] = None,

--- a/src/biome/text/modules/heads/language_modelling.py
+++ b/src/biome/text/modules/heads/language_modelling.py
@@ -8,7 +8,7 @@ from allennlp.nn.util import get_text_field_mask
 from allennlp.training.metrics import Perplexity
 
 from biome.text.featurizer import InputFeaturizer
-from biome.text.backbone import BackboneEncoder
+from biome.text.backbone import ModelBackbone
 from biome.text.modules.specs import ComponentSpec
 from biome.text.vocabulary import vocabulary
 from .defs import TaskHead, TaskName, TaskOutput
@@ -50,7 +50,7 @@ class LanguageModelling(TaskHead):
     def task_name(self) -> TaskName:
         return TaskName.language_modelling
 
-    def __init__(self, backbone: BackboneEncoder, dropout: float = None) -> None:
+    def __init__(self, backbone: ModelBackbone, dropout: float = None) -> None:
         super(LanguageModelling, self).__init__(backbone)
 
         if not backbone.featurizer.words:

--- a/src/biome/text/modules/heads/record_classification.py
+++ b/src/biome/text/modules/heads/record_classification.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Union
 
 from allennlp.data import Instance
 
-from biome.text.backbone import BackboneEncoder
+from biome.text.backbone import ModelBackbone
 from biome.text.modules.specs import (
     ComponentSpec,
     FeedForwardSpec,
@@ -22,7 +22,7 @@ class RecordClassification(DocumentClassification):
 
     def __init__(
         self,
-        backbone: BackboneEncoder,
+        backbone: ModelBackbone,
         pooler: Seq2VecEncoderSpec,
         labels: List[str],
         record_keys: List[str],

--- a/src/biome/text/modules/heads/text_classification.py
+++ b/src/biome/text/modules/heads/text_classification.py
@@ -8,7 +8,7 @@ from allennlp.data.fields import TextField
 from allennlp.nn.util import get_text_field_mask
 from captum.attr import IntegratedGradients
 
-from biome.text.backbone import BackboneEncoder
+from biome.text.backbone import ModelBackbone
 from biome.text.modules.specs import (
     ComponentSpec,
     FeedForwardSpec,
@@ -29,7 +29,7 @@ class TextClassification(ClassificationHead):
 
     def __init__(
         self,
-        backbone: BackboneEncoder,
+        backbone: ModelBackbone,
         pooler: Seq2VecEncoderSpec,
         labels: List[str],
         feedforward: Optional[FeedForwardSpec] = None,

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -8,7 +8,7 @@ from allennlp.modules.conditional_random_field import allowed_transitions
 from allennlp.nn.util import get_text_field_mask
 from allennlp.training.metrics import CategoricalAccuracy, SpanBasedF1Measure
 
-from biome.text.backbone import BackboneEncoder
+from biome.text.backbone import ModelBackbone
 from biome.text.modules.specs import ComponentSpec, FeedForwardSpec
 from biome.text.vocabulary import vocabulary
 from .defs import TaskHead, TaskName, TaskOutput
@@ -19,7 +19,7 @@ class TokenClassification(TaskHead):
 
     def __init__(
         self,
-        backbone: BackboneEncoder,
+        backbone: ModelBackbone,
         labels: List[str],
         label_encoding: Optional[str] = "BIOUL",
         dropout: Optional[float] = None,

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -28,7 +28,7 @@ from ._configuration import (
     TrainConfiguration,
     _ModelImpl,
 )
-from .backbone import BackboneEncoder
+from .backbone import ModelBackbone
 from .modules.heads import TaskHead
 from .modules.heads.defs import TaskHeadSpec
 
@@ -345,7 +345,7 @@ class Pipeline:
         return self._model.output
 
     @property
-    def backbone(self) -> BackboneEncoder:
+    def backbone(self) -> ModelBackbone:
         """Gets pipeline backbone encoder"""
         return self.head.backbone
 


### PR DESCRIPTION
A refactor following the discussion yesterday.

Also have a look at the new doc string for the `ModelBackbone` in case you any comments.