### PR TITLE
refactor(ui): use env var for explore endpoint

### DIFF
--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -77,7 +77,7 @@ class FeaturesConfiguration(FromParams):
 
         Parameters
         ----------
-        vocab: Vocabulary
+        vocab: `Vocabulary`
             The vocabulary for which to create the embedder
 
         Returns


### PR DESCRIPTION
Using `BIOME_EXPLORE_ENDPOINT` env var value for configure and launching the explore access.

This is very useful when you access to your jupyter lab instance from other than localhost access