### PR TITLE
feature(head) allow reference heads full qualified name

### DIFF
--- a/examples/1.text_classifier/text_classifier.yaml
+++ b/examples/1.text_classifier/text_classifier.yaml
@@ -31,7 +31,7 @@ encoder:
     type: rnn
 
 head:
-    type: TextClassification
+    type: biome.text.modules.heads.TextClassification
     labels:
         - duplicate
         - not_duplicate

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -2,7 +2,6 @@ import inspect
 import os
 import os.path
 import re
-import tempfile
 from inspect import Parameter
 from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 
@@ -181,3 +180,19 @@ def save_dict_as_yaml(dictionary: dict, path: str) -> str:
         yaml.dump(dictionary, yml_file, default_flow_style=False, allow_unicode=True)
 
     return path
+
+
+def get_full_class_name(the_class: Type) -> str:
+    """Given a type class return the full qualified class name """
+    # o.__module__ + "." + o.__class__.__qualname__ is an example in
+    # this context of H.L. Mencken's "neat, plausible, and wrong."
+    # Python makes no guarantees as to whether the __module__ special
+    # attribute is defined, so we take a more circumspect approach.
+    # Alas, the module name is explicitly excluded from __qualname__
+    # in Python 3.
+
+    module = the_class.__module__
+    if module is None or module == str.__class__.__module__:
+        return the_class.__name__  # Avoid reporting __builtin__
+    else:
+        return module + "." + the_class.__name__

--- a/src/biome/text/modules/specs/defs.py
+++ b/src/biome/text/modules/specs/defs.py
@@ -7,6 +7,8 @@ from allennlp.modules.bimpm_matching import BiMpmMatching
 from allennlp.modules.seq2seq_encoders import PytorchSeq2SeqWrapper
 from allennlp.modules.seq2vec_encoders import PytorchSeq2VecWrapper
 
+from biome.text import helpers
+
 
 def _find_input_attribute(component: Type[Any]) -> str:
     """Find the properly input dimension attribute name for a given component"""
@@ -51,7 +53,7 @@ class ComponentSpec(Generic[T], FromParams):
 
     def __init__(self, **config):
         self._layer_class = self.__resolve_layer_class(config.get("type"))
-        config["type"] = config.get("type", self._layer_class.__name__)
+        config["type"] = helpers.get_full_class_name(self._layer_class)
         self._config = config or {}
 
     def input_dim(self, input_dim: int) -> "ComponentSpec":

--- a/tests/text/test_pipeline_with_custom_head.py
+++ b/tests/text/test_pipeline_with_custom_head.py
@@ -1,0 +1,52 @@
+import os
+from tempfile import mkdtemp
+
+from biome.text import Pipeline, PipelineConfiguration
+from biome.text.configuration import (
+    FeaturesConfiguration,
+    TrainerConfiguration,
+    VocabularyConfiguration,
+)
+from biome.text.data import DataSource
+from biome.text.modules.heads import TaskHeadSpec, TextClassification
+from tests.test_context import TEST_RESOURCES
+
+
+class MyCustomHead(TextClassification):
+    """Just a head renaming the original TextClassification head"""
+
+    pass
+
+
+def test_load_pipeline_with_custom_head():
+    config = PipelineConfiguration(
+        "test-pipeline",
+        features=FeaturesConfiguration(),
+        head=TaskHeadSpec(
+            type=MyCustomHead,
+            labels=[
+                "blue-collar",
+                "technician",
+                "management",
+                "services",
+                "retired",
+                "admin.",
+            ],
+        ),
+    )
+
+    pipeline = Pipeline.from_config(config)
+    assert isinstance(pipeline.head, MyCustomHead)
+
+    train = DataSource(
+        source=os.path.join(TEST_RESOURCES, "resources/data/dataset_source.csv"),
+        mapping={"label": "job", "text": ["education", "marital"]},
+    )
+    trainer = TrainerConfiguration()
+    output = mkdtemp()
+    pipeline.create_vocabulary(VocabularyConfiguration(sources=[train]))
+    pipeline.train(output=output, training=train, trainer=trainer)
+
+    trained_pl = Pipeline.from_pretrained(os.path.join(output, "model.tar.gz"))
+    trained_pl.predict("Oh yeah")
+    assert isinstance(trained_pl.head, MyCustomHead)


### PR DESCRIPTION
We can reference heads with full qualified name in configuration. The full qualified name is composed by head module + head name.

This is useful when define non custom heads or custom head that could not be always available as part of imported module (custom head with serve command line)