### PR TITLE
fix: include ith label in metrics

### DIFF
--- a/src/biome/text/modules/heads/classification/defs.py
+++ b/src/biome/text/modules/heads/classification/defs.py
@@ -37,7 +37,7 @@ class ClassificationHead(TaskHead):
                     "micro": FBetaMeasure(average="micro"),
                     "macro": FBetaMeasure(average="macro"),
                     "per_label": FBetaMeasure(
-                        labels=[i for i in range(0, len(labels) - 1)]
+                        labels=[i for i in range(0, len(labels))]
                     ),
                 }
             )


### PR DESCRIPTION
Last label id was left out the per_label metrics calculation