### PR TITLE
refactor: vocabulary helper as module

### DIFF
--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -20,6 +20,7 @@ from allennlp.data import DatasetReader, Instance, Vocabulary
 from allennlp.models.archival import CONFIG_NAME, archive_model
 from allennlp.training import Trainer
 from allennlp.training.util import evaluate
+from biome.text.vocabulary import _EmptyVocab
 from dask.dataframe import Series as DaskSeries
 
 from .backbone import ModelBackbone
@@ -28,7 +29,6 @@ from .data import DataSource
 from .errors import MissingArgumentError
 from .helpers import split_signature_params_by_predicate
 from .modules.heads import TaskHead
-from .vocabulary import vocabulary
 
 
 class _HashDict(dict):
@@ -95,12 +95,11 @@ class PipelineModel(allennlp.models.Model, allennlp.data.DatasetReader):
         if not isinstance(config, PipelineConfiguration):
             config = PipelineConfiguration.from_params(config)
 
-        vocab = vocab or vocabulary.empty_vocab(features=config.features.keys)
+        vocab = vocab or _EmptyVocab(namespaces=config.features.keys)
 
         return cls(
             name=config.name,
             head=config.head.compile(
-
                 backbone=ModelBackbone(
                     vocab,
                     tokenizer=config.tokenizer.compile(),

--- a/src/biome/text/modules/heads/classification/defs.py
+++ b/src/biome/text/modules/heads/classification/defs.py
@@ -6,7 +6,7 @@ from allennlp.data.fields import LabelField, MultiLabelField
 from allennlp.training.metrics import CategoricalAccuracy, F1Measure
 
 from biome.text.backbone import ModelBackbone
-from biome.text.vocabulary import vocabulary
+from biome.text import vocabulary
 from ..defs import TaskHead, TaskName, TaskOutput
 
 
@@ -28,7 +28,7 @@ class ClassificationHead(TaskHead):
         # metrics and loss
         self.metrics = {"accuracy": CategoricalAccuracy()}
         if self._multilabel:
-            # TODO: for multilabel we want to calculate F1 per label and/or ROC-AUC
+            # TODO: for multi-label we want to calculate F1 per label and/or ROC-AUC
             self._loss = torch.nn.BCEWithLogitsLoss()
         else:
             # metrics, some AllenNLP models use the names _accuracy or _metrics, so we have to be more specific.
@@ -82,7 +82,7 @@ class ClassificationHead(TaskHead):
                 if torch.cuda.is_available()
                 else None,
             )
-            all_classes_probs[:probabilities.size()[0]] = probabilities
+            all_classes_probs[: probabilities.size()[0]] = probabilities
             sorted_indexes_by_prob = torch.argsort(
                 all_classes_probs, descending=True
             ).tolist()

--- a/src/biome/text/modules/heads/defs.py
+++ b/src/biome/text/modules/heads/defs.py
@@ -8,7 +8,7 @@ from allennlp.data import Instance, Vocabulary
 
 from biome.text.backbone import ModelBackbone
 from biome.text.modules.specs import ComponentSpec
-from biome.text.vocabulary import vocabulary
+from biome.text import vocabulary
 
 
 class TaskOutput:

--- a/src/biome/text/modules/heads/doc_classification.py
+++ b/src/biome/text/modules/heads/doc_classification.py
@@ -18,7 +18,7 @@ from biome.text.modules.specs import (
     Seq2SeqEncoderSpec,
     Seq2VecEncoderSpec,
 )
-from biome.text.vocabulary import vocabulary
+from biome.text import vocabulary
 from .classification.defs import ClassificationHead
 from .defs import TaskOutput
 

--- a/src/biome/text/modules/heads/language_modelling.py
+++ b/src/biome/text/modules/heads/language_modelling.py
@@ -10,7 +10,7 @@ from allennlp.training.metrics import Perplexity
 from biome.text.featurizer import InputFeaturizer
 from biome.text.backbone import ModelBackbone
 from biome.text.modules.specs import ComponentSpec
-from biome.text.vocabulary import vocabulary
+from biome.text import vocabulary
 from .defs import TaskHead, TaskName, TaskOutput
 
 

--- a/src/biome/text/modules/heads/text_classification.py
+++ b/src/biome/text/modules/heads/text_classification.py
@@ -14,7 +14,7 @@ from biome.text.modules.specs import (
     FeedForwardSpec,
     Seq2VecEncoderSpec,
 )
-from biome.text.vocabulary import vocabulary
+from biome.text import vocabulary
 from .classification.defs import ClassificationHead
 from .defs import TaskOutput
 

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -10,7 +10,7 @@ from allennlp.training.metrics import CategoricalAccuracy, SpanBasedF1Measure
 
 from biome.text.backbone import ModelBackbone
 from biome.text.modules.specs import ComponentSpec, FeedForwardSpec
-from biome.text.vocabulary import vocabulary
+from biome.text import vocabulary
 from .defs import TaskHead, TaskName, TaskOutput
 
 

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -496,6 +496,7 @@ class Pipeline:
             tokens_to_add=vocab_config.tokens_to_add,
         )
 
+
 class _BlankPipeline(Pipeline):
     """
     Parameters

--- a/src/biome/text/vocabulary.py
+++ b/src/biome/text/vocabulary.py
@@ -1,171 +1,144 @@
+"""
+    Manages vocabulary tasks and fetches vocabulary information
+
+    Provides utilities for getting information from a given vocabulary.
+
+    Provides management actions such as extending the labels, setting new labels or creating an "empty" vocab.
+"""
 from typing import Dict, List
 
 from allennlp.data import Vocabulary
+from allennlp.data.vocabulary import DEFAULT_OOV_TOKEN
+from biome.text.featurizer import WordFeatures
 
-from .featurizer import InputFeaturizer
-
-# TODO: convert class into helper functions
+LABELS_NAMESPACE = "gold_labels"
 
 
-class vocabulary:
-    """Manages vocabulary tasks and fetches vocabulary information
-    
-    Provides utilities for getting information from a given vocabulary.
-    
-    Provides management actions such as extending the labels, setting new labels or creating an "empty" vocab.
+def get_labels(vocab: Vocabulary) -> List[str]:
+    """Gets list of labels in the vocabulary
+
+    Parameters
+    ----------
+    vocab: `allennlp.data.Vocabulary`
+
+    Returns
+    -------
+    labels: `List[str]`
+        A list of label strings
+    """
+    return [k for k in vocab.get_token_to_index_vocabulary(namespace=LABELS_NAMESPACE)]
+
+
+def label_for_index(vocab: Vocabulary, idx: int) -> str:
+    """Gets label string for a label `int` id
+
+    Parameters
+    ----------
+    vocab: `allennlp.data.Vocabulary`
+    idx: `int
+        the token index
+
+    Returns
+    -------
+    label: `str`
+        The string for a label id
+    """
+    return vocab.get_token_from_index(idx, namespace=LABELS_NAMESPACE)
+
+
+def index_for_label(vocab: Vocabulary, label: str) -> int:
+    """Gets the label `int` id for label string
+
+    Parameters
+    ----------
+    vocab: `allennlp.data.Vocabulary``
+    label: `str`
+        the label
+
+    Returns
+    -------
+    label_idx: `int`
+        The label id for label string
+    """
+    return vocab.get_token_index(label, namespace=LABELS_NAMESPACE)
+
+
+def get_index_to_labels_dictionary(vocab: Vocabulary) -> Dict[int, str]:
+    """Gets a dictionary for turning label `int` ids into label strings
+
+    Parameters
+    ----------
+    vocab: `allennlp.data.Vocabulary`
+
+    Returns
+    -------
+    labels: `Dict[int, str]`
+        A dictionary to get fetch label strings from ids
+    """
+    return vocab.get_index_to_token_vocabulary(LABELS_NAMESPACE)
+
+
+def words_vocab_size(vocab: Vocabulary) -> int:
+    """Fetches the vocabulary size for the `words` namespace
+
+    Parameters
+    ----------
+    vocab: `allennlp.data.Vocabulary`
+
+    Returns
+    -------
+    size: `int`
+        The vocabulary size for the words namespace
+    """
+    return vocab.get_vocab_size(WordFeatures.namespace)
+
+
+def extend_labels(vocab: Vocabulary, labels: List[str]):
+    """Adds a list of label strings to the vocabulary
+
+    Use this to add new labels to your vocabulary (e.g., useful for reusing the weights of an existing classifier)
+
+    Parameters
+    ----------
+    vocab: `allennlp.data.Vocabulary`
+    labels: `List[str]`
+        A list of strings containing the labels to add to an existing vocabulary
+    """
+    vocab.add_tokens_to_namespace(labels, namespace=LABELS_NAMESPACE)
+
+
+def set_labels(vocab: Vocabulary, new_labels: List[str]):
+    """Resets the labels in the vocabulary with a given labels string list
+
+    Parameters
+    ----------
+    vocab: `allennlp.data.Vocabulary`
+    new_labels: `List[str]`
+        The label strings to add to the vocabulary
+    """
+    for namespace_vocab in [
+        vocab.get_token_to_index_vocabulary(LABELS_NAMESPACE),
+        vocab.get_index_to_token_vocabulary(LABELS_NAMESPACE),
+    ]:
+        tokens = list(namespace_vocab.keys())
+        for token in tokens:
+            del namespace_vocab[token]
+
+    extend_labels(vocab, new_labels)
+
+
+class _EmptyVocab(Vocabulary):
+    """
+    Represents an empty vocabulary. Used for early pipeline initialization
+
+    Arguments
+    ----------
+    namespaces: `List[str]`
+        The vocab namespaces to create
     """
 
-    """Namespace for labels in the vocabulary"""
-    LABELS_NAMESPACE = "gold_labels"
+    def __init__(self, namespaces: List[str]):
+        super(_EmptyVocab, self).__init__()
 
-    @classmethod
-    def num_labels(cls, vocab: Vocabulary) -> int:
-        """Gives the number of labels in the vocabulary
-        
-        # Parameters
-            vocab: `allennlp.data.Vocabulary`
-
-        # Returns
-            num_labels: `int`
-                The number of labels in the vocabulary
-        """
-        return len(cls.get_labels(vocab))
-
-    @classmethod
-    def get_labels(cls, vocab: Vocabulary) -> List[str]:
-        """Gets list of labels in the vocabulary
-        
-        # Parameters
-            vocab: `allennlp.data.Vocabulary`
-
-        # Returns
-            labels: `List[str]`
-                A list of label strings
-        """
-        return [
-            k
-            for k in vocab.get_token_to_index_vocabulary(namespace=cls.LABELS_NAMESPACE)
-        ]
-
-    @classmethod
-    def label_for_index(cls, vocab: Vocabulary, idx: int) -> str:
-        """Gets label string for a label `int` id
-        
-        # Parameters
-            vocab: `allennlp.data.Vocabulary`
-
-        # Returns
-            label: `str`
-               The string for a label id
-        """
-        return vocab.get_token_from_index(idx, namespace=cls.LABELS_NAMESPACE)
-
-    @classmethod
-    def index_for_label(cls, vocab: Vocabulary, label: str) -> int:
-        """Gets the label `int` id for label string
-        
-        # Parameters
-            vocab: `allennlp.data.Vocabulary`
-
-        # Returns
-            label_idx: `int`
-                The label id for label string
-        """
-        return vocab.get_token_index(label, namespace=cls.LABELS_NAMESPACE)
-
-    @classmethod
-    def get_index_to_labels_dictionary(cls, vocab: Vocabulary) -> Dict[int, str]:
-        """Gets a dictionary for turning label `int` ids into label strings
-
-        # Parameters
-            vocab: `allennlp.data.Vocabulary`
-
-        # Returns
-            labels: `Dict[int, str]`
-                A dictionary to get fetch label strings from ids
-        """
-        return vocab.get_index_to_token_vocabulary(cls.LABELS_NAMESPACE)
-
-    @classmethod
-    def vocab_size(cls, vocab: Vocabulary, namespace: str) -> int:
-        """Fetches the vocabulary size of a given namespace
-
-        # Parameters
-            vocab: `allennlp.data.Vocabulary`
-            namespace: `str`
-            
-        # Returns
-            size: `int`
-                The vocabulary size for a given namespace
-        """
-        return vocab.get_vocab_size(namespace=namespace)
-
-    @classmethod
-    def words_vocab_size(cls, vocab: Vocabulary) -> int:
-        """Fetches the vocabulary size for the `words` namespace
-
-        # Parameters
-            vocab: `allennlp.data.Vocabulary`
-            
-        # Returns
-            size: `int`
-                The vocabulary size for the words namespace
-        """
-        return cls.vocab_size(vocab, namespace=InputFeaturizer.WORDS)
-
-    @classmethod
-    def extend_labels(cls, vocab: Vocabulary, labels: List[str]):
-        """Adds a list of label strings to the vocabulary
-        
-        Use this to add new labels to your vocabulary (e.g., useful for reusing the weights of an existing classifier)
-        
-        # Parameters
-            vocab: `allennlp.data.Vocabulary`
-            labels: `List[str]`
-                A list of strings containing the labels to add to an existing vocabulary
-        """
-        vocab.add_tokens_to_namespace(labels, namespace=cls.LABELS_NAMESPACE)
-
-    @classmethod
-    def empty_vocab(cls, features: List[str], labels: List[str] = None) -> Vocabulary:
-        """Generates a "mock" empty vocabulary for a given features set
-        
-        This method generate a mock vocabulary for the each feature namespace
-
-        Parameters
-        ----------
-            features: `List[str]`
-                A list for feature names
-            labels: `List[str]`
-                The label strings to add to the vocabulary
-        Returns
-        -------
-            vocabulary: `allennlp.data.Vocabulary`
-                The instantiated vocabulary
-        """
-        labels = labels or []
-        vocab = Vocabulary()
-        vocabulary.extend_labels(vocab, labels=labels)
-        for namespace in features:
-            # TODO: better empty vocab creation
-            vocab.add_token_to_namespace("a", namespace=namespace)
-        return vocab
-
-    @classmethod
-    def set_labels(cls, vocab: Vocabulary, new_labels: List[str]):
-        """Resets the labels in the vocabulary with a given labels string list
-
-        # Parameters
-            vocab: `allennlp.data.Vocabulary`
-            new_labels: `List[str]`
-                The label strings to add to the vocabulary
-        """
-        for namespace_vocab in [
-            vocab.get_token_to_index_vocabulary(cls.LABELS_NAMESPACE),
-            vocab.get_index_to_token_vocabulary(cls.LABELS_NAMESPACE),
-        ]:
-            tokens = list(namespace_vocab.keys())
-            for token in tokens:
-                del namespace_vocab[token]
-
-        cls.extend_labels(vocab, new_labels)
+        for namespace in namespaces:
+            self.add_token_to_namespace(DEFAULT_OOV_TOKEN, namespace=namespace)


### PR DESCRIPTION
Just redefine vocabulary helper as module methods.

Also includes a new `_EmptyVocab` class for a early pipeline initialization