### PR TITLE
implement `Pipeline.to_dict()` and `Pipeline.to_yaml()`

### DIFF
--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -49,6 +49,15 @@ class WordFeatures:
 
         return data
 
+    def to_dict(self):
+        return {
+            "embedding_dim": self.embedding_dim,
+            "lowercase_tokens": self.lowercase_tokens,
+            "trainable": self.trainable,
+            "weights_file": self.weights_file,
+            **self.extra_params,
+        }
+
 
 class CharFeatures:
     """Feature configuration at character level"""
@@ -94,3 +103,11 @@ class CharFeatures:
         data.update(data.pop("extra_params"))
 
         return data
+
+    def to_dict(self):
+        return {
+            "embedding_dim": self.embedding_dim,
+            "encoder": self.encoder,
+            "dropout": self.dropout,
+            **self.extra_params,
+        }

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -21,6 +21,7 @@ from biome.text.configuration import (
     VocabularyConfiguration,
 )
 from biome.text.data import DataSource
+from biome.text.data.helpers import save_dict_as_yaml
 from biome.text.errors import ActionNotSupportedError, EmptyVocabError
 from biome.text.helpers import update_method_signature
 from dask import dataframe as dd
@@ -496,6 +497,37 @@ class Pipeline:
         )
         vocab.extend_from_vocab(instances_vocab)
         return vocab
+
+    def to_dict(self) -> dict:
+        """Returns the pipeline configuration as a dictionary
+
+        Returns
+        -------
+        pipeline_configuration : dict
+        """
+        config_dict = self.config.as_dict()
+        config_dict["features"]["word"] = (
+            config_dict["features"]["word"].to_dict()
+            if config_dict["features"]["word"] is not None
+            else None
+        )
+        config_dict["features"]["char"] = (
+            config_dict["features"]["char"].to_dict()
+            if config_dict["features"]["char"] is not None
+            else None
+        )
+
+        return config_dict
+
+    def to_yaml(self, path: str):
+        """Saves the pipeline configuration to a yaml formatted file
+
+        Parameters
+        ----------
+        path : str
+            Path to the output file
+        """
+        save_dict_as_yaml(self.to_dict(), path)
 
 
 class _BlankPipeline(Pipeline):


### PR DESCRIPTION
This PR implements basically two new methods:
 - `Pipeline.to_dict()`
 - `Pipeline.to_yaml()`

I am not 100% about the use case, but this allows you to do:
```
pl : Pipeline
pl_copy = Pipeline.from_yaml(pl.to_yaml("path/to/config.yaml"))
```
Also i did not fully understand why `WordFeatures` and `CharFeatures` are kind of a special case when calling `PipelineConfiguration.as_dict()`, so i did not touch this method directly.