### PR TITLE
pipeline.train accepts `DataSource`s

### DIFF
--- a/examples/1.text_classifier/text_classifier.py
+++ b/examples/1.text_classifier/text_classifier.py
@@ -7,8 +7,8 @@ from biome.text.featurizer import WordFeatures
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
-    train = "train.data.yml"
-    validation = "validation.data.yml"
+    train = DataSource.from_yaml("train.data.yml")
+    validation = DataSource.from_yaml("validation.data.yml")
     training_folder = "experiment"
 
     pl = Pipeline.from_yaml("text_classifier.yaml")
@@ -17,7 +17,7 @@ if __name__ == "__main__":
 
     pl.create_vocabulary(
         VocabularyConfiguration(
-            sources=[DataSource.from_yaml(path) for path in [train, validation]],
+            sources=[train, validation],
             min_count={WordFeatures.namespace: 5},
         )
     )
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     trained_pl.predict(text="Header main; This is a test body!!!")
     trained_pl.head.extend_labels(["other"])
     trained_pl.explore(
-        explore_id="test-trained", ds_path="validation.data.yml", explain=True
+        explore_id="test-trained", data_source=validation, explain=True
     )
 
     trainer_configuration.batch_size = 8
@@ -52,4 +52,4 @@ if __name__ == "__main__":
     trained_pl.predict(text="Header main. This is a test body!!!")
 
     pl.head.extend_labels(["yes", "no"])
-    pl.explore(ds_path="validation.data.yml")
+    pl.explore(data_source=validation)

--- a/examples/2.document_classifier/document_classifier.py
+++ b/examples/2.document_classifier/document_classifier.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     pl.predict(
         document=["Header main. This is a test body!!!", "The next phrase is here"]
     )
-    pl.explore(ds_path="validation.data.yml")
+    pl.explore(data_source="validation.data.yml")
 
     trained_pl = Pipeline.from_pretrained("experiment/model.tar.gz")
-    trained_pl.explore(ds_path="validation.data.yml")
+    trained_pl.explore(data_source="validation.data.yml")

--- a/examples/2.document_classifier/document_classifier.py
+++ b/examples/2.document_classifier/document_classifier.py
@@ -19,24 +19,28 @@ if __name__ == "__main__":
         )
     )
 
-    trainer = TrainerConfiguration(**yaml_to_dict("trainer.yml"))
+    training_ds = DataSource.from_yaml("train.data.yml")
+    validation_ds = DataSource.from_yaml("validation.data.yml")
     pl.create_vocabulary(
         VocabularyConfiguration(
-            sources=[DataSource.from_yaml("train.data.yml")], min_count={"words": 10}
+            sources=[training_ds, validation_ds], min_count={"words": 10}
         )
     )
+
+    trainer = TrainerConfiguration(**yaml_to_dict("trainer.yml"))
+
     pl.train(
         output="experiment",
         trainer=trainer,
-        training="train.data.yml",
-        validation="validation.data.yml",
+        training=training_ds,
+        validation=validation_ds,
     )
 
     pl = Pipeline.from_pretrained("experiment/model.tar.gz")
     pl.predict(
         document=["Header main. This is a test body!!!", "The next phrase is here"]
     )
-    pl.explore(data_source="validation.data.yml")
+    pl.explore(data_source=validation_ds)
 
     trained_pl = Pipeline.from_pretrained("experiment/model.tar.gz")
-    trained_pl.explore(data_source="validation.data.yml")
+    trained_pl.explore(data_source=validation_ds)

--- a/examples/3.email_classifier/email_classifier.py
+++ b/examples/3.email_classifier/email_classifier.py
@@ -12,8 +12,10 @@ if __name__ == "__main__":
             body="The next phrase is here",
         )
     )
+    training_ds = DataSource.from_yaml("train.data.yml")
+    validation_ds = DataSource.from_yaml("validation.data.yml")
     pl.create_vocabulary(
-        VocabularyConfiguration(sources=[DataSource.from_yaml("validation.data.yml")])
+        VocabularyConfiguration(sources=[training_ds, validation_ds])
     )
 
     trainer = TrainerConfiguration(**yaml_to_dict("trainer.yml"))
@@ -21,8 +23,8 @@ if __name__ == "__main__":
     pl.train(
         output="experiment",
         trainer=trainer,
-        training="train.data.yml",
-        validation="validation.data.yml",
+        training=training_ds,
+        validation=validation_ds,
     )
 
     trained = Pipeline.from_pretrained("experiment/model.tar.gz")
@@ -30,4 +32,4 @@ if __name__ == "__main__":
         subject="Header main. This is a test body!!!", body="The next phrase is here"
     )
     trained.head.extend_labels(["other"])
-    trained.explore(data_source="validation.data.yml")
+    trained.explore(data_source=validation_ds)

--- a/examples/3.email_classifier/email_classifier.py
+++ b/examples/3.email_classifier/email_classifier.py
@@ -30,4 +30,4 @@ if __name__ == "__main__":
         subject="Header main. This is a test body!!!", body="The next phrase is here"
     )
     trained.head.extend_labels(["other"])
-    trained.explore(ds_path="validation.data.yml")
+    trained.explore(data_source="validation.data.yml")

--- a/examples/4.language_model/classifier_from_scratch.py
+++ b/examples/4.language_model/classifier_from_scratch.py
@@ -6,12 +6,16 @@ from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
     pl = Pipeline.from_yaml("configs/text_classifier.yml")
-    sources = [DataSource.from_yaml("configs/train.data.yml")]
-    pl.create_vocabulary(VocabularyConfiguration(sources, min_count={"words": 12}))
+
+    training_ds = DataSource.from_yaml("configs/train.data.yml")
+    validation_ds = DataSource.from_yaml("configs/val.data.yml")
+    pl.create_vocabulary(VocabularyConfiguration(sources=[training_ds], min_count={"words": 12}))
+
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
+
     pl.train(
         output="experiment_text_classifier",
         trainer=trainer,
-        training="configs/train.data.yml",
-        validation="configs/val.data.yml",
+        training=training_ds,
+        validation=validation_ds,
     )

--- a/examples/4.language_model/finetune_classifier.py
+++ b/examples/4.language_model/finetune_classifier.py
@@ -2,6 +2,7 @@ from biome.text import Pipeline
 from biome.text import TrainerConfiguration
 from biome.text.helpers import yaml_to_dict
 from biome.text.modules.heads import TextClassification
+from biome.text.data import DataSource
 
 if __name__ == "__main__":
     # load an existing pre-trained model
@@ -37,6 +38,6 @@ if __name__ == "__main__":
     pipe.train(
         output="text_classifier_fine_tuned",
         trainer=trainer,
-        training="configs/train.data.yml",
-        validation="configs/val.data.yml",
+        training=DataSource.from_yaml("configs/train.data.yml"),
+        validation=DataSource.from_yaml("configs/val.data.yml"),
     )

--- a/examples/4.language_model/pretrain_lm.py
+++ b/examples/4.language_model/pretrain_lm.py
@@ -3,13 +3,13 @@ from biome.text.data import DataSource
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
-    train = "configs/train.data.yml"
-    validation = "configs/val.data.yml"
+    training_ds = DataSource.from_yaml("configs/train.data.yml")
+    validation_ds = DataSource.from_yaml("configs/val.data.yml")
 
     pl = Pipeline.from_yaml("configs/language_model.yml")
     pl.create_vocabulary(
         VocabularyConfiguration(
-            sources=[DataSource.from_yaml(path) for path in [train, validation]],
+            sources=[training_ds, validation_ds],
             min_count={"words": 12},
         )
     )
@@ -17,6 +17,6 @@ if __name__ == "__main__":
     pl.train(
         output="configs/experiment_lm",
         trainer=trainer,
-        training=train,
-        validation=validation,
+        training=training_ds,
+        validation=validation_ds,
     )

--- a/examples/5.ner/train_ner.py
+++ b/examples/5.ner/train_ner.py
@@ -4,10 +4,13 @@ from biome.text.data import DataSource
 from biome.text.helpers import yaml_to_dict
 
 if __name__ == "__main__":
+    training_ds = DataSource.from_yaml("configs/train.data.yml")
+    validation_ds = DataSource.from_yaml("configs/val.data.yml")
+
     pl = Pipeline.from_yaml("configs/char_gru_token_classifier.yml")
     pl.create_vocabulary(
         VocabularyConfiguration(
-            sources=[DataSource.from_yaml("configs/train.data.yml")]
+            sources=[training_ds]
         )
     )
     trainer = TrainerConfiguration(**yaml_to_dict("configs/trainer.yml"))
@@ -15,6 +18,6 @@ if __name__ == "__main__":
     pl.train(
         output="experiment",
         trainer=trainer,
-        training="configs/train.data.yml",
-        validation="configs/validation.data.yml",
+        training=training_ds,
+        validation=validation_ds,
     )

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             "allennlp~=1.0.0rc",
-            "gevent~=20.5.0",
+            "gevent~=1.4.0",
             "flask~=1.1.2",
             "flask-cors~=3.0.8",
             "click~=7.0.0",

--- a/src/biome/text/_configuration.py
+++ b/src/biome/text/_configuration.py
@@ -128,11 +128,11 @@ class TrainConfiguration:
              The experiment output path
         trainer: `TrainerConfiguration`
              The trainer file path
-        train_cfg: `str`
-            The train datasource file path
-        validation_cfg: `Optional[str]`
+        training: `str`
+            The training datasource file path
+        validation: `Optional[str]`
             The validation datasource file path
-        test_cfg: `Optional[str]`
+        test: `Optional[str]`
             The test datasource file path
     """
 
@@ -140,12 +140,12 @@ class TrainConfiguration:
         self,
         output: str,
         trainer: TrainerConfiguration,
-        train_cfg: str = "",
-        validation_cfg: Optional[str] = None,
-        test_cfg: Optional[str] = None,
+        training: str = "",
+        validation: Optional[str] = None,
+        test: Optional[str] = None,
     ):
         self.output = output
         self.trainer = trainer
-        self.training = train_cfg
-        self.validation = validation_cfg
-        self.test = test_cfg
+        self.training = training
+        self.validation = validation
+        self.test = test

--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -14,7 +14,6 @@ from biome.text._configuration import (
     TrainConfiguration,
     _ModelImpl,
 )
-
 from biome.text.data import DataSource
 from biome.text.errors import http_error_handling
 from biome.text.modules.encoders import TimeDistributedEncoder
@@ -140,7 +139,7 @@ def _allennlp_configuration(
 
 def _explore(
     pipeline: Pipeline,
-    ds_path: str,
+    data_source: DataSource,
     config: ExploreConfiguration,
     elasticsearch: ElasticsearchExplore,
 ) -> dd.DataFrame:
@@ -150,7 +149,7 @@ def _explore(
     Parameters
     ----------
     pipeline
-    ds_path
+    data_source
     config
     elasticsearch
 
@@ -162,7 +161,6 @@ def _explore(
         # TODO: do it
         pipeline.init_predictions_cache(config.prediction_cache)
 
-    data_source = DataSource.from_yaml(ds_path)
     ddf_mapped = data_source.to_mapped_dataframe()
     # this only makes really sense when we have a predict_batch_json method implemented ...
     n_partitions = max(1, round(len(ddf_mapped) / config.batch_size))
@@ -196,7 +194,7 @@ def _explore(
     elasticsearch.create_explore_data_record(
         {
             **(config.metadata or {}),
-            "datasource": ds_path,
+            "datasource": data_source.source,
             # TODO this should change when ui is normalized (action detail and action link naming)F
             "explore_name": elasticsearch.es_index,
             "model": pipeline.name,

--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -361,9 +361,10 @@ class PipelineModel(allennlp.models.Model, allennlp.data.DatasetReader):
         instance
             An `Instance` that is fed to the model
         """
-        data_source = DataSource.from_yaml(
-            file_path, default_mapping=self._default_ds_mapping
-        )
+        data_source = DataSource.from_yaml(file_path)
+        if not data_source.mapping:
+            data_source.mapping = self._default_ds_mapping
+
         dataframe = data_source.to_mapped_dataframe()
         instances: DaskSeries = dataframe.apply(
             lambda x: self.text_to_instance(**x.to_dict()),

--- a/src/biome/text/cli/explore.py
+++ b/src/biome/text/cli/explore.py
@@ -25,5 +25,5 @@ def _sanizite_index(index_name: str) -> str:
 @click.option("-es", "--es-host", "es_host", envvar=ES_HOST, default=DEFAULT_ES_HOST)
 def explore(data_source: str, pipeline_path: str, explain: bool, es_host: str) -> None:
     Pipeline.from_pretrained(pipeline_path).explore(
-        ds_path=data_source, es_host=es_host, explain=explain
+        data_source=data_source, es_host=es_host, explain=explain
     )

--- a/src/biome/text/data/datasource.py
+++ b/src/biome/text/data/datasource.py
@@ -220,7 +220,6 @@ class DataSource:
         }
         save_dict_as_yaml(yaml_dict, path)
 
-
         return path
 
     def head(self, n: int = 10) -> "pandas.DataFrame":  # pylint: disable=invalid-name

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -1,10 +1,12 @@
 import inspect
 import os
 import re
+import tempfile
 from inspect import Parameter
 from typing import Any, Callable, Dict, List, Tuple, Type
 
 import yaml
+from biome.text.data import DataSource
 from elasticsearch import Elasticsearch
 
 from . import environment
@@ -99,3 +101,22 @@ def clean_metric_name(name):
     new_name = _INVALID_TAG_CHARACTERS.sub("_", name)
     new_name = new_name.lstrip("/")
     return new_name
+
+
+def serialize_datasource_to_temp_yaml(data_source):
+    """Serializes data sources to a temporary yaml file
+
+    Parameters
+    ----------
+    data_source : `DataSource`
+        DataSource to be serialized
+
+    Returns
+    -------
+    temporary_yaml_path
+        If `data_source` is not a `DataSource` instance, just returns `data_source`
+    """
+    if isinstance(data_source, DataSource):
+        yaml_path = tempfile.NamedTemporaryFile(suffix=".yml", delete=False).name
+        return data_source.to_yaml(yaml_path, make_source_path_absolute=True)
+    return data_source

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -103,8 +103,8 @@ def clean_metric_name(name):
     return new_name
 
 
-def serialize_datasource_to_temp_yaml(data_source):
-    """Serializes data sources to a temporary yaml file
+def serialize_datasource_to_temp_yaml(data_source: DataSource) -> str:
+    """Serializes the data source to a temporary yaml file
 
     Parameters
     ----------
@@ -113,10 +113,9 @@ def serialize_datasource_to_temp_yaml(data_source):
 
     Returns
     -------
-    temporary_yaml_path
-        If `data_source` is not a `DataSource` instance, just returns `data_source`
+    temporary_yaml_path : str
     """
-    if isinstance(data_source, DataSource):
-        yaml_path = tempfile.NamedTemporaryFile(suffix=".yml", delete=False).name
-        return data_source.to_yaml(yaml_path, make_source_path_absolute=True)
-    return data_source
+    yaml_path = tempfile.NamedTemporaryFile(suffix=".yml", delete=False).name
+    data_source.to_yaml(yaml_path, make_source_path_absolute=True)
+
+    return yaml_path

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -101,21 +101,3 @@ def clean_metric_name(name):
     new_name = _INVALID_TAG_CHARACTERS.sub("_", name)
     new_name = new_name.lstrip("/")
     return new_name
-
-
-def serialize_datasource_to_temp_yaml(data_source: DataSource) -> str:
-    """Serializes the data source to a temporary yaml file
-
-    Parameters
-    ----------
-    data_source : `DataSource`
-        DataSource to be serialized
-
-    Returns
-    -------
-    temporary_yaml_path : str
-    """
-    yaml_path = tempfile.NamedTemporaryFile(suffix=".yml", delete=False).name
-    data_source.to_yaml(yaml_path, make_source_path_absolute=True)
-
-    return yaml_path

--- a/tests/integration/test_text_classification.py
+++ b/tests/integration/test_text_classification.py
@@ -119,12 +119,8 @@ def test_text_classification(
     pl.train(
         output=str(output),
         trainer=trainer,
-        training=train_valid_data_source[0].to_yaml(
-            str(tmp_path / "train.yml"), make_source_path_absolute=True
-        ),
-        validation=train_valid_data_source[1].to_yaml(
-            str(tmp_path / "valid.yml"), make_source_path_absolute=True
-        ),
+        training=train_valid_data_source[0],
+        validation=train_valid_data_source[1],
     )
 
     assert pl.trainable_parameters == 22070


### PR DESCRIPTION
In this PR the main change is that `Pipeline.train` and `Pipeline.explore`now also accept `DataSource`s instead of yaml files.

@frascuchon @dvsrepo Actually i would like to be a bit more radical and remove the option of passing on a yaml file path to these methods to keep the code simple and to "have only one obvious way to do stuff". Also, if you have a yaml file, you can always do:
```python
...
    training=DataSource.from_yaml(path),
...
```
What do you think?