### PR TITLE
fix(save_yaml): skip folder creation for current working routes

### DIFF
--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -178,6 +178,6 @@ def save_dict_as_yaml(dictionary: dict, path: str) -> str:
         os.makedirs(dir_name, exist_ok=True)
 
     with open(path, "w") as yml_file:
-        yaml.dump(dictionary, yml_file, default_flow_style=False)
+        yaml.dump(dictionary, yml_file, default_flow_style=False, allow_unicode=True)
 
     return path


### PR DESCRIPTION
Fix over helper function `save_as_dict_yaml` when try to save in current folder

```python
save_to_file("just-here.yml")
```

Also remove `create_dir` parameter and creates folder automatically if does not exists