### PR TITLE
fix record pair classifier explain with allennlp 1.0

### DIFF
--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import torch
-from allennlp.data import Batch, Instance
+from allennlp.data import Batch, Instance, TextFieldTensors
 from allennlp.modules import (
     FeedForward,
     Seq2SeqEncoder,
@@ -14,6 +14,10 @@ from captum.attr import IntegratedGradients
 
 from biome.text.backbone import ModelBackbone
 from biome.text.configuration import CharFeatures, WordFeatures
+from biome.text.helpers import (
+    get_char_tokens_ids_from_text_field_tensors,
+    get_word_tokens_ids_from_text_field_tensors,
+)
 from biome.text.modules.encoders import TimeDistributedEncoder
 from biome.text.modules.heads import TaskOutput
 from biome.text.modules.specs import (
@@ -161,8 +165,8 @@ class RecordPairClassification(ClassificationHead):
 
     def forward(
         self,  # type: ignore
-        record1: Dict[str, torch.LongTensor],
-        record2: Dict[str, torch.LongTensor],
+        record1: TextFieldTensors,
+        record2: TextFieldTensors,
         label: torch.LongTensor = None,
     ) -> TaskOutput:
         # pylint: disable=arguments-differ
@@ -210,7 +214,7 @@ class RecordPairClassification(ClassificationHead):
         return output
 
     def _field_encoding(
-        self, record: Dict[str, torch.Tensor],
+        self, record: TextFieldTensors,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Embeds and encodes the records in a field context.
 
@@ -474,7 +478,7 @@ class RecordPairClassification(ClassificationHead):
             },
         }
 
-    def _get_field_tokens(self, record_token_ids: torch.Tensor) -> List[str]:
+    def _get_field_tokens(self, record_token_ids: TextFieldTensors) -> List[str]:
         """
         TODO: This can very likely be optimised!
         Parameters
@@ -489,7 +493,9 @@ class RecordPairClassification(ClassificationHead):
 
         if WordFeatures.namespace in record_token_ids:
             # batch size is 1 -> [0]
-            for field in record_token_ids[WordFeatures.namespace][0]:
+            for field in get_word_tokens_ids_from_text_field_tensors(record_token_ids)[
+                0
+            ]:
                 tokens = []
                 for word_idx in field:
                     # skipp padding
@@ -503,7 +509,9 @@ class RecordPairClassification(ClassificationHead):
 
         elif CharFeatures.namespace in record_token_ids:
             # batch size is 1 -> [0]
-            for field in record_token_ids[CharFeatures.namespace][0]:
+            for field in get_char_tokens_ids_from_text_field_tensors(record_token_ids)[
+                0
+            ]:
                 tokens = []
                 for word in field:
                     token = []

--- a/tests/text/modules/heads/test_record_pair_classification.py
+++ b/tests/text/modules/heads/test_record_pair_classification.py
@@ -169,6 +169,17 @@ def trainer_dict() -> Dict:
     return trainer_dict
 
 
+def test_explain(
+    path_to_pipeline_yaml
+):
+    pipeline = Pipeline.from_yaml(path_to_pipeline_yaml)
+    explain = pipeline.explain(
+        record1={"first_name": "Hans"},
+        record2={"first_name": "Hansel"},
+    )
+    assert len(explain["explain"]["record1"]) == len(explain["explain"]["record2"])
+
+
 def test_record_bimpm_train(
     path_to_pipeline_yaml, trainer_dict, path_to_training_data_yaml, tmp_path
 ):


### PR DESCRIPTION
Allennlp 1.0 includes changes in `TextField` tensors structures passed to `forward` method. 

In previous version, those tensors was dispatched in a dictionary, where the key references to the original feature name:

```python
{
   "word": Tensor.....,
   "char": Tensor.....
}
```

Now, there is a new indexation level. The reason is not quite clear, but some source code comments refers to integration with pretrained language models:

```python
{
   "word": { "tokens" : Tensor.... } },
   "char":  { "token_characters": Tensor... } }
}
```

This change impacts directly to `RecordPairClassification` and how it explains a prediction, since the token ids are calculated from those tensor structures.

This PR fixes problems finding token ids, taking in account this new format.