### PR TITLE
Move probabilities calculation to decode

### DIFF
--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -123,7 +123,7 @@ class PipelineModel(allennlp.models.Model, allennlp.data.DatasetReader):
     def forward(self, *args, **kwargs) -> Dict[str, torch.Tensor]:
         """The main forward method. Wraps the head forward method and converts the head output into a dictionary"""
         head_output: TaskOutput = self._head.forward(*args, **kwargs)
-        # we don't want to break AllenNLP API -> as_dict()
+        # we don't want to break AllenNLP API: TaskOutput -> as_dict()
         return head_output.as_dict()
 
     def decode(self, output_dict: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
@@ -139,9 +139,10 @@ class PipelineModel(allennlp.models.Model, allennlp.data.DatasetReader):
         output_dict
             Completed output
         """
-        # we don't want to break AllenNLP API: dict -> TaskOutput
+        # we don't want to break AllenNLP API: dict -> TaskOutput -> dict
         output = TaskOutput(**output_dict)
-        return self._head.decode(output)
+        completed_output = self._head.decode(output)
+        return completed_output.as_dict()
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         """Fetch metrics defined in head layer"""

--- a/src/biome/text/modules/heads/classification/defs.py
+++ b/src/biome/text/modules/heads/classification/defs.py
@@ -70,37 +70,33 @@ class ClassificationHead(TaskHead):
     def task_name(self) -> TaskName:
         return TaskName.text_classification
 
-    def process_output(self, output: TaskOutput) -> TaskOutput:
-        def labels_with_probabilities(probabilities: torch.Tensor) -> Dict[str, float]:
-            """
-            Calculates the descendant sorted label + probs dictionary
-            using all output classes (not only predicted)
-            """
-            all_classes_probs = torch.zeros(
-                self.num_labels,
-                device=probabilities.get_device()
-                if torch.cuda.is_available()
-                else None,
-            )
-            all_classes_probs[: probabilities.size()[0]] = probabilities
-            sorted_indexes_by_prob = torch.argsort(
-                all_classes_probs, descending=True
-            ).tolist()
-            return {
-                vocabulary.label_for_index(self.backbone.vocab, idx): all_classes_probs[
-                    idx
-                ]
-                for idx in sorted_indexes_by_prob
-            }
+    def decode(self, output: TaskOutput) -> Dict[str, Any]:
+        """Completes the output for the prediction
 
-        probs_batch = output.probs
+        Mainly adds probabilities and keys for the UI.
+
+        Parameters
+        ----------
+        output
+            The output from the head's forward method
+
+        Returns
+        -------
+        output_dict
+            Completed output
+        """
+        if self._multilabel:
+            probabilities = output.logits.sigmoid()
+        else:
+            probabilities = torch.nn.functional.softmax(output.logits, dim=-1)
+        output.probs = probabilities
 
         output_map_probs = []
         max_classes = []
         max_classes_prob = []
         if self.num_labels > 0:
-            for probs in probs_batch:
-                labels_with_prob = labels_with_probabilities(probs)
+            for probs in probabilities:
+                labels_with_prob = self._labels_with_probabilities(probs)
                 output_map_probs.append(labels_with_prob)
 
                 label, prob = list(labels_with_prob.items())[0]
@@ -112,10 +108,32 @@ class ClassificationHead(TaskHead):
         output.max_class = max_classes
         output.max_class_prob = max_classes_prob
 
+        # TODO: This is just a duplicate of output.max_class. Revise if it is still necessary!
         output.label = max_classes
         output.prob = max_classes_prob
 
-        return output
+        return output.as_dict()
+
+    def _labels_with_probabilities(
+        self, probabilities: torch.Tensor
+    ) -> Dict[str, float]:
+        """
+        Calculates the descendant sorted label + probs dictionary
+        using all output classes (not only predicted)
+        """
+        all_classes_probs = torch.zeros(
+            self.num_labels,
+            device=probabilities.get_device() if torch.cuda.is_available() else None,
+        )
+        all_classes_probs[: probabilities.size()[0]] = probabilities
+        sorted_indexes_by_prob = torch.argsort(
+            all_classes_probs, descending=True
+        ).tolist()
+
+        return {
+            vocabulary.label_for_index(self.backbone.vocab, idx): all_classes_probs[idx]
+            for idx in sorted_indexes_by_prob
+        }
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         """Get the metrics of our classifier, see :func:`~allennlp_2.models.Model.get_metrics`.
@@ -161,9 +179,7 @@ class ClassificationHead(TaskHead):
     def single_label_output(
         self, logits: torch.Tensor, label: Optional[torch.IntTensor] = None,
     ) -> TaskOutput:
-        output = TaskOutput(
-            logits=logits, probs=torch.nn.functional.softmax(logits, dim=-1)
-        )
+        output = TaskOutput(logits=logits)
 
         if label is not None:
             output.loss = self._loss(logits, label.long())
@@ -175,7 +191,7 @@ class ClassificationHead(TaskHead):
     def multi_label_output(
         self, logits: torch.Tensor, label: Optional[torch.IntTensor] = None,
     ) -> TaskOutput:
-        output = TaskOutput(logits=logits, probs=logits.sigmoid())
+        output = TaskOutput(logits=logits)
 
         if label is not None:
             # casting long to float for BCELoss

--- a/src/biome/text/modules/heads/classification/defs.py
+++ b/src/biome/text/modules/heads/classification/defs.py
@@ -110,7 +110,7 @@ class ClassificationHead(TaskHead):
         output.label = max_classes
         output.prob = max_classes_prob
 
-        return output.as_dict()
+        return output
 
     def _labels_with_probabilities(
         self, probabilities: torch.Tensor

--- a/src/biome/text/modules/heads/classification/defs.py
+++ b/src/biome/text/modules/heads/classification/defs.py
@@ -104,10 +104,9 @@ class ClassificationHead(TaskHead):
 
         output.classes = output_map_probs
 
-        output.max_class = max_classes
-        output.max_class_prob = max_classes_prob
+        output.max_class = max_classes  # deprecated
+        output.max_class_prob = max_classes_prob  # deprecated
 
-        # TODO: This is just a duplicate of output.max_class. Revise if it is still necessary!
         output.label = max_classes
         output.prob = max_classes_prob
 

--- a/src/biome/text/modules/heads/classification/defs.py
+++ b/src/biome/text/modules/heads/classification/defs.py
@@ -70,7 +70,7 @@ class ClassificationHead(TaskHead):
     def task_name(self) -> TaskName:
         return TaskName.text_classification
 
-    def decode(self, output: TaskOutput) -> Dict[str, Any]:
+    def decode(self, output: TaskOutput) -> TaskOutput:
         """Completes the output for the prediction
 
         Mainly adds probabilities and keys for the UI.
@@ -82,8 +82,7 @@ class ClassificationHead(TaskHead):
 
         Returns
         -------
-        output_dict
-            Completed output
+        completed_output
         """
         if self._multilabel:
             probabilities = output.logits.sigmoid()

--- a/src/biome/text/modules/heads/defs.py
+++ b/src/biome/text/modules/heads/defs.py
@@ -113,10 +113,10 @@ class TaskHead(torch.nn.Module, Registrable):
         """Converts incoming data into an allennlp `Instance`, used for pyTorch tensors generation"""
         raise NotImplementedError
 
-    def decode(self, output: TaskOutput) -> Dict[str, Any]:
+    def decode(self, output: TaskOutput) -> TaskOutput:
         """Completes the output for the prediction
 
-        The base implementation just transforms the output to an output_dict.
+        The base implementation adds nothing.
 
         Parameters
         ----------
@@ -125,10 +125,9 @@ class TaskHead(torch.nn.Module, Registrable):
 
         Returns
         -------
-        output_dict
-            Completed output
+        completed_output
         """
-        return output.as_dict()
+        return output
 
     def explain_prediction(
         self, prediction: Dict[str, numpy.array], instance: Instance

--- a/src/biome/text/modules/heads/defs.py
+++ b/src/biome/text/modules/heads/defs.py
@@ -21,12 +21,10 @@ class TaskOutput:
     def __init__(
         self,
         logits: torch.Tensor,
-        probs: torch.Tensor,
         loss: Optional[torch.Tensor] = None,
         **extra_data
     ):
         self.logits = logits
-        self.probs = probs
         self.loss = loss
 
         for k, v in extra_data.items():
@@ -115,9 +113,22 @@ class TaskHead(torch.nn.Module, Registrable):
         """Converts incoming data into an allennlp `Instance`, used for pyTorch tensors generation"""
         raise NotImplementedError
 
-    def process_output(self, output: TaskOutput) -> TaskOutput:
-        """Build extra parameters over basic task output"""
-        return output
+    def decode(self, output: TaskOutput) -> Dict[str, Any]:
+        """Completes the output for the prediction
+
+        The base implementation just transforms the output to an output_dict.
+
+        Parameters
+        ----------
+        output
+            The output from the head's forward method
+
+        Returns
+        -------
+        output_dict
+            Completed output
+        """
+        return output.as_dict()
 
     def explain_prediction(
         self, prediction: Dict[str, numpy.array], instance: Instance

--- a/src/biome/text/modules/heads/doc_classification.py
+++ b/src/biome/text/modules/heads/doc_classification.py
@@ -173,7 +173,7 @@ class DocumentClassification(ClassificationHead):
             embedded_text = self.feedforward(embedded_text)
 
         logits = self._classification_layer(embedded_text)
-        return self.calculate_output(logits=logits, label=None).probs
+        return logits
 
 
 class DocumentClassificationSpec(ComponentSpec[DocumentClassification]):

--- a/src/biome/text/modules/heads/text_classification.py
+++ b/src/biome/text/modules/heads/text_classification.py
@@ -123,9 +123,8 @@ class TextClassification(ClassificationHead):
         if self.feedforward:
             embedded_text = self.feedforward.forward(embedded_text)
         logits = self._classification_layer(embedded_text)
-        output = self.calculate_output(logits=logits, label=None)
         # TODO: review what kind of information we need to pass
-        return output.probs
+        return logits
 
 
 class TextClassificationSpec(ComponentSpec[TextClassification]):


### PR DESCRIPTION
This PR moves the calculation of the probabilities and other UI stuff to the `decode` method, that is only called for predictions.

@frascuchon I left one TODO about the duplicated information in `output.label` and `output.max_class`. I guess removing one or the other has implications for the UI, but we should only use one of the keys.