### PR TITLE
refactor: use fbeta score to simplify metrics for classifiers

### DIFF
--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -94,9 +94,8 @@ def split_signature_params_by_predicate(
 
 
 def clean_metric_name(name):
-    if name is not None:
-        new_name = _INVALID_TAG_CHARACTERS.sub("_", name)
-        new_name = new_name.lstrip("/")
-        if new_name != name:
-            name = new_name
-    return name
+    if not name:
+        return name
+    new_name = _INVALID_TAG_CHARACTERS.sub("_", name)
+    new_name = new_name.lstrip("/")
+    return new_name

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import re
 from inspect import Parameter
 from typing import Any, Callable, Dict, List, Tuple, Type
 
@@ -7,6 +8,8 @@ import yaml
 from elasticsearch import Elasticsearch
 
 from . import environment
+
+_INVALID_TAG_CHARACTERS = re.compile(r"[^-/\w\.]")
 
 
 def yaml_to_dict(filepath: str) -> Dict[str, Any]:
@@ -88,3 +91,12 @@ def split_signature_params_by_predicate(
     non_matches_group = list(filter(lambda p: not predicate(p), parameters))
 
     return matches_group, non_matches_group
+
+
+def clean_metric_name(name):
+    if name is not None:
+        new_name = _INVALID_TAG_CHARACTERS.sub("_", name)
+        new_name = new_name.lstrip("/")
+        if new_name != name:
+            name = new_name
+    return name

--- a/src/biome/text/modules/heads/classification/defs.py
+++ b/src/biome/text/modules/heads/classification/defs.py
@@ -8,6 +8,7 @@ from allennlp.training.metrics import CategoricalAccuracy, F1Measure, FBetaMeasu
 from biome.text.backbone import ModelBackbone
 from biome.text import vocabulary
 from ..defs import TaskHead, TaskName, TaskOutput
+from biome.text import helpers
 
 
 class ClassificationHead(TaskHead):
@@ -152,15 +153,22 @@ class ClassificationHead(TaskHead):
         """
         metrics = {}
         for name, metric in self.metrics.items():
-            if name == 'accuracy':
-                metrics['accuracy'] = metric.get_metric(reset)
-            elif name in ['macro', 'micro']:
-                metrics.update({'{}/{}'.format(name, k): v for k, v in metric.get_metric(reset).items()})
-            elif name == 'per_label':
+            if name == "accuracy":
+                metrics["accuracy"] = metric.get_metric(reset)
+            elif name in ["macro", "micro"]:
+                metrics.update(
+                    {
+                        "{}/{}".format(name, k): v
+                        for k, v in metric.get_metric(reset).items()
+                    }
+                )
+            elif name == "per_label":
                 for k, values in metric.get_metric(reset).items():
                     for i, v in enumerate(values):
                         label = vocabulary.label_for_index(self.backbone.vocab, i)
-                        metrics.update({'{}/{}'.format(k, label): v})
+                        # sanitize label using same patters as tensorboardX to avoid warnings
+                        label = helpers.clean_metric_name(label)
+                        metrics.update({"{}/{}".format(k, label): v})
         return metrics
 
     def single_label_output(

--- a/src/biome/text/modules/heads/classification/defs.py
+++ b/src/biome/text/modules/heads/classification/defs.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Union
 import torch
 from allennlp.data import Instance
 from allennlp.data.fields import LabelField, MultiLabelField
-from allennlp.training.metrics import CategoricalAccuracy, F1Measure
+from allennlp.training.metrics import CategoricalAccuracy, F1Measure, FBetaMeasure
 
 from biome.text.backbone import ModelBackbone
 from biome.text import vocabulary
@@ -31,9 +31,14 @@ class ClassificationHead(TaskHead):
             # TODO: for multi-label we want to calculate F1 per label and/or ROC-AUC
             self._loss = torch.nn.BCEWithLogitsLoss()
         else:
-            # metrics, some AllenNLP models use the names _accuracy or _metrics, so we have to be more specific.
             self.metrics.update(
-                {label: F1Measure(index) for index, label in enumerate(self.labels)}
+                {
+                    "micro": FBetaMeasure(average="micro"),
+                    "macro": FBetaMeasure(average="macro"),
+                    "per_label": FBetaMeasure(
+                        labels=[i for i in range(0, len(labels) - 1)]
+                    ),
+                }
             )
             self._loss = torch.nn.CrossEntropyLoss()
 
@@ -145,34 +150,18 @@ class ClassificationHead(TaskHead):
         -------
         A dictionary with all metric names and values.
         """
-
-        # TODO: Refactor and simplify
-        all_metrics = {}
-
-        total_f1 = 0.0
-        total_precision = 0.0
-        total_recall = 0.0
-        for metric_name, metric in self.metrics.items():
-            if metric_name == "accuracy":
-                all_metrics["accuracy"] = metric.get_metric(reset)
-            else:
-                # pylint: disable=invalid-name
-                precision, recall, f_1 = metric.get_metric(
-                    reset
-                )  # pylint: disable=invalid-name
-                total_f1 += f_1
-                total_precision += precision
-                total_recall += recall
-                all_metrics[metric_name + "/f1"] = f_1
-                all_metrics[metric_name + "/precision"] = precision
-                all_metrics[metric_name + "/recall"] = recall
-
-        num_classes = self.num_labels
-        all_metrics["average/f1"] = total_f1 / num_classes
-        all_metrics["average/precision"] = total_precision / num_classes
-        all_metrics["average/recall"] = total_recall / num_classes
-
-        return all_metrics
+        metrics = {}
+        for name, metric in self.metrics.items():
+            if name == 'accuracy':
+                metrics['accuracy'] = metric.get_metric(reset)
+            elif name in ['macro', 'micro']:
+                metrics.update({'{}/{}'.format(name, k): v for k, v in metric.get_metric(reset).items()})
+            elif name == 'per_label':
+                for k, values in metric.get_metric(reset).items():
+                    for i, v in enumerate(values):
+                        label = vocabulary.label_for_index(self.backbone.vocab, i)
+                        metrics.update({'{}/{}'.format(k, label): v})
+        return metrics
 
     def single_label_output(
         self, logits: torch.Tensor, label: Optional[torch.IntTensor] = None,


### PR DESCRIPTION
First version, still missing:

- Cleanup metric names to avoid tensorboard renaming during training.
- maybe simplify the get_metrics function with a helper function.
- @frascuchon @dcfidalgo I would like to make the per_label metrics configurable in classification heads, sometimes you don't want such level of detail and it makes very large logs, metric results files. But sometimes is very useful to have separate metrics for labels. I was thinking about a bool like `log_per_label_metrics` , what do you think?