### PR TITLE
Feat/add slot filling tutorial

### DIFF
--- a/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb
+++ b/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb
@@ -1,0 +1,811 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training a sequence tagger for Slot Filling"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://www.recogn.ai/biome-text/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.html\"><img src=\"https://www.recogn.ai/biome-text/assets/img/biome-isotype.svg\" width=32 />View on recogn.ai</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb\"><img src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" />Run in Google Colab</a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a target=\"_blank\" href=\"https://github.com/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb\"><img src=\"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\" width=32 />View source on GitHub</a>\n",
+    "  </td>\n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this tutorial we will train a sequence tagger for filling slots in spoken requests.\n",
+    "The goal is to look for specific pieces of information in the request and tag the corresponding tokens accordingly. \n",
+    "The requests will include several intents, from getting weather information to adding a song to a playlist, each requiring its own set of slots.\n",
+    "Therefore, slot filling often goes hand in hand with intent classification.\n",
+    "In this tutorial, however, we will only focus on the slot filling task.\n",
+    "\n",
+    "Slot filling is closely related to [Named-entity recognition (NER)](https://en.wikipedia.org/wiki/Named-entity_recognition) and the model of this tutorial can also be used to train a NER system.\n",
+    "\n",
+    "In this tutorial we will use the [SNIPS data set](https://github.com/snipsco/nlu-benchmark/tree/master/2017-06-custom-intent-engines) adapted by [Su Zhu](https://github.com/sz128/slot_filling_and_intent_detection_of_SLU/tree/master/data/snips) and our simple [data preparation notebook](https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/token_classifier/data_prep.ipynb).\n",
+    "\n",
+    "When running this tutorial in Google Colab, make sure to install *biome.text* first:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U git+https://github.com/recognai/biome-text.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ignore warnings and don't forget to restart your runtime afterwards (*Runtime -> Restart runtime*)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Explore the data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a look at the data before starting with the configuration of our pipeline.\n",
+    "For this we create a `DataSource` instance providing a path to our data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from biome.text.data import DataSource"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>text</th>\n",
+       "      <th>labels</th>\n",
+       "      <th>intent</th>\n",
+       "      <th>path</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>[Find, the, schedule, for, Across, the, Line, ...</td>\n",
+       "      <td>[O, O, B-object_type, O, B-movie_name, I-movie...</td>\n",
+       "      <td>SearchScreeningEvent</td>\n",
+       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>[play, Party, Ben, on, Slacker]</td>\n",
+       "      <td>[O, B-artist, I-artist, O, B-service]</td>\n",
+       "      <td>PlayMusic</td>\n",
+       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>[play, a, 1988, soundtrack]</td>\n",
+       "      <td>[O, O, B-year, B-music_item]</td>\n",
+       "      <td>PlayMusic</td>\n",
+       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>[Can, you, play, The, Change, Is, Made, on, Ne...</td>\n",
+       "      <td>[O, O, O, B-track, I-track, I-track, I-track, ...</td>\n",
+       "      <td>PlayMusic</td>\n",
+       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>[what, is, the, forecast, for, colder, in, Ans...</td>\n",
+       "      <td>[O, O, O, O, O, B-condition_temperature, O, B-...</td>\n",
+       "      <td>GetWeather</td>\n",
+       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>[What's, the, weather, in, Totowa, WY, one, mi...</td>\n",
+       "      <td>[O, O, O, O, B-city, B-state, B-timeRange, I-t...</td>\n",
+       "      <td>GetWeather</td>\n",
+       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>[Play, a, tune, from, Space, Mandino, .]</td>\n",
+       "      <td>[O, O, B-music_item, O, B-artist, I-artist, O]</td>\n",
+       "      <td>PlayMusic</td>\n",
+       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>[give, five, out, of, 6, stars, to, current, e...</td>\n",
+       "      <td>[O, B-rating_value, O, O, B-best_rating, B-rat...</td>\n",
+       "      <td>RateBook</td>\n",
+       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>[Play, some, chanson, style, music.]</td>\n",
+       "      <td>[O, O, B-genre, O, O]</td>\n",
+       "      <td>PlayMusic</td>\n",
+       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>[I, would, give, French, Poets, and, Novelists...</td>\n",
+       "      <td>[O, O, O, B-object_name, I-object_name, I-obje...</td>\n",
+       "      <td>RateBook</td>\n",
+       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                text  \\\n",
+       "0  [Find, the, schedule, for, Across, the, Line, ...   \n",
+       "1                    [play, Party, Ben, on, Slacker]   \n",
+       "2                        [play, a, 1988, soundtrack]   \n",
+       "3  [Can, you, play, The, Change, Is, Made, on, Ne...   \n",
+       "4  [what, is, the, forecast, for, colder, in, Ans...   \n",
+       "5  [What's, the, weather, in, Totowa, WY, one, mi...   \n",
+       "6           [Play, a, tune, from, Space, Mandino, .]   \n",
+       "7  [give, five, out, of, 6, stars, to, current, e...   \n",
+       "8               [Play, some, chanson, style, music.]   \n",
+       "9  [I, would, give, French, Poets, and, Novelists...   \n",
+       "\n",
+       "                                              labels                 intent  \\\n",
+       "0  [O, O, B-object_type, O, B-movie_name, I-movie...   SearchScreeningEvent   \n",
+       "1              [O, B-artist, I-artist, O, B-service]              PlayMusic   \n",
+       "2                       [O, O, B-year, B-music_item]              PlayMusic   \n",
+       "3  [O, O, O, B-track, I-track, I-track, I-track, ...              PlayMusic   \n",
+       "4  [O, O, O, O, O, B-condition_temperature, O, B-...             GetWeather   \n",
+       "5  [O, O, O, O, B-city, B-state, B-timeRange, I-t...             GetWeather   \n",
+       "6     [O, O, B-music_item, O, B-artist, I-artist, O]              PlayMusic   \n",
+       "7  [O, B-rating_value, O, O, B-best_rating, B-rat...               RateBook   \n",
+       "8                              [O, O, B-genre, O, O]              PlayMusic   \n",
+       "9  [O, O, O, B-object_name, I-object_name, I-obje...               RateBook   \n",
+       "\n",
+       "                                                path  \n",
+       "0  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
+       "1  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
+       "2  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
+       "3  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
+       "4  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
+       "5  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
+       "6  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
+       "7  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
+       "8  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
+       "9  https://biome-tutorials-data.s3-eu-west-1.amaz...  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_ds = DataSource(source=\"https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/token_classifier/train.json\")\n",
+    "train_ds.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see we have two relevant columns for our task: *text* and *labels*. \n",
+    "The *intent* column will be ignored in this tutorial. \n",
+    "The *path* column is added automatically by the [DataSource](../../api/biome/text/data/datasource.html#datasource) class to keep track of the source file.\n",
+    "\n",
+    "The input already comes pre-tokenized and each token in the *text* column has a label/tag in the *labels* column, this means that both list always have the same length.\n",
+    "The labels are given in the [BIO tagging scheme](https://en.wikipedia.org/wiki/Inside%E2%80%93outside%E2%80%93beginning_(tagging)), which is widely used in Slot Filling/NER systems.\n",
+    "\n",
+    "When specifying the [TokenClassification](../../api/biome/text/modules/heads/token_classification.html#tokenclassification) head (see [below](#Configure-your-biome.text-Pipeline)), the tokenization step in the pipeline is automatically disabled and the input is expected to be a list of tokens.\n",
+    "\n",
+    "The [DataSource](../../api/biome/text/data/datasource.html#datasource) class stores the data in an underlying [Dask DataFrame](https://docs.dask.org/en/latest/dataframe.html) that you can easily access.\n",
+    "For example, let's check the size of our training data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "13084"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(train_ds.to_dataframe())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or let's check how many different labels/tags we have:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "72"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = train_ds.to_dataframe().compute()\n",
+    "labels_total = df.labels.sum()\n",
+    "len(set(labels_total))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "and how they are distributed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "O                               59610\n",
+       "I-object_name                    7400\n",
+       "I-playlist                       3230\n",
+       "B-object_type                    3023\n",
+       "B-object_name                    2778\n",
+       "                                ...  \n",
+       "I-cuisine                          28\n",
+       "I-facility                         14\n",
+       "I-object_select                     3\n",
+       "I-object_part_of_series_type        3\n",
+       "I-playlist_owner                    1\n",
+       "Length: 72, dtype: int64"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "pd.Series(labels_total).value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "::: tip\n",
+    "\n",
+    "The [TaskHead](../../api/biome/text/modules/heads/task_head.html#taskhead) of our model (the [TokenClassification](../../api/biome/text/modules/heads/token_classification.html#tokenclassification)) will expect a *text* and a *labels* column to be present in the dataframe. \n",
+    "Since they are already present, there is no need for a `mapping` in the [DataSource](../../api/biome/text/data/datasource.html#datasource).\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure your *biome.text* Pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A typical [Pipeline](../../api/biome/text/pipeline.html#pipeline) consists of tokenizing the input, extracting features, applying a language encoding (optionally) and executing a task-specific head in the end.\n",
+    "\n",
+    "After training a pipeline, you can use it to make predictions or explore the underlying model via the [explore UI](../../documentation/user-guides/02.explore.html).\n",
+    "\n",
+    "As a first step we must define a configuration for our pipeline. \n",
+    "In this tutorial we will create a configuration dictionary and use the `Pipeline.from_config()` method to create our pipeline, but there are [other ways](../../api/biome/text/pipeline.html#pipeline).\n",
+    "\n",
+    "A *biome.text* pipeline has the following main components:\n",
+    "\n",
+    "```yaml\n",
+    "name: # a descriptive name of your pipeline\n",
+    "\n",
+    "tokenizer: # how to tokenize the input\n",
+    "\n",
+    "features: # input features of the model\n",
+    "\n",
+    "encoder: # the language encoder\n",
+    "\n",
+    "head: # your task configuration\n",
+    "\n",
+    "```\n",
+    "\n",
+    "See the [Configuration section](../../documentation/user-guides/05.configuration.html) for a detailed description of how these main components can be configured.\n",
+    "\n",
+    "Our complete configuration for this tutorial will be following:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline_dict = {\n",
+    "    \"name\": \"slot_filling\",\n",
+    "    \"features\": {\n",
+    "        \"word\": {\n",
+    "            \"embedding_dim\": 300,\n",
+    "            \"weights_file\": \"https://dl.fbaipublicfiles.com/fasttext/vectors-english/wiki-news-300d-1M.vec.zip\",\n",
+    "        },\n",
+    "        \"char\": {\n",
+    "            \"embedding_dim\": 32,\n",
+    "            \"encoder\": {\n",
+    "                \"type\": \"gru\",\n",
+    "                \"bidirectional\": True,\n",
+    "                \"num_layers\": 1,\n",
+    "                \"hidden_size\": 32,\n",
+    "            },\n",
+    "            \"dropout\": 0.1,\n",
+    "        },\n",
+    "    },\n",
+    "    \"encoder\": {\n",
+    "        \"type\": \"gru\",\n",
+    "        \"hidden_size\": 128,\n",
+    "        \"num_layers\": 1,\n",
+    "        \"bidirectional\": True,\n",
+    "    },\n",
+    "    \"head\": {\n",
+    "        \"type\": \"TokenClassification\",\n",
+    "        \"labels\": list(set(labels_total)),\n",
+    "        \"label_encoding\": \"BIO\",\n",
+    "        \"feedforward\": {\n",
+    "            \"num_layers\": 1,\n",
+    "            \"hidden_dims\": [128],\n",
+    "            \"activations\": [\"relu\"],\n",
+    "            \"dropout\": [0.1],\n",
+    "        },\n",
+    "        \"dropout\": 0.1,\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see in the `features` section, we will use pretrained word embeddings from [fasttext](https://fasttext.cc/docs/en/english-vectors.html) for our `word` features.\n",
+    "Keep in mind that your `embedding_dim` parameter must be equal to the dimensions of those pretrained embeddings.\n",
+    "\n",
+    "With the dictionary above we can now create a `Pipeline`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from biome.text import Pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pl = Pipeline.from_config(pipeline_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create a vocabulary\n",
+    "\n",
+    "Before we can start the training we need to create the vocabulary for our model.\n",
+    "For this we define a `VocabularyConfiguration`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from biome.text import VocabularyConfiguration"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we use pretrained word embeddings we will also consider the validation data when creating the vocabulary. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "valid_ds = DataSource(source=\"https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/token_classifier/valid.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also get rid of the rarest words by adding the `min_count` argument and set it to 2 for the word feature vocabulary.\n",
+    "For a complete list of available arguments see the [VocabularyConfiguration API](../../api/biome/text/configuration.html#vocabularyconfiguration)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vocab_config = VocabularyConfiguration(\n",
+    "    sources=[train_ds, valid_ds],\n",
+    "    min_count={\"word\": 2},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then pass this configuration to our `Pipeline` to create the vocabulary.\n",
+    "Apart from the loading bar of building the vocabulary, there will be two more loading bars corresponding to the `weights_file` provided in the word feature:\n",
+    " - the progress of downloading the file (this file will be cached)\n",
+    " - the progress loading the weights from the file "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "nbreg": {
+     "diff_ignore": [
+      "/outputs/0/data"
+     ]
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "dd917fff2cda4f1e8e8ccd063d95457c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=1.0, bar_style='info', max=1.0), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a3823d97e11145ea9b688c2c467ce2bf",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "HBox(children=(FloatProgress(value=0.0, max=999994.0), HTML(value='')))"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "pl.create_vocabulary(vocab_config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After creating the vovocab_configbulary we can check the size of our entire model in terms of trainable parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1989112"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pl.trainable_parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configure the trainer\n",
+    "\n",
+    "As a next step we have to configure the *trainer*.\n",
+    "\n",
+    "For this tutorial we will use the default configuration that has sensible values and works alright for our experiment.\n",
+    "You can have a look at the [TrainerConfiguration API](../../api/biome/text/configuration.html#trainerconfiguration) for a complete list of available configurations.\n",
+    "\n",
+    "::: tip\n",
+    "\n",
+    "In case you have a cuda device available, you also specify it here.\n",
+    "\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from biome.text import TrainerConfiguration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainer = TrainerConfiguration()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train your model\n",
+    "\n",
+    "Now we have everything ready to start the training of our model:\n",
+    "- training data set\n",
+    "- vocabulary\n",
+    "- trainer\n",
+    "\n",
+    "Apart from the validation data source to estimate the generalization error, we will also pass in a test data set in case we want to do some Hyperparameter optimization and compare different encoder architectures in the end. \n",
+    "For this we will create another `DataSource` pointing to our test data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_ds = DataSource(source=\"https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/token_classifier/test.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The training output will be saved in a folder specified by the `output` argument of the `train` method. \n",
+    "It will contain the trained model weights and the metrics, as well as the vocabulary and a *log* folder for visualizing the training process with [tensorboard](https://www.tensorflow.org/tensorboard/).\n",
+    "\n",
+    "When the training has finished it will automatically make a pass over the test data with the best weights to gather the test metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "nbreg": {
+     "diff_ignore": [
+      "/outputs/*"
+     ]
+    }
+   },
+   "outputs": [],
+   "source": [
+    "pl.train(\n",
+    "    output=\"output\",\n",
+    "    training=train_ds,\n",
+    "    validation=valid_ds,\n",
+    "    test=test_ds,\n",
+    "    trainer=trainer,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The model above achieves an overall F1 score of around **0.95**, which is not bad when compared to [published results](https://nlpprogress.com/english/intent_detection_slot_filling.html) of the same data set.\n",
+    "You could continue the experiment changing the encoder to an LSTM network, try out a transformer architecture or fine tune the trainer.\n",
+    "But for now we will go on and make our first predictions with this trained model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make your first predictions\n",
+    "\n",
+    "Now that we trained our model we can go on to make our first predictions.\n",
+    "First we must load our trained model into a new `Pipeline`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pl_trained = Pipeline.from_pretrained(\"output/model.tar.gz\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then provide the input expected by our `TaskHead` of the model to the `Pipeline.predict()` method.\n",
+    "In our case it is a `TokenClassification` head that classifies a `text` input. **Remember that the input has to to pre-tokenized!**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[('can', 'O'),\n",
+       " ('you', 'O'),\n",
+       " ('play', 'O'),\n",
+       " ('biome', 'B-track'),\n",
+       " ('text', 'I-track'),\n",
+       " ('by', 'O'),\n",
+       " ('backstreet', 'B-artist'),\n",
+       " ('recognais', 'I-artist'),\n",
+       " ('on', 'O'),\n",
+       " ('Spotify', 'B-service')]"
+      ]
+     },
+     "execution_count": 89,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "text = \"can you play biome text by backstreet recognais on Spotify\".split()\n",
+    "prediction = pl_trained.predict(text)\n",
+    "list(zip(text, prediction[\"tags\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Apart from the most likely *tags*, the `prediction` dictionary contains the *logits* and *probs* of each of the label for each of the input token."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  },
+  "nbreg": {
+   "diff_ignore": [
+    "/metadata/widgets",
+    "/metadata/language_info",
+    "/cells/*/execution_count"
+   ]
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb
+++ b/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb
@@ -312,7 +312,13 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "nbreg": {
+     "diff_ignore": [
+      "/outputs/*"
+     ]
+    }
+   },
    "outputs": [
     {
      "data": {
@@ -738,7 +744,7 @@
    "metadata": {},
    "source": [
     "We then provide the input expected by our `TaskHead` of the model to the `Pipeline.predict()` method.\n",
-    "In our case it is a `TokenClassification` head that classifies a `text` input. **Remember that the input has to to pre-tokenized!**"
+    "In our case it is a `TokenClassification` head that classifies a `text` input. **Remember that the input has to be pre-tokenized!**"
    ]
   },
   {

--- a/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb
+++ b/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb
@@ -535,7 +535,7 @@
    "metadata": {
     "nbreg": {
      "diff_ignore": [
-      "/outputs/0/data"
+      "/outputs/*"
      ]
     }
    },
@@ -647,7 +647,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainer = TrainerConfiguration()"
+    "trainer_config = TrainerConfiguration()"
    ]
   },
   {
@@ -701,7 +701,7 @@
     "    training=train_ds,\n",
     "    validation=valid_ds,\n",
     "    test=test_ds,\n",
-    "    trainer=trainer,\n",
+    "    trainer=trainer_config,\n",
     ")"
    ]
   },
@@ -744,7 +744,13 @@
   {
    "cell_type": "code",
    "execution_count": 89,
-   "metadata": {},
+   "metadata": {
+    "nbreg": {
+     "diff_ignore": [
+      "/outputs/*"
+     ]
+    }
+   },
    "outputs": [
     {
      "data": {

--- a/docs/docs/documentation/tutorials/Training_a_text_classifier.ipynb
+++ b/docs/docs/documentation/tutorials/Training_a_text_classifier.ipynb
@@ -310,7 +310,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Configure your `biome.text` Pipeline"
+    "## Configure your *biome.text* Pipeline"
    ]
   },
   {
@@ -319,17 +319,12 @@
    "source": [
     "A typical [Pipeline](../../api/biome/text/pipeline.html#pipeline) consists of tokenizing the input, extracting features, applying a language encoding (optionally) and executing a task-specific head in the end.\n",
     "\n",
-    "After training a pipeline, you can use it to make predictions or explore the underlying model via the [UI](../../documentation/user-guides/02.explore.html).\n",
+    "After training a pipeline, you can use it to make predictions or explore the underlying model via the [explore UI](../../documentation/user-guides/02.explore.html).\n",
     "\n",
     "As a first step we must define a configuration for our pipeline. \n",
-    "In this tutorial we will create a configuration dictionary and use the `Pipeline.from_config()` method to create our pipeline, but there are [other ways](../../api/biome/text/pipeline.html#pipeline)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "A `biome.text` pipeline has the following main components:\n",
+    "In this tutorial we will create a configuration dictionary and use the `Pipeline.from_config()` method to create our pipeline, but there are [other ways](../../api/biome/text/pipeline.html#pipeline).\n",
+    "\n",
+    "A *biome.text* pipeline has the following main components:\n",
     "\n",
     "```yaml\n",
     "name: # a descriptive name of your pipeline\n",
@@ -348,6 +343,11 @@
     "\n",
     "Our complete configuration for this tutorial will be following:"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "code",

--- a/docs/docs/documentation/tutorials/Training_a_text_classifier.ipynb
+++ b/docs/docs/documentation/tutorials/Training_a_text_classifier.ipynb
@@ -470,7 +470,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b22808a95d674cb1bc9155a36c7c2c8f",
+       "model_id": "c0b555eb39fd4e3e80a6267ab8ccc1d4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -652,16 +652,7 @@
      ]
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:filelock:Lock 140475560757072 acquired on /tmp/tmpwhw1ojkf/vocabulary/.lock\n",
-      "INFO:filelock:Lock 140475560757072 released on /tmp/tmpwhw1ojkf/vocabulary/.lock\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pl_trained = Pipeline.from_pretrained(\"output/model.tar.gz\")"
    ]
@@ -688,43 +679,43 @@
     {
      "data": {
       "text/plain": [
-       "{'logits': array([ -6.2526927, -12.3927355,  -4.7647996,  -3.067424 ,   7.4543405,\n",
-       "         -2.3797615,  -4.6205163,  -8.315695 , -22.648367 , -13.5710745,\n",
-       "        -17.335678 ,  -2.408677 , -13.462036 ,  -4.141186 , -14.408431 ,\n",
-       "        -16.615704 ,  -4.739997 ,  -5.768703 ,   1.5712477,  -4.3752007,\n",
-       "        -20.959383 ,  -7.2523   ], dtype=float32),\n",
-       " 'probs': array([1.1112966e-06, 2.3946556e-09, 4.9205510e-06, 2.6864234e-05,\n",
-       "        9.9705434e-01, 5.3434618e-05, 5.6842759e-06, 1.4121464e-07,\n",
-       "        8.4193645e-14, 7.3704992e-10, 1.7082473e-11, 5.1911611e-05,\n",
-       "        8.2196266e-10, 9.1800612e-06, 3.1903444e-10, 3.5093907e-11,\n",
-       "        5.0441176e-06, 1.8031176e-06, 2.7779476e-03, 7.2646444e-06,\n",
-       "        4.5582245e-13, 4.0898382e-07], dtype=float32),\n",
-       " 'classes': {'Gebrauchtwagen': tensor(0.9971),\n",
-       "  'Autowerkstätten': tensor(0.0028),\n",
-       "  'Elektriker': tensor(5.3435e-05),\n",
-       "  'Sanitärinstallationen': tensor(5.1912e-05),\n",
-       "  'Dienstleistungen': tensor(2.6864e-05),\n",
-       "  'Werbeagenturen': tensor(9.1801e-06),\n",
-       "  'Elektrotechnik': tensor(7.2646e-06),\n",
-       "  'Restaurants': tensor(5.6843e-06),\n",
-       "  'Vermittlungen': tensor(5.0441e-06),\n",
-       "  'Tiefbau': tensor(4.9206e-06),\n",
-       "  'Hotels': tensor(1.8031e-06),\n",
-       "  'Unternehmensberatungen': tensor(1.1113e-06),\n",
-       "  'Handelsvermittler Und -vertreter': tensor(4.0898e-07),\n",
-       "  'Architekturbüros': tensor(1.4121e-07),\n",
-       "  'Friseure': tensor(2.3947e-09),\n",
-       "  'Edv': tensor(8.2196e-10),\n",
-       "  'Versicherungsvermittler': tensor(7.3705e-10),\n",
-       "  'Apotheken': tensor(3.1903e-10),\n",
-       "  'Physiotherapie': tensor(3.5094e-11),\n",
-       "  'Maler': tensor(1.7082e-11),\n",
-       "  'Allgemeinärzte': tensor(4.5582e-13),\n",
-       "  'Vereine': tensor(8.4194e-14)},\n",
+       "{'logits': array([ -4.304719 ,  -3.8636725,  -1.6030725,  -5.0883775,   7.001268 ,\n",
+       "         -9.106283 ,  -3.654954 ,  -3.5827587,  -9.726389 ,  -6.2862067,\n",
+       "         -5.833785 ,  -6.622146 ,   1.3630733,  -5.9988494,  -6.60332  ,\n",
+       "        -18.756678 ,  -2.0176373,  -6.002221 ,   0.1751552,  -7.061343 ,\n",
+       "         -9.219639 ,  -5.909651 ], dtype=float32),\n",
+       " 'probs': array([1.2237285e-05, 1.9020801e-05, 1.8238745e-04, 5.5891569e-06,\n",
+       "        9.9497592e-01, 1.0055225e-07, 2.3435510e-05, 2.5190011e-05,\n",
+       "        5.4085806e-08, 1.6870799e-06, 2.6522846e-06, 1.2056993e-06,\n",
+       "        3.5414065e-03, 2.2487095e-06, 1.2286135e-06, 6.4755809e-12,\n",
+       "        1.2049017e-04, 2.2411414e-06, 1.0796164e-03, 7.7713838e-07,\n",
+       "        8.9776378e-08, 2.4585079e-06], dtype=float32),\n",
+       " 'classes': {'Gebrauchtwagen': tensor(0.9950),\n",
+       "  'Edv': tensor(0.0035),\n",
+       "  'Autowerkstätten': tensor(0.0011),\n",
+       "  'Tiefbau': tensor(0.0002),\n",
+       "  'Vermittlungen': tensor(0.0001),\n",
+       "  'Architekturbüros': tensor(2.5190e-05),\n",
+       "  'Restaurants': tensor(2.3436e-05),\n",
+       "  'Friseure': tensor(1.9021e-05),\n",
+       "  'Unternehmensberatungen': tensor(1.2237e-05),\n",
+       "  'Dienstleistungen': tensor(5.5892e-06),\n",
+       "  'Maler': tensor(2.6523e-06),\n",
+       "  'Handelsvermittler Und -vertreter': tensor(2.4585e-06),\n",
+       "  'Werbeagenturen': tensor(2.2487e-06),\n",
+       "  'Hotels': tensor(2.2411e-06),\n",
+       "  'Versicherungsvermittler': tensor(1.6871e-06),\n",
+       "  'Apotheken': tensor(1.2286e-06),\n",
+       "  'Sanitärinstallationen': tensor(1.2057e-06),\n",
+       "  'Elektrotechnik': tensor(7.7714e-07),\n",
+       "  'Elektriker': tensor(1.0055e-07),\n",
+       "  'Allgemeinärzte': tensor(8.9776e-08),\n",
+       "  'Vereine': tensor(5.4086e-08),\n",
+       "  'Physiotherapie': tensor(6.4756e-12)},\n",
        " 'max_class': 'Gebrauchtwagen',\n",
-       " 'max_class_prob': tensor(0.9971),\n",
+       " 'max_class_prob': tensor(0.9950),\n",
        " 'label': 'Gebrauchtwagen',\n",
-       " 'prob': tensor(0.9971)}"
+       " 'prob': tensor(0.9950)}"
       ]
      },
      "execution_count": 18,
@@ -806,6 +797,13 @@
     "Exploring our model we could take advantage of the F1 scores of each label to figure out which labels to prioritize when gathering new training data.\n",
     "For example, although \"Allgemeinärzte\" is the second rarest label in our training data, it still seems relatively easy to classify for our model due to the distinctive words \"Dr.\" and \"Allgemeinmedizin\"."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/docs/docs/documentation/tutorials/Training_a_text_classifier.ipynb
+++ b/docs/docs/documentation/tutorials/Training_a_text_classifier.ipynb
@@ -345,11 +345,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": []
-  },
-  {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},

--- a/src/biome/text/__init__.py
+++ b/src/biome/text/__init__.py
@@ -1,5 +1,6 @@
 import warnings
 from warnings import warn_explicit
+import logging
 
 import pkg_resources
 
@@ -11,6 +12,7 @@ from .pipeline import (
 )
 
 warnings.showwarning = warn_explicit
+logging.basicConfig()
 
 try:
     __version__ = pkg_resources.get_distribution(__name__.replace(".", "-")).version

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -366,7 +366,12 @@ class VocabularyConfiguration:
     max_vocab_size:  `Union[int, Dict[str, int]]`, optional (default=`None`)
         Maximum number of tokens in the vocabulary
     pretrained_files: `Optional[Dict[str, str]]`, optional
-        Pretrained files with word vectors
+        If provided, this map specifies the path to optional pretrained embedding files for each
+        namespace. This can be used to either restrict the vocabulary to only words which appear
+        in this file, or to ensure that any words in this file are included in the vocabulary
+        regardless of their count, depending on the value of `only_include_pretrained_words`.
+        Words which appear in the pretrained embedding file but not in the data are NOT included
+        in the Vocabulary.
     only_include_pretrained_words: `bool`, optional (default=False)
         Only include tokens present in pretrained_files
     tokens_to_add: `Dict[str, int]`, optional

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -90,7 +90,6 @@ class FeaturesConfiguration(FromParams):
         ):
             # We simplify embedder configuration for better load an blank pipeline which create the vocab
             embedder_cfg = configuration["word"]["embedder"]
-            embedder_cfg["embedding_dim"] = 1
             if "pretrained_file" in embedder_cfg:
                 embedder_cfg["pretrained_file"] = None
         return TextFieldEmbedder.from_params(

--- a/src/biome/text/data/readers.py
+++ b/src/biome/text/data/readers.py
@@ -30,8 +30,10 @@ class DataFrameReader:
 
         Parameters
         ----------
-        source: The source information.
-        kwargs: extra arguments passed to read method. Each reader should declare needed arguments
+        source:
+            The source information.
+        **kwargs:
+            extra arguments passed to read method. Each reader should declare needed arguments
 
         Returns
         -------
@@ -44,29 +46,30 @@ class DataFrameReader:
 
 
 def from_csv(path: Union[str, List[str]], **params) -> dd.DataFrame:
-    """Creates a `dask.dataframe.DataFrame` from one or several csv files.
+    """Creates a `dd.DataFrame` from one or several csv files.
+
     Includes a "path column".
 
     Parameters
     ----------
     path
         Path to files
-    params
+    **params
         Extra arguments passed on to `dask.dataframe.read_csv`
 
     Returns
     -------
-    df
-        A `dask.DataFrame`
-
+    dataframe
+        A `dd.DataFrame`
     """
     return dd.read_csv(path, include_path_column=PATH_COLUMN_NAME, **params)
 
 
 def from_json(
-    path: Union[str, List[str]], flatten: bool = True, **params
+    path: Union[str, List[str]], flatten: bool = False, **params
 ) -> dd.DataFrame:
-    """Creates a `dask.dataframe.DataFrame` from one or several json files.
+    """Creates a `dd.DataFrame` from one or several json files.
+
     Includes a "path column".
 
     Parameters
@@ -74,17 +77,17 @@ def from_json(
     path
         Path to files
     flatten
-        If true (default false), flatten json nested data
-    params
+        If true, flatten nested data (default false).
+    **params
         Extra arguments passed on to `pandas.read_json`
 
     Returns
     -------
-    df
-        A `dask.DataFrame`
+    dataframe
+        A `dd.DataFrame`
     """
 
-    def json_engine(*args, flatten: bool = False, **kwargs) -> pd.DataFrame:
+    def json_engine(*args, **kwargs) -> pd.DataFrame:
         data_frame = pd.read_json(*args, **kwargs)
         return flatten_dataframe(data_frame) if flatten else data_frame
 
@@ -92,7 +95,7 @@ def from_json(
 
     dds = []
     for path_name in path_list:
-        ddf = dd.read_json(path_name, flatten=flatten, engine=json_engine, **params)
+        ddf = dd.read_json(path_name, engine=json_engine, **params)
         ddf[PATH_COLUMN_NAME] = path_name
         dds.append(ddf)
 
@@ -100,20 +103,21 @@ def from_json(
 
 
 def from_parquet(path: Union[str, List[str]], **params) -> dd.DataFrame:
-    """Creates a `dask.dataframe.DataFrame` from one or several parquet files.
+    """Creates a `dd.DataFrame` from one or several parquet files.
+
     Includes a "path column".
 
     Parameters
     ----------
     path
         Path to files
-    params
+    **params
         Extra arguments passed on to `pandas.read_parquet`
 
     Returns
     -------
     df
-        A `dask.dataframe.DataFrame`
+        A `dd.DataFrame`
     """
     path_list = _get_file_paths(path)
 

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -1,5 +1,4 @@
 import copy
-import glob
 import inspect
 import logging
 import os

--- a/src/biome/text/ui/ui.py
+++ b/src/biome/text/ui/ui.py
@@ -6,10 +6,8 @@ from gevent.pywsgi import WSGIServer
 from biome.text.environment import ES_HOST
 from .app import make_app
 
-# TODO centralize configuration
-logging.basicConfig(level=logging.INFO)
-
 __LOGGER = logging.getLogger(__name__)
+__LOGGER.setLevel(logging.INFO)
 
 STATICS_DIR = os.path.join(os.path.dirname(__file__), "webapp")
 

--- a/tests/integration/test_text_classification.py
+++ b/tests/integration/test_text_classification.py
@@ -6,11 +6,11 @@ from typing import Tuple
 import numpy as np
 import pytest
 import torch
-import yaml
+
 from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration
-from biome.text.data import DataSource
-from biome.text.configuration import WordFeatures
 from biome.text.configuration import CharFeatures
+from biome.text.configuration import WordFeatures
+from biome.text.data import DataSource
 
 
 @pytest.fixture
@@ -128,7 +128,7 @@ def test_text_classification(
     with (output / "metrics.json").open() as file:
         metrics = json.load(file)
 
-    assert metrics["training_loss"] == pytest.approx(0.767, abs=0.003)
+    assert metrics["training_loss"] == pytest.approx(0.642, abs=0.003)
 
     # test vocab from a pretrained file
     pl = Pipeline.from_pretrained(str(output / "model.tar.gz"))

--- a/tests/tutorials/test_tutorials.py
+++ b/tests/tutorials/test_tutorials.py
@@ -48,12 +48,6 @@ def test_slot_filling_tutorial(tmp_path):
     for cell in notebook["cells"]:
         if cell["source"].startswith("!pip install"):
             cell["source"] = re.sub(r"!pip install", r"#!pip install", cell["source"])
-        if cell["source"].startswith("train_ds ="):
-            cell["source"] = re.sub(
-                r"token_classifier/train.json",
-                r"token_classifier/test.json",
-                cell["source"],
-            )
         if cell["source"].startswith("pipeline_dict ="):
             cell["source"] = re.sub(
                 r"https://dl.fbaipublicfiles.com/fasttext/vectors-english/wiki-news-300d-1M.vec.zip",
@@ -64,6 +58,12 @@ def test_slot_filling_tutorial(tmp_path):
             cell["source"] = re.sub(
                 r"TrainerConfiguration\(\)",
                 r"TrainerConfiguration(num_epochs=1)",
+                cell["source"],
+            )
+        if cell["source"].startswith("pl.train("):
+            cell["source"] = re.sub(
+                r"training=train_ds",
+                r"training=valid_ds",
                 cell["source"],
             )
 

--- a/tests/tutorials/test_tutorials.py
+++ b/tests/tutorials/test_tutorials.py
@@ -36,3 +36,42 @@ def test_text_classifier_tutorial(tmp_path):
     # test adapted notebook
     fixture = NBRegressionFixture(exec_timeout=100)
     fixture.check(str(mod_notebook_path))
+
+
+def test_slot_filling_tutorial(tmp_path):
+    notebook_path = (
+        Path(TUTORIALS_PATH) / "Training_a_sequence_tagger_for_Slot_Filling.ipynb"
+    )
+
+    # adapt notebook to CI (make its execution quicker + comment lines)
+    notebook = load_notebook(str(notebook_path))
+    for cell in notebook["cells"]:
+        if cell["source"].startswith("!pip install"):
+            cell["source"] = re.sub(r"!pip install", r"#!pip install", cell["source"])
+        if cell["source"].startswith("train_ds ="):
+            cell["source"] = re.sub(
+                r"token_classifier/train.json",
+                r"token_classifier/test.json",
+                cell["source"],
+            )
+        if cell["source"].startswith("pipeline_dict ="):
+            cell["source"] = re.sub(
+                r"https://dl.fbaipublicfiles.com/fasttext/vectors-english/wiki-news-300d-1M.vec.zip",
+                r"https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/token_classifier/wiki-news-300d-1M.head.vec",
+                cell["source"],
+            )
+        if cell["source"].startswith("trainer_config ="):
+            cell["source"] = re.sub(
+                r"TrainerConfiguration\(\)",
+                r"TrainerConfiguration(num_epochs=1)",
+                cell["source"],
+            )
+
+    # dump adapted notebook
+    mod_notebook_path = tmp_path / notebook_path.name
+    with mod_notebook_path.open("w") as file:
+        file.write(str(dump_notebook(notebook)))
+
+    # test adapted notebook
+    fixture = NBRegressionFixture(exec_timeout=100)
+    fixture.check(str(mod_notebook_path))


### PR DESCRIPTION
This PR adds the slot filling tutorial. You can find the tutorial [here](https://github.com/recognai/biome-text/blob/feat/add_slot_filling_tutorial/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb)

Apart from the tutorial there are several fixes:
- bug fix in the tokenclassifier
- i set `flatten` by default to False when reading json (cc @frascuchon )
- moved the basicConfig for the logging module to the init of the package (cc @frascuchon ). this one was driving me crazy to figure out how logging works when no handler is specified ...

I still have to improve the test, so it does not take ages, but tests a fair amount of functionality.