### PR TITLE
refactor: allow create and load vocabulary for pipelines from scratch

### DIFF
--- a/examples/1.text_classifier/text_classifier.py
+++ b/examples/1.text_classifier/text_classifier.py
@@ -12,6 +12,7 @@ if __name__ == "__main__":
     training_folder = "experiment"
 
     pl = Pipeline.from_yaml("text_classifier.yaml")
+
     print(pl.predict(text="Header main. This is a test body!!!"))
 
     pl.create_vocabulary(

--- a/examples/1.text_classifier/text_classifier.py
+++ b/examples/1.text_classifier/text_classifier.py
@@ -1,6 +1,9 @@
 import os
 
-from biome.text import Pipeline, VocabularyConfiguration, TrainerConfiguration
+from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration
+
+from biome.text.data import DataSource
+from biome.text.featurizer import WordFeatures
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
@@ -8,20 +11,25 @@ if __name__ == "__main__":
     validation = "validation.data.yml"
     training_folder = "experiment"
 
-    pl = Pipeline.from_yaml(
-        "text_classifier.yaml", vocab_path=os.path.join(training_folder, "vocabulary")
-    )
-
+    pl = Pipeline.from_yaml("text_classifier.yaml")
     print(pl.predict(text="Header main. This is a test body!!!"))
+
+    pl.create_vocabulary(
+        VocabularyConfiguration(
+            sources=[DataSource.from_yaml(path) for path in [train, validation]],
+            min_count={WordFeatures.namespace: 5},
+        )
+    )
 
     trainer_configuration = TrainerConfiguration(**yaml_to_dict("trainer.yml"))
     trainer_configuration.data_bucketing = False
+
     pl.train(
         output=training_folder,
         trainer=trainer_configuration,
         training=train,
         validation=validation,
-        extend_vocab=VocabularyConfiguration(sources=[train, validation]),
+        restore=True,
     )
 
     trained_pl = Pipeline.from_pretrained(os.path.join(training_folder, "model.tar.gz"))

--- a/examples/1.text_classifier/text_classifier.yaml
+++ b/examples/1.text_classifier/text_classifier.yaml
@@ -9,7 +9,7 @@ features:
     words:
         embedding_dim: 300
         lowercase_tokens: true
-        weights_file: https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.es.300.vec.gz
+        # weights_file: https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.es.300.vec.gz
     chars:
         embedding_dim: 8
         encoder:

--- a/examples/1.text_classifier/text_classifier.yaml
+++ b/examples/1.text_classifier/text_classifier.yaml
@@ -16,7 +16,12 @@ features:
             num_filters: 50
             ngram_filter_sizes: [ 4 ]
         dropout: 0.2
-
+        embedder:
+            embedding:
+                padding_index: 0
+        indexer:
+            character_tokenizer:
+                lowercase_characters: true
 
 encoder:
     hidden_size: 10

--- a/examples/1.text_classifier/text_classifier.yaml
+++ b/examples/1.text_classifier/text_classifier.yaml
@@ -7,8 +7,9 @@ tokenizer:
 
 features:
     words:
-        embedding_dim: 100
+        embedding_dim: 300
         lowercase_tokens: true
+        weights_file: https://dl.fbaipublicfiles.com/fasttext/vectors-crawl/cc.es.300.vec.gz
     chars:
         embedding_dim: 8
         encoder:

--- a/examples/1.text_classifier/train.data.yml
+++ b/examples/1.text_classifier/train.data.yml
@@ -1,4 +1,4 @@
-path: ../data/train.csv
+source: ../data/train.csv
 format: csv
 mapping:
   label: target

--- a/examples/1.text_classifier/validation.data.yml
+++ b/examples/1.text_classifier/validation.data.yml
@@ -1,4 +1,4 @@
-path: ../data/validation.csv
+source: ../data/validation.csv
 format: csv
 mapping:
   label: target

--- a/examples/2.document_classifier/doc_interpret.py
+++ b/examples/2.document_classifier/doc_interpret.py
@@ -4,10 +4,8 @@ if __name__ == "__main__":
     trained_pl = Pipeline.from_pretrained("experiment/model.tar.gz")
 
     document = [
-        "Prrrt",
-        "The simple file enormeous sentence length",
-        "Another sentence",
+        "this is my email subject",
+        "A very long body. I have many sentences. I am writing very boring, long emails.",
     ]
-    another_document = ["Uno", "Uno dos", "uno dos tres"]
-    print(trained_pl.explain(document=another_document))
+    print(trained_pl.explain(document=document))
     trained_pl.serve()

--- a/examples/2.document_classifier/document_classifier.py
+++ b/examples/2.document_classifier/document_classifier.py
@@ -1,8 +1,8 @@
 from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration
+from biome.text.data import DataSource
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
-
     pl = Pipeline.from_yaml("document_classifier.yaml", vocab_path="not_found_folder")
     print(f"Pipeline parameters: {pl.trainable_parameter_names}")
     print(f"Trainable parameters: {pl.trainable_parameters}")
@@ -20,14 +20,16 @@ if __name__ == "__main__":
     )
 
     trainer = TrainerConfiguration(**yaml_to_dict("trainer.yml"))
+    pl.create_vocabulary(
+        VocabularyConfiguration(
+            sources=[DataSource.from_yaml("train.data.yml")], min_count={"words": 10}
+        )
+    )
     pl.train(
         output="experiment",
         trainer=trainer,
         training="train.data.yml",
         validation="validation.data.yml",
-        extend_vocab=VocabularyConfiguration(
-            sources=["train.data.yml"], min_count={"words": 10}
-        ),
     )
 
     pl = Pipeline.from_pretrained("experiment/model.tar.gz")

--- a/examples/2.document_classifier/train.data.yml
+++ b/examples/2.document_classifier/train.data.yml
@@ -1,4 +1,4 @@
-path: ../data/train.csv
+source: ../data/train.csv
 format: csv
 mapping:
   label: target

--- a/examples/2.document_classifier/validation.data.yml
+++ b/examples/2.document_classifier/validation.data.yml
@@ -1,4 +1,4 @@
-path: ../data/validation.csv
+source: ../data/validation.csv
 format: csv
 mapping:
   label: target

--- a/examples/3.email_classifier/email_classifier.py
+++ b/examples/3.email_classifier/email_classifier.py
@@ -1,4 +1,5 @@
 from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration
+from biome.text.data import DataSource
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
@@ -11,14 +12,17 @@ if __name__ == "__main__":
             body="The next phrase is here",
         )
     )
+    pl.create_vocabulary(
+        VocabularyConfiguration(sources=[DataSource.from_yaml("validation.data.yml")])
+    )
 
     trainer = TrainerConfiguration(**yaml_to_dict("trainer.yml"))
+
     pl.train(
         output="experiment",
         trainer=trainer,
         training="train.data.yml",
         validation="validation.data.yml",
-        extend_vocab=VocabularyConfiguration(sources=["validation.data.yml"]),
     )
 
     trained = Pipeline.from_pretrained("experiment/model.tar.gz")

--- a/examples/3.email_classifier/train.data.yml
+++ b/examples/3.email_classifier/train.data.yml
@@ -1,4 +1,4 @@
-path: ../data/train.csv
+source: ../data/train.csv
 format: csv
 mapping:
   label: target

--- a/examples/3.email_classifier/validation.data.yml
+++ b/examples/3.email_classifier/validation.data.yml
@@ -1,4 +1,4 @@
-path: ../data/validation.csv
+source: ../data/validation.csv
 format: csv
 mapping:
   label: target

--- a/examples/4.language_model/classifier_from_scratch.py
+++ b/examples/4.language_model/classifier_from_scratch.py
@@ -1,16 +1,17 @@
 from biome.text import Pipeline, VocabularyConfiguration
 from biome.text import TrainerConfiguration
+from biome.text.data import DataSource
 from biome.text.helpers import yaml_to_dict
+
 
 if __name__ == "__main__":
     pl = Pipeline.from_yaml("configs/text_classifier.yml")
+    sources = [DataSource.from_yaml("configs/train.data.yml")]
+    pl.create_vocabulary(VocabularyConfiguration(sources, min_count={"words": 12}))
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
     pl.train(
         output="experiment_text_classifier",
         trainer=trainer,
         training="configs/train.data.yml",
         validation="configs/val.data.yml",
-        extend_vocab=VocabularyConfiguration(
-            sources=["configs/train.data.yml"], min_count={"words": 12}
-        ),
     )

--- a/examples/4.language_model/configs/train.data.yml
+++ b/examples/4.language_model/configs/train.data.yml
@@ -1,3 +1,3 @@
-path: ../data/business.cat.10K.csv
+source: ../data/business.cat.10K.csv
 format: csv
 

--- a/examples/4.language_model/configs/val.data.yml
+++ b/examples/4.language_model/configs/val.data.yml
@@ -1,3 +1,3 @@
-path: ../data/business.cat.30.csv
+source: ../data/business.cat.30.csv
 format: csv
 

--- a/examples/4.language_model/pretrain_lm.py
+++ b/examples/4.language_model/pretrain_lm.py
@@ -1,4 +1,5 @@
 from biome.text import Pipeline, VocabularyConfiguration, TrainerConfiguration
+from biome.text.data import DataSource
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
@@ -6,13 +7,16 @@ if __name__ == "__main__":
     validation = "configs/val.data.yml"
 
     pl = Pipeline.from_yaml("configs/language_model.yml")
+    pl.create_vocabulary(
+        VocabularyConfiguration(
+            sources=[DataSource.from_yaml(path) for path in [train, validation]],
+            min_count={"words": 12},
+        )
+    )
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
     pl.train(
         output="configs/experiment_lm",
         trainer=trainer,
         training=train,
         validation=validation,
-        extend_vocab=VocabularyConfiguration(
-            sources=[train, validation], min_count={"words": 12}
-        ),
     )

--- a/examples/5.ner/configs/train.data.yml
+++ b/examples/5.ner/configs/train.data.yml
@@ -1,4 +1,4 @@
-path: ../data/ner.drugs.train.jsonl
+source: ../data/ner.drugs.train.jsonl
 format: json
 mapping:
   labels: labels

--- a/examples/5.ner/configs/validation.data.yml
+++ b/examples/5.ner/configs/validation.data.yml
@@ -1,4 +1,4 @@
-path: ../data/ner.drugs.train.jsonl
+source: ../data/ner.drugs.train.jsonl
 format: json
 mapping:
   labels: labels

--- a/examples/5.ner/train_ner.py
+++ b/examples/5.ner/train_ner.py
@@ -1,14 +1,20 @@
 from biome.text import Pipeline, VocabularyConfiguration
 from biome.text import TrainerConfiguration
+from biome.text.data import DataSource
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
     pl = Pipeline.from_yaml("configs/char_gru_token_classifier.yml")
+    pl.create_vocabulary(
+        VocabularyConfiguration(
+            sources=[DataSource.from_yaml("configs/train.data.yml")]
+        )
+    )
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
+
     pl.train(
         output="experiment",
         trainer=trainer,
         training="configs/train.data.yml",
         validation="configs/validation.data.yml",
-        extend_vocab=VocabularyConfiguration(sources=["configs/train.data.yml"]),
     )

--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -158,9 +158,9 @@ class PipelineModel(allennlp.models.Model, allennlp.data.DatasetReader):
     def set_vocab(self, vocab: Vocabulary):
         """Replace the current vocab and reload all model layer"""
         self.vocab = vocab
-        # TODO: remove vocab argument and use already updated self.vocab
-        self._head.backbone._update_vocab(vocab)  # pylint: disable=protected-access
-        self._head._update_vocab(vocab)  # pylint: disable=protected-access
+        self._head.backbone.vocab = vocab
+        self._head.backbone.on_vocab_update()
+        self._head.on_vocab_update()
 
     @property
     def inputs(self) -> List[str]:

--- a/src/biome/text/backbone.py
+++ b/src/biome/text/backbone.py
@@ -60,10 +60,8 @@ class ModelBackbone(torch.nn.Module):
         embeddings = self.embedder(text, num_wrapping_dims=num_wrapping_dims)
         return self.encoder(embeddings, mask=mask)
 
-    def _update_vocab(self, vocab: Vocabulary, **kwargs):
+    def on_vocab_update(self):
         """This method is called when a base model updates the vocabulary"""
-        self.vocab = vocab
-
         # This loop applies only for embedding layer.
         for model_path, module in self.named_modules():
             if hasattr(module, "extend_vocab"):

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Type, Union
 
 from allennlp.common import FromParams, Params
 from allennlp.data import Vocabulary
+from biome.text.data import DataSource
 
 from .featurizer import CharFeatures, InputFeaturizer, WordFeatures
 from .modules.encoders import Encoder
@@ -233,8 +234,8 @@ class VocabularyConfiguration:
 
     Parameters
     ----------
-    sources : `List[str]`
-        Datasource paths to be used for data creation
+    sources : `List[DataSource]`
+        Datasource to be used for data creation
     min_count : `Dict[str, int]`, optional (default=None)
         Minimum number of appearances of a token to be included in the vocabulary
     max_vocab_size :  `Union[int, Dict[str, int]]`, optional (default=`None`)
@@ -251,7 +252,7 @@ class VocabularyConfiguration:
 
     def __init__(
         self,
-        sources: List[str],
+        sources: List[DataSource],
         min_count: Dict[str, int] = None,
         max_vocab_size: Union[int, Dict[str, int]] = None,
         pretrained_files: Optional[Dict[str, str]] = None,

--- a/src/biome/text/errors.py
+++ b/src/biome/text/errors.py
@@ -24,6 +24,10 @@ class MissingArgumentError(ValidationError):
         return f"Missing argument '{self.arg_name}'"
 
 
+class ActionNotSupportedError(ValidationError):
+    """Raised when an action is not supported for a given component state"""
+
+
 class EmptyVocabError(ValidationError):
     """Error related with using empty vocabs for a training"""
 

--- a/src/biome/text/modules/heads/defs.py
+++ b/src/biome/text/modules/heads/defs.py
@@ -57,11 +57,7 @@ class TaskHead(torch.nn.Module, Registrable):
         super(TaskHead, self).__init__()
         self.backbone = backbone
 
-    def _update_vocab(self, vocab: Vocabulary, **kwargs):
-        """This method is automatically called when a vocab is updated"""
-        self._on_vocab_update()
-
-    def _on_vocab_update(self):
+    def on_vocab_update(self):
         """
         Actions when vocab is updated. Rebuild here modules that initialization depends on some vocab metric
 

--- a/src/biome/text/modules/heads/language_modelling.py
+++ b/src/biome/text/modules/heads/language_modelling.py
@@ -73,7 +73,7 @@ class LanguageModelling(TaskHead):
             embedding_dim=self.backbone.encoder.get_output_dim(),
         )
 
-    def _on_vocab_update(self):
+    def on_vocab_update(self):
         self._loss = SoftmaxLoss(
             num_words=vocabulary.words_vocab_size(self.backbone.vocab),
             embedding_dim=self.backbone.encoder.get_output_dim(),

--- a/src/biome/text/vocabulary.py
+++ b/src/biome/text/vocabulary.py
@@ -5,13 +5,16 @@
 
     Provides management actions such as extending the labels, setting new labels or creating an "empty" vocab.
 """
-from typing import Dict, List
+import logging
+from typing import Dict, List, Optional
 
 from allennlp.data import Vocabulary
 from allennlp.data.vocabulary import DEFAULT_OOV_TOKEN
 from biome.text.featurizer import WordFeatures
 
 LABELS_NAMESPACE = "gold_labels"
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def get_labels(vocab: Vocabulary) -> List[str]:
@@ -153,3 +156,26 @@ def is_empty(vocab: Vocabulary, namespaces: List[str]) -> bool:
         if vocab.get_vocab_size(namespaces) > 2:
             return False
     return True
+
+
+def load_vocabulary(vocab_path: str) -> Optional[Vocabulary]:
+    """
+    Loads a vocabulary from a path
+    Parameters
+    ----------
+    vocab_path: str
+        The vocab folder path
+
+    Returns
+    -------
+    An operative `allennlp.data.Vocabulary`
+    """
+    try:
+        if not vocab_path:
+            return None
+        return Vocabulary.from_files(vocab_path)
+    except TypeError:
+        return None
+    except FileNotFoundError:
+        _LOGGER.warning("%s folder not found", vocab_path)
+        return None

--- a/tests/text/pipelines/test_bimpm.py
+++ b/tests/text/pipelines/test_bimpm.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 from biome.text import TrainerConfiguration, VocabularyConfiguration
 from biome.text import Pipeline
+from biome.text.data import DataSource
 
 
 @pytest.fixture
@@ -180,12 +181,15 @@ def test_bimpm_train(
 ):
     pipeline = Pipeline.from_yaml(path_to_pipeline_yaml,)
     pipeline.predict(record1="The one", record2="The other")
+    pipeline.create_vocabulary(
+        VocabularyConfiguration(
+            sources=[DataSource.from_yaml(path_to_training_data_yaml)]
+        )
+    )
 
     pipeline.train(
         output="experiment",
         trainer=TrainerConfiguration(**trainer_dict),
         training=path_to_training_data_yaml,
         validation=path_to_training_data_yaml,
-        restore=False,
-        extend_vocab=VocabularyConfiguration(sources=[path_to_training_data_yaml]),
     )


### PR DESCRIPTION
This PR defines a better vocabulary creation flow. Includes two method to `Pipeline` class for this purpose.

For create or load a vocabulary for a "from-scratch" pipeline you can do as follow:

```python
pipeline = Pipeline.from_yaml("your_config.yaml")
pipeline.create_vocabulary(vocab_config=VocabularyConfiguration(....))
# or, if you want to use an already created vocab
# pipeline.load_vocabulary("path/to/your/vocab/folder")

pipeline.train(....)
```

The vocab creation/load is not allowed for pretrained pipelines, raising an error.

Also, this flow restrict the vocab extension config (in training) only to pretrained pipelines, raising an error if you tries to extend a vocab for an "from-scratch" pipeline.
