### PR TITLE
fix(output): discard optional args selected as input from pipeline output

### DIFF
--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -81,7 +81,7 @@ class PipelineModel(allennlp.models.Model, allennlp.data.DatasetReader):
             self._head.featurize, lambda p: p.default == inspect.Parameter.empty
         )
         self._inputs = self._head.inputs() or [p.name for p in required]
-        self._output = ([p.name for p in optional] or [None])[0]
+        self._output = ([p.name for p in optional if p.name not in self._inputs] or [None])[0]
         self._default_ds_mapping = {k: k for k in self._inputs + [self._output] if k}
 
     @classmethod

--- a/tests/text/test_pipeline_with_optional_inputs.py
+++ b/tests/text/test_pipeline_with_optional_inputs.py
@@ -1,0 +1,51 @@
+from typing import Any, List, Optional, Union
+
+from astroid import Instance
+
+from biome.text import Pipeline, PipelineConfiguration
+from biome.text.configuration import FeaturesConfiguration
+from biome.text.modules.heads import TaskHeadSpec, TextClassification
+
+
+class MyCustomHead(TextClassification):
+    """Just a head renaming the original TextClassification head"""
+
+    def inputs(self) -> Optional[List[str]]:
+        return ["text", "second_text"]
+
+    def featurize(
+            self,
+            text: Any,
+            second_text: Optional[Any] = None,
+            label: Optional[Union[int, str, List[Union[int, str]]]] = None
+    ) -> Optional[Instance]:
+        instance = self.backbone.featurizer(
+            {"text": text, "text-2": second_text},
+            to_field=self.forward_arg_name,
+            aggregate=True,
+            exclude_record_keys=True,
+        )
+        return self.add_label(instance, label, to_field=self.label_name)
+
+
+def test_check_pipeline_inputs_and_output():
+    config = PipelineConfiguration(
+        "test-pipeline",
+        features=FeaturesConfiguration(),
+        head=TaskHeadSpec(
+            type=MyCustomHead,
+            labels=[
+                "blue-collar",
+                "technician",
+                "management",
+                "services",
+                "retired",
+                "admin.",
+            ],
+        ),
+    )
+
+    pipeline = Pipeline.from_config(config)
+
+    assert pipeline.inputs == ["text", "second_text"]
+    assert pipeline.output == "label"


### PR DESCRIPTION
As default, optional arguments are pipeline output candidates.

Here, if we have optional arguments as part of pipeline inputs definition, we discard them from output candidates