### PR TITLE
feat(record-pair): allow compare (explain) record with missing keys

### DIFF
--- a/src/biome/text/modules/heads/record_pair_classification.py
+++ b/src/biome/text/modules/heads/record_pair_classification.py
@@ -147,6 +147,9 @@ class RecordPairClassification(ClassificationHead):
         instance
             AllenNLP instance containing the two records plus optionally a label
         """
+
+        record1, record2 = self._even_records(record1, record2)
+
         record1_instance = self.backbone.featurizer(
             record1, to_field="record", aggregate=False
         )
@@ -162,6 +165,25 @@ class RecordPairClassification(ClassificationHead):
         instance = self.add_label(instance, label)
 
         return instance
+
+    def _even_records(
+            self,
+            record1: Dict[str, Any],
+            record2: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+        """
+        Given two record dictionaries, generate two new record dictionaries,
+        with the same key structure. Values not found will be added as None
+
+        """
+        record_keys = set([key for record in [record1, record2] for key in record])
+
+        new_record_1 = {}
+        new_record_2 = {}
+        for key in record_keys:
+            new_record_1[key] = record1.get(key)
+            new_record_2[key] = record2.get(key)
+
+        return new_record_1, new_record_2
 
     def forward(
         self,  # type: ignore

--- a/src/biome/text/modules/heads/record_pair_classification.py
+++ b/src/biome/text/modules/heads/record_pair_classification.py
@@ -1,9 +1,8 @@
-from typing import Dict, List, Any, Optional, Tuple
-import numpy as np
+from typing import Any, Dict, List, Optional, Tuple
 
+import numpy as np
 import torch
-from allennlp.data import Instance
-from allennlp.data import Batch
+from allennlp.data import Batch, Instance, TextFieldTensors
 from allennlp.modules import (
     FeedForward,
     Seq2SeqEncoder,
@@ -11,19 +10,23 @@ from allennlp.modules import (
 )
 from allennlp.modules.bimpm_matching import BiMpmMatching
 from allennlp.nn import InitializerApplicator, util
+from captum.attr import IntegratedGradients
+
 from biome.text.backbone import ModelBackbone
+from biome.text.configuration import CharFeatures, WordFeatures
+from biome.text.helpers import (
+    get_char_tokens_ids_from_text_field_tensors,
+    get_word_tokens_ids_from_text_field_tensors,
+)
 from biome.text.modules.encoders import TimeDistributedEncoder
 from biome.text.modules.heads import TaskOutput
 from biome.text.modules.heads.classification.defs import ClassificationHead
 from biome.text.modules.specs import (
-    Seq2VecEncoderSpec,
-    Seq2SeqEncoderSpec,
     BiMpmMatchingSpec,
     FeedForwardSpec,
+    Seq2SeqEncoderSpec,
+    Seq2VecEncoderSpec,
 )
-from captum.attr import IntegratedGradients
-
-from biome.text.configuration import WordFeatures, CharFeatures
 
 
 class RecordPairClassification(ClassificationHead):
@@ -162,8 +165,8 @@ class RecordPairClassification(ClassificationHead):
 
     def forward(
         self,  # type: ignore
-        record1: Dict[str, torch.LongTensor],
-        record2: Dict[str, torch.LongTensor],
+        record1: TextFieldTensors,
+        record2: TextFieldTensors,
         label: torch.LongTensor = None,
     ) -> TaskOutput:
         # pylint: disable=arguments-differ
@@ -211,7 +214,7 @@ class RecordPairClassification(ClassificationHead):
         return output
 
     def _field_encoding(
-        self, record: Dict[str, torch.Tensor],
+        self, record: TextFieldTensors,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Embeds and encodes the records in a field context.
 
@@ -475,7 +478,7 @@ class RecordPairClassification(ClassificationHead):
             },
         }
 
-    def _get_field_tokens(self, record_token_ids: torch.Tensor) -> List[str]:
+    def _get_field_tokens(self, record_token_ids: TextFieldTensors) -> List[str]:
         """
         TODO: This can very likely be optimised!
         Parameters
@@ -490,7 +493,9 @@ class RecordPairClassification(ClassificationHead):
 
         if WordFeatures.namespace in record_token_ids:
             # batch size is 1 -> [0]
-            for field in record_token_ids[WordFeatures.namespace][0]:
+            for field in get_word_tokens_ids_from_text_field_tensors(record_token_ids)[
+                0
+            ]:
                 tokens = []
                 for word_idx in field:
                     # skipp padding
@@ -504,7 +509,9 @@ class RecordPairClassification(ClassificationHead):
 
         elif CharFeatures.namespace in record_token_ids:
             # batch size is 1 -> [0]
-            for field in record_token_ids[CharFeatures.namespace][0]:
+            for field in get_char_tokens_ids_from_text_field_tensors(record_token_ids)[
+                0
+            ]:
                 tokens = []
                 for word in field:
                     token = []

--- a/tests/text/modules/heads/test_record_pair_classification.py
+++ b/tests/text/modules/heads/test_record_pair_classification.py
@@ -169,6 +169,17 @@ def trainer_dict() -> Dict:
     return trainer_dict
 
 
+def test_explain(
+    path_to_pipeline_yaml
+):
+    pipeline = Pipeline.from_yaml(path_to_pipeline_yaml)
+    explain = pipeline.explain(
+        record1={"first_name": "Hans"},
+        record2={"first_name": "Hansel"},
+    )
+    assert len(explain["explain"]["record1"]) == len(explain["explain"]["record2"])
+
+
 def test_record_bimpm_train(
     path_to_pipeline_yaml, trainer_dict, path_to_training_data_yaml, tmp_path
 ):


### PR DESCRIPTION
This PR includes a minimal change to `RecordPairClassification` record featurize for even both record before generate features.

This change make available explain over records with missing keys 