### PR TITLE
adapt namespace values of WordFeatures and CharFeatures

### DIFF
--- a/src/biome/text/featurizer.py
+++ b/src/biome/text/featurizer.py
@@ -13,7 +13,7 @@ Embedder = TextFieldEmbedder
 class WordFeatures:
     """Feature configuration at word level"""
 
-    namespace = "words"
+    namespace = "word"
 
     def __init__(
         self,
@@ -60,7 +60,7 @@ class WordFeatures:
 class CharFeatures:
     """Feature configuration at character level"""
 
-    namespace = "chars"
+    namespace = "char"
 
     def __init__(
         self,


### PR DESCRIPTION
Just a small refactor for consistency.
I would also immediately drop the backward compatibility for the `chars` and `words` keys in the config! Knowing us, we will forget to remove them in the end ... @frascuchon If you are ok with dropping them, i could push an extra commit to this PR.