### PR TITLE
feat(explain): default explain with input tokenization

### DIFF
--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -289,7 +289,7 @@ class PipelineModel(allennlp.models.Model, allennlp.data.DatasetReader):
         ----------
         n_steps: int
             The number of steps for token attribution calculation (if proceed).
-            If the number of steps is less than 0, the attributions will not be calculated
+            If the number of steps is less than 1, the attributions will not be calculated
         args and kwargs:
             Dynamic arguments aligned to the current model head input features.
 

--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -132,7 +132,9 @@ class ClassificationHead(TaskHead):
         """
         all_classes_probs = torch.zeros(
             self.num_labels,
-            device=probabilities.get_device() if probabilities.get_device() > -1 else None,
+            device=probabilities.get_device()
+            if probabilities.get_device() > -1
+            else None,
         )
         all_classes_probs[: probabilities.size()[0]] = probabilities
         sorted_indexes_by_prob = torch.argsort(

--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -111,7 +111,7 @@ class DocumentClassification(ClassificationHead):
         return self.calculate_output(logits=logits, label=label)
 
     def explain_prediction(
-        self, prediction: Dict[str, numpy.array], instance: Instance
+        self, prediction: Dict[str, numpy.array], instance: Instance, n_steps: int
     ) -> Dict[str, Any]:
         """Here, we must apply transformations for manage ListFields tensors shapes"""
 
@@ -141,6 +141,7 @@ class DocumentClassification(ClassificationHead):
             target=label_id,
             additional_forward_args=mask,
             return_convergence_delta=True,
+            n_steps=n_steps,
         )
         # TODO: what the attribution and deltas means
         attributions = attributions.sum(dim=3).squeeze(0)

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -369,7 +369,7 @@ class RecordPairClassification(ClassificationHead):
         return matching_vector_record1_cat, matching_vector_record2_cat
 
     def explain_prediction(
-        self, prediction: Dict[str, np.array], instance: Instance
+        self, prediction: Dict[str, np.array], instance: Instance, n_steps: int
     ) -> Dict[str, Any]:
         """Calculates attributions for each data field in the record by integrating the gradients.
 
@@ -380,6 +380,7 @@ class RecordPairClassification(ClassificationHead):
         ----------
         prediction
         instance
+        n_steps
 
         Returns
         -------
@@ -439,6 +440,7 @@ class RecordPairClassification(ClassificationHead):
             additional_forward_args=(record_mask_record1, record_mask_record2),
             target=prediction_target,
             return_convergence_delta=True,
+            n_steps=n_steps,
         )
 
         ig_attribute_record2 = ig.attribute(
@@ -447,6 +449,7 @@ class RecordPairClassification(ClassificationHead):
             additional_forward_args=(record_mask_record1, record_mask_record2),
             target=prediction_target,
             return_convergence_delta=True,
+            n_steps=n_steps,
         )
 
         attributions_record1, delta_record1 = self._get_attributions_and_delta(

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -75,7 +75,7 @@ class TextClassification(ClassificationHead):
         return self.calculate_output(logits=logits, label=label)
 
     def explain_prediction(
-        self, prediction: Dict[str, numpy.array], instance: Instance
+        self, prediction: Dict[str, numpy.array], instance: Instance, n_steps: int
     ) -> Dict[str, Any]:
 
         dataset = Batch([instance])
@@ -99,6 +99,7 @@ class TextClassification(ClassificationHead):
         )
         attributions, delta = ig.attribute(
             text_embeddings,
+            n_steps=n_steps,
             target=label_id,
             additional_forward_args=mask,
             return_convergence_delta=True,

--- a/src/biome/text/modules/heads/task_head.py
+++ b/src/biome/text/modules/heads/task_head.py
@@ -123,9 +123,24 @@ class TaskHead(torch.nn.Module, Registrable):
         return output
 
     def explain_prediction(
-        self, prediction: Dict[str, numpy.array], instance: Instance
+        self, prediction: Dict[str, numpy.array], instance: Instance, n_steps: int
     ) -> Dict[str, Any]:
-        """Adds embedding explanations information to prediction output"""
+        """
+        Adds embedding explanations information to prediction output
+
+        Parameters
+        ----------
+        prediction: `Dict[str,, numpy.array]`
+            The result input predictions
+        instance: `Instance`
+            The featurized input instance
+        n_steps: int
+            The number of steps to find token level attributions
+
+        Returns
+        -------
+            Prediction with explanation
+        """
         raise {**prediction, "explain": {}}
 
 

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -298,7 +298,7 @@ class Pipeline:
 
         n_steps: int
             The number of steps for token attribution calculation (if proceed).
-            If the number of steps is less than 0, the attributions will not be calculated
+            If the number of steps is less than 1, the attributions will not be calculated
 
         Returns
         -------

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -81,7 +81,9 @@ class Pipeline:
 
     @classmethod
     def from_config(
-        cls, config: Union[PipelineConfiguration, dict], vocab_path: Optional[str] = None
+        cls,
+        config: Union[PipelineConfiguration, dict],
+        vocab_path: Optional[str] = None,
     ) -> "Pipeline":
         """Creates a pipeline from a `PipelineConfiguration` object
 
@@ -286,17 +288,24 @@ class Pipeline:
         """
         return self._model.predict(*args, **kwargs)
 
-    def explain(self, *args, **kwargs) -> Dict[str, Any]:
+    def explain(self, *args, n_steps: int = 5, **kwargs) -> Dict[str, Any]:
         """Predicts over some input data with current state of the model and provides explanations of token importance.
 
         The accepted input is dynamically calculated from head.input
+
+        Parameters
+        ----------
+
+        n_steps: int
+            The number of steps for token attribution calculation (if proceed).
+            If the number of steps is less than 0, the attributions will not be calculated
 
         Returns
         -------
         predictions: `Dict[str, numpy.ndarray]`
             A dictionary containing the predictions with token importance calculated using IntegratedGradients
         """
-        return self._model.explain(*args, **kwargs)
+        return self._model.explain(*args, n_steps=n_steps, **kwargs)
 
     def save_vocabulary(self, path: str) -> None:
         """Save the pipeline vocabulary into a path"""

--- a/tests/text/test_pipeline_model.py
+++ b/tests/text/test_pipeline_model.py
@@ -1,0 +1,60 @@
+from typing import Any, Dict
+
+import numpy
+import pytest
+from allennlp.data import Instance
+
+from biome.text import Pipeline, PipelineConfiguration
+from biome.text.backbone import ModelBackbone
+from biome.text.configuration import FeaturesConfiguration
+from biome.text.modules.heads import TaskHeadSpec, TextClassification
+
+
+class TestHead(TextClassification):
+    def __init__(self, backbone: ModelBackbone):
+        super(TestHead, self).__init__(backbone, labels=["test", "notest"])
+
+    def explain_prediction(
+        self, prediction: Dict[str, numpy.array], instance: Instance, n_steps: int
+    ) -> Dict[str, Any]:
+        return {}
+
+
+class TestHeadWithRaise(TestHead):
+    def explain_prediction(
+        self, prediction: Dict[str, numpy.array], instance: Instance, n_steps: int
+    ) -> Dict[str, Any]:
+        raise NotImplementedError
+
+
+def test_explain_tokenized_as_default():
+    pipeline_config = PipelineConfiguration(
+        name="test-classifier",
+        features=FeaturesConfiguration(),
+        head=TaskHeadSpec(type=TestHead),
+    )
+    pipeline = Pipeline.from_config(pipeline_config)
+    prediction = pipeline.explain("This is a simple test with only tokens in explain")
+    explain = prediction["explain"]
+
+    assert explain
+    assert explain.get("text")
+    for token_info in explain["text"]:
+        assert isinstance(token_info.get("token"), str)
+        assert token_info.get("attribution") == 0.0
+
+
+def test_explain_without_steps():
+    pipeline_config = PipelineConfiguration(
+        name="test-classifier",
+        features=FeaturesConfiguration(),
+        head=TaskHeadSpec(type=TestHeadWithRaise),
+    )
+    pipeline = Pipeline.from_config(pipeline_config)
+    with pytest.raises(NotImplementedError):
+        pipeline.explain("This is a simple test with only tokens in explain")
+
+    prediction = pipeline.explain(
+        "This is a simple test with only tokens in explain", n_steps=0
+    )
+    assert "explain" in prediction


### PR DESCRIPTION
This PR adds a default behaviour to `Pipeline.explain` method. 

If no explain was found/implemented, automatically generates an input tokenization as explain with no token attributions

Also, these changes exposes the number of steps (`n_steps`) for allow control attribution calculation (even deactivation if `n_steps` is less than 1.