### PR TITLE
fix: text cleaning and max sequence length before other tokenization processes

### DIFF
--- a/src/biome/text/text_cleaning.py
+++ b/src/biome/text/text_cleaning.py
@@ -101,4 +101,5 @@ def fix_html(text: str) -> str:
 @TextCleaningRule
 def html_to_text(text: str) -> str:
     """Extracts text from an HTML document"""
+    print(BeautifulSoup(text, "lxml").get_text())
     return BeautifulSoup(text, "lxml").get_text()


### PR DESCRIPTION
Text cleaning and max sequence length must be applied before any other process (sentence segmentation, etc.) 

Otherwise it causes issues with preproc functions (segmented html which is not cleaned by html_text) and leads to difficult to understand interactions (e.g., max seq len is only applied at the sentence level).

