### PR TITLE
fix(explore): passing missing elasticsearch params for index creation

### DIFF
--- a/src/biome/text/_configuration.py
+++ b/src/biome/text/_configuration.py
@@ -2,10 +2,10 @@ import datetime
 from typing import Any, Dict, Optional
 
 import allennlp
-from biome.text import constants
-from biome.text._model import PipelineModel
 from elasticsearch import Elasticsearch
 
+from biome.text import constants
+from biome.text._model import PipelineModel
 from . import helpers
 from .configuration import TrainerConfiguration
 
@@ -76,7 +76,12 @@ class ElasticsearchExplore:
         self.client.indices.create(
             index=constants.BIOME_METADATA_INDEX,
             body={
-                "settings": {"index": {"number_of_shards": 1, "number_of_replicas": 0}}
+                "settings": {
+                    "index": {
+                        "number_of_shards": 1,
+                        "number_of_replicas": 0,
+                    }
+                }
             },
             params=dict(ignore=400),
         )
@@ -114,8 +119,10 @@ class ElasticsearchExplore:
 
         self.client.indices.create(
             index=self.es_index,
+            # TODO: include index.number_of_shards settings
             body={"mappings": {self.es_doc: {"dynamic_templates": dynamic_templates}}},
             ignore=400,
+            params={"include_type_name": "true"},
         )
 
 


### PR DESCRIPTION
This PR fixes found problem with data index creation on explore method. Without this fix, the data index is created with no dynamic mapping configuration, bringing weird search problems 