### PR TITLE
Fix trainer config params bucketing and cache always True

### DIFF
--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -220,7 +220,7 @@ class TrainerConfiguration:
         # Data Iteration
         self.batch_size = batch_size or 32
         self.data_bucketing = data_bucketing
-        self.cache_instances = cache_instances or True
+        self.cache_instances = cache_instances
         self.in_memory_batches = in_memory_batches
 
 

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -219,7 +219,7 @@ class TrainerConfiguration:
 
         # Data Iteration
         self.batch_size = batch_size or 32
-        self.data_bucketing = data_bucketing or True
+        self.data_bucketing = data_bucketing
         self.cache_instances = cache_instances or True
         self.in_memory_batches = in_memory_batches
 


### PR DESCRIPTION
Small fix for default boolean params which were always `True` even when config was set to `False`.

