### PR TITLE
implement a `PipelineConfiguration` test 

### DIFF
--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -59,7 +59,7 @@ class CharFeatures:
         self,
         embedding_dim: int,
         encoder: Dict[str, Any],
-        dropout: int = 0.0,
+        dropout: float = 0.0,
         **extra_params
     ):
         self.embedding_dim = embedding_dim

--- a/tests/text/test_configuration.py
+++ b/tests/text/test_configuration.py
@@ -1,0 +1,92 @@
+import pytest
+import yaml
+from biome.text import Pipeline
+from biome.text.configuration import (
+    PipelineConfiguration,
+    TokenizerConfiguration,
+    FeaturesConfiguration,
+    WordFeatures,
+    CharFeatures,
+    TaskHeadSpec,
+)
+from biome.text.modules.specs.allennlp_specs import Seq2SeqEncoderSpec
+
+
+@pytest.fixture
+def pipeline_yaml(tmp_path):
+    pipeline_dict = {
+        "name": "test_pipeline_config",
+        "tokenizer": {"text_cleaning": {"rules": ["strip_spaces"]},},
+        "features": {
+            "word": {"embedding_dim": 2, "lowercase_tokens": True,},
+            "char": {
+                "embedding_dim": 2,
+                "encoder": {
+                    "type": "gru",
+                    "hidden_size": 2,
+                    "num_layers": 1,
+                    "bidirectional": True,
+                },
+                "dropout": 0.1,
+            },
+        },
+        "encoder": {
+            "type": "gru",
+            "hidden_size": 2,
+            "num_layers": 1,
+            "bidirectional": True,
+        },
+        "head": {
+            "type": "TextClassification",
+            "labels": ["duplicate", "not_duplicate"],
+            "pooler": {"type": "boe",},
+        },
+    }
+
+    yaml_path = tmp_path / "pipeline.yml"
+    with yaml_path.open("w") as file:
+        yaml.safe_dump(pipeline_dict, file)
+
+    return str(yaml_path)
+
+
+def test_pipeline_config(pipeline_yaml):
+    tokenizer_config = TokenizerConfiguration(text_cleaning={"rules": ["strip_spaces"]})
+
+    word_features = WordFeatures(embedding_dim=2, lowercase_tokens=True)
+    char_features = CharFeatures(
+        embedding_dim=2,
+        encoder={
+            "type": "gru",
+            "hidden_size": 2,
+            "num_layers": 1,
+            "bidirectional": True,
+        },
+        dropout=0.1,
+    )
+    features_config = FeaturesConfiguration(word=word_features, char=char_features)
+
+    encoder_spec = Seq2SeqEncoderSpec(
+        type="gru", hidden_size=2, num_layers=1, bidirectional=True
+    )
+
+    head_spec = TaskHeadSpec(
+        type="TextClassification",
+        labels=["duplicate", "not_duplicate"],
+        pooler={"type": "boe"},
+    )
+
+    pipeline_config = PipelineConfiguration(
+        name="test_pipeline_config",
+        tokenizer=tokenizer_config,
+        features=features_config,
+        encoder=encoder_spec,
+        head=head_spec,
+    )
+
+    pl = Pipeline.from_config(pipeline_config)
+
+    pl_yaml = Pipeline.from_yaml(pipeline_yaml)
+
+    assert pl.trainable_parameter_names == pl_yaml.trainable_parameter_names
+    assert pl.trainable_parameters == pl_yaml.trainable_parameters

--- a/tests/text/test_configuration.py
+++ b/tests/text/test_configuration.py
@@ -9,6 +9,7 @@ from biome.text.configuration import (
     CharFeatures,
     TaskHeadSpec,
 )
+from biome.text.modules.heads import TextClassification
 from biome.text.modules.specs.allennlp_specs import Seq2SeqEncoderSpec
 
 
@@ -90,3 +91,6 @@ def test_pipeline_config(pipeline_yaml):
 
     assert pl.trainable_parameter_names == pl_yaml.trainable_parameter_names
     assert pl.trainable_parameters == pl_yaml.trainable_parameters
+
+    sample_text = "My simple text"
+    assert pl.backbone.featurizer(sample_text) == pl_yaml.backbone.featurizer(sample_text)


### PR DESCRIPTION
This PR adds a test for the `PipelineConfiguration` class by comparing it to a yaml file when creating a Pipeline via `Pipeline.from_yaml` versus `Pipeline.from_config`.
@frascuchon Maybe you have some more ideas for additional asserts?