### PR TITLE
`from_config` accepts dict instead of yaml formatted string

### DIFF
--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -76,18 +76,20 @@ class Pipeline:
             A configured pipeline
         """
         with open(path) as yaml_file:
-            return cls.from_config(yaml_file.read(), vocab_path=vocab_path)
+            config_dict = yaml.safe_load(yaml_file)
+
+        return cls.from_config(config_dict, vocab_path=vocab_path)
 
     @classmethod
     def from_config(
-        cls, config: Union[str, PipelineConfiguration], vocab_path: Optional[str] = None
+        cls, config: Union[PipelineConfiguration, dict], vocab_path: Optional[str] = None
     ) -> "Pipeline":
         """Creates a pipeline from a `PipelineConfiguration` object
 
         Parameters
         ----------
-        config: `Union[str, PipelineConfiguration]`
-            A `PipelineConfiguration` object or a YAML `str` for the pipeline configuration
+        config: `Union[PipelineConfiguration, dict]`
+            A `PipelineConfiguration` object or a configuration dict
         vocab_path: `Optional[str]`
             If provided, the pipeline vocab will be loaded from this path
 
@@ -97,8 +99,8 @@ class Pipeline:
             A configured pipeline
         """
 
-        if isinstance(config, str):
-            config = PipelineConfiguration.from_params(Params(yaml.safe_load(config)))
+        if isinstance(config, dict):
+            config = PipelineConfiguration.from_params(Params(config))
         return _BlankPipeline(
             config=config, vocab=vocabulary.load_vocabulary(vocab_path)
         )

--- a/tests/integration/test_text_classification.py
+++ b/tests/integration/test_text_classification.py
@@ -103,7 +103,7 @@ def test_text_classification(
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(4222)
 
-    pl = Pipeline.from_config(yaml.safe_dump(pipeline_dict))
+    pl = Pipeline.from_config(pipeline_dict)
     trainer = TrainerConfiguration(**trainer_dict)
     vocab = VocabularyConfiguration(
         sources=[train_valid_data_source[0]], max_vocab_size={"word": 50}


### PR DESCRIPTION
When i wrote the integration test and also now the tutorials, i find myself writing something like this quite often:
```python
config_dict = {
    "name": ...,
}
import yaml
pl = Pipeline.from_config(yaml.safe_dump(config_dict, allow_unicode=True))
```
I think it would be more useful for the `.from_config()` method to accept directly dict than a yaml formatted string.