### PR TITLE
feat(tokenizer): allow exclude record key on featurization

### DIFF
--- a/src/biome/text/featurizer.py
+++ b/src/biome/text/featurizer.py
@@ -39,6 +39,7 @@ class InputFeaturizer:
         to_field: str = "record",
         aggregate: bool = False,
         tokenize: bool = True,
+        exclude_record_keys: bool = False,
     ) -> Instance:
         return self(record, to_field, aggregate, tokenize,)
 
@@ -48,6 +49,7 @@ class InputFeaturizer:
         to_field: str = "record",
         aggregate: bool = False,
         tokenize: bool = True,
+        exclude_record_keys: bool = False,
     ):
 
         """
@@ -66,6 +68,8 @@ class InputFeaturizer:
             set data aggregation flag
         tokenize: `bool`
             If disabled, skip tokenization phase, and pass record data as tokenized token list.
+        exclude_record_keys: `bool`
+            If enabled, drop from tokenization tokens from record key in dictionaries featurization
 
         Returns
         -------
@@ -77,14 +81,14 @@ class InputFeaturizer:
         data = record
 
         record_tokens = (
-            self._data_tokens(data) if tokenize else [[Token(t) for t in data]]
+            self._data_tokens(data, exclude_record_keys) if tokenize else [[Token(t) for t in data]]
         )
         return Instance({to_field: self._tokens_to_field(record_tokens, aggregate)})
 
-    def _data_tokens(self, data: Any) -> List[List[Token]]:
+    def _data_tokens(self, data: Any, exclude_record_keys: bool) -> List[List[Token]]:
         """Convert data into a list of list of token depending on data type"""
         if isinstance(data, dict):
-            return self.tokenizer.tokenize_record(data)
+            return self.tokenizer.tokenize_record(data, exclude_record_keys)
         if isinstance(data, str):
             return self.tokenizer.tokenize_text(data)
         return self.tokenizer.tokenize_document(data)

--- a/src/biome/text/featurizer.py
+++ b/src/biome/text/featurizer.py
@@ -69,7 +69,7 @@ class InputFeaturizer:
         tokenize: `bool`
             If disabled, skip tokenization phase, and pass record data as tokenized token list.
         exclude_record_keys: `bool`
-            If enabled, drop from tokenization tokens from record key in dictionaries featurization
+            If enabled, excludes record keys from output tokens in dictionary featurization
 
         Returns
         -------

--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -77,7 +77,7 @@ class DocumentClassification(ClassificationHead):
         document: Any,
         label: Optional[Union[int, str, List[Union[int, str]]]] = None,
     ) -> Optional[Instance]:
-        instance = self.backbone.featurize(document, to_field=self.forward_arg_name)
+        instance = self.backbone.featurizer(document, to_field=self.forward_arg_name, exclude_record_keys=True)
         return self.add_label(instance, label, to_field=self.label_name)
 
     def forward(

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -51,7 +51,10 @@ class TextClassification(ClassificationHead):
         self, text: Any, label: Optional[Union[int, str, List[Union[int, str]]]] = None
     ) -> Optional[Instance]:
         instance = self.backbone.featurizer(
-            text, to_field=self.forward_arg_name, aggregate=True
+            text,
+            to_field=self.forward_arg_name,
+            aggregate=True,
+            exclude_record_keys=True
         )
         return self.add_label(instance, label, to_field=self.label_name)
 

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -140,7 +140,7 @@ class Tokenizer(FromParams):
             for sentence in sentences[: self.max_nr_of_sentences]
         ]
 
-    def tokenize_record(self, record: Dict[str, Any]) -> List[List[Token]]:
+    def tokenize_record(self, record: Dict[str, Any], exclude_record_keys:bool) -> List[List[Token]]:
         """ Tokenizes a record-like structure containing text inputs
         
         Use this to keep information about the record-like data structure as input features to the model.
@@ -149,6 +149,8 @@ class Tokenizer(FromParams):
         ----------
         record: `Dict[str, Any]`
             A `Dict` with arbitrary "fields" containing text.
+        exclude_record_keys: `bool`
+            If enabled, exclude tokens related to record key text
             
         Returns
         -------
@@ -156,6 +158,12 @@ class Tokenizer(FromParams):
             A list of tokenized fields as token list
         """
         data = self._sanitize_dict(record)
+        if exclude_record_keys:
+            return [
+                sentence
+                for key, value in data.items()
+                for sentence in self.tokenize_text(value)
+            ]
 
         return [
             tokenized_key + sentence


### PR DESCRIPTION
This PR adds an extra parameter to data featurization/tokenization for disable record dictionaries with record keys.

This behaviour can be interesting on record inputs without a fixed field structure. Removing the data keys from featurized data can inprove the trained model generalization.

This behaviour is applied to `DocumentClassification` and `TextClassification` forcing to use the`RecordClassification` for more strict data structures problems