### PR TITLE
quick pass over API doc strings

### DIFF
--- a/src/biome/text/about.py
+++ b/src/biome/text/about.py
@@ -5,20 +5,45 @@ __version__ = "1.0.0rc3"
 from typing import Optional
 
 
-def package_version(version: str):
-    """Generates a proper package version from git repository info"""
+def package_version(version: str) -> str:
+    """Generates a proper package version from the git repository info
+
+    Parameters
+    ----------
+    version
+
+    Returns
+    -------
+    package_version
+    """
 
     def get_commit_hash(repository: git.Git) -> str:
         """
-        Fetch current commit hash from configured git repository. The working folder should
-        be part of a already git repository
+        Fetch current commit hash from the configured git repository.
+        The working directory should already be part of a git repository.
 
+        Parameters
+        ----------
+        repository
+
+        Returns
+        -------
+        commit_hash
         """
         return repository.log("--pretty=format:'%h'", "-n 1").replace("'", "")
 
     def get_first_tag_for_commit(repository: git.Git, commit_hash: str) -> str:
-        """ Return tags related to current commit """
+        """Return tags related to current commit
 
+        Parameters
+        ----------
+        repository
+        commit_hash
+
+        Returns
+        -------
+        tag
+        """
         tags = (
             repository.tag("--contains", commit_hash)
             if commit_hash
@@ -27,14 +52,33 @@ def package_version(version: str):
         return tags[0]
 
     def get_version_from_branch(repository: git.Git) -> Optional[str]:
-        """Extract version from release branch name"""
+        """Extract version from release branch name
+
+        Parameters
+        ----------
+        repository
+
+        Returns
+        -------
+        version
+        """
         current_remote_branch = repository.branch("--remote", "--contains")
         if "releases/" in current_remote_branch:
             return current_remote_branch.split("/")[-1]
         return None
 
     def version_matches(release_branch_version: str, configured_version: str) -> bool:
-        """Checks if a version matches with related release branch version"""
+        """Checks if a version matches the related release branch version
+
+        Parameters
+        ----------
+        release_branch_version
+        configured_version
+
+        Returns
+        -------
+        bool
+        """
         minor_release = tuple(release_branch_version.split(".")[:2])
         minor_configured = tuple(configured_version.split(".")[:2])
 

--- a/src/biome/text/backbone.py
+++ b/src/biome/text/backbone.py
@@ -18,13 +18,13 @@ class ModelBackbone(torch.nn.Module):
 
     Attributes
     ----------
-    vocab: `Vocabulary`
+    vocab
         The vocabulary of the pipeline
-    featurizer: `InputFeaturizer`
+    featurizer
         Defines the input features of the tokens and indexes
-    embedder: `TextFieldEmbedder`
+    embedder
         The embedding layer
-    encoder: Encoder
+    encoder
         Outputs an encoded sequence of the tokens
     """
 

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -4,7 +4,22 @@ from biome.text.modules.configuration import Seq2VecEncoderConfiguration
 
 
 class WordFeatures:
-    """Feature configuration at word level"""
+    """Feature configuration at word level
+
+    Parameters
+    ----------
+    embedding_dim
+        Dimension of the embeddings
+    lowercase_tokens
+        If True, lowercase tokens before the indexing
+    trainable
+        If False, freeze the embeddings
+    weights_file
+        Path to a file with pretrained weights for the embedding
+    **extra_params
+        Extra parameters passed on to the `indexer` and `embedder` of the AllenNLP configuration framework.
+        For example: `WordFeatures(embedding_dim=300, embedder={"padding_index": 0})`
+    """
 
     namespace = "word"
 
@@ -23,7 +38,8 @@ class WordFeatures:
         self.extra_params = extra_params
 
     @property
-    def config(self):
+    def config(self) -> Dict:
+        """Returns the config in AllenNLP format"""
         config = {
             "indexer": {
                 "type": "single_id",
@@ -43,13 +59,15 @@ class WordFeatures:
 
         return config
 
-    def to_json(self):
+    def to_json(self) -> Dict:
+        """Returns the config as dict for the serialized json config file"""
         data = vars(self)
         data.update(data.pop("extra_params"))
 
         return data
 
-    def to_dict(self):
+    def to_dict(self) -> Dict:
+        """Returns the config as dict"""
         return {
             "embedding_dim": self.embedding_dim,
             "lowercase_tokens": self.lowercase_tokens,
@@ -60,7 +78,22 @@ class WordFeatures:
 
 
 class CharFeatures:
-    """Feature configuration at character level"""
+    """Feature configuration at character level
+
+    Parameters
+    ----------
+    embedding_dim
+        Dimension of the character embeddings.
+    encoder
+        A sequence to vector encoder resulting in a word representation based on its characters
+    dropout
+        Dropout applied to the output of the encoder
+    lowercase_characters
+        If True, lowercase characters before the indexing
+    **extra_params
+        Extra parameters passed on to the `indexer` and `embedder` of the AllenNLP configuration framework.
+        For example: `CharFeatures(embedding_dim=32, indexer={"min_padding_length": 5}, ...)`
+    """
 
     namespace = "char"
 
@@ -79,7 +112,8 @@ class CharFeatures:
         self.extra_params = extra_params
 
     @property
-    def config(self):
+    def config(self) -> Dict:
+        """Returns the config in AllenNLP format"""
         config = {
             "indexer": {
                 "type": "characters",
@@ -108,12 +142,14 @@ class CharFeatures:
         return config
 
     def to_json(self):
+        """Returns the config as dict for the serialized json config file"""
         data = vars(self)
         data.update(data.pop("extra_params"))
 
         return data
 
     def to_dict(self):
+        """Returns the config as dict"""
         return {
             "embedding_dim": self.embedding_dim,
             "encoder": self.encoder,

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -17,15 +17,25 @@ _INVALID_TAG_CHARACTERS = re.compile(r"[^-/\w\.]")
 
 
 def yaml_to_dict(filepath: str) -> Dict[str, Any]:
-    """Loads a yaml file into a data dictionary"""
+    """Loads a yaml file into a data dictionary
+
+    Parameters
+    ----------
+    filepath
+        Path to the yaml file
+
+    Returns
+    -------
+    dict
+    """
     with open(filepath) as yaml_content:
         config = yaml.safe_load(yaml_content)
     return config
 
 
 def get_compatible_doc_type(client: Elasticsearch) -> str:
-    """
-    Find a compatible name for doc type by checking the cluster info
+    """Find a compatible name for doc type by checking the cluster info
+
     Parameters
     ----------
     client
@@ -33,9 +43,9 @@ def get_compatible_doc_type(client: Elasticsearch) -> str:
 
     Returns
     -------
+    name
         A compatible name for doc type in function of cluster version
     """
-
     es_version = int(client.info()["version"]["number"].split(".")[0])
     return "_doc" if es_version >= 6 else "doc"
 
@@ -51,12 +61,24 @@ def get_env_cuda_device() -> int:
         The integer number of the CUDA device
     """
     cuda_device = int(os.getenv(environment.CUDA_DEVICE, "-1"))
+
     return cuda_device
 
 
-def update_method_signature(signature: inspect.Signature, to_method):
-    """Updates signature to method"""
+def update_method_signature(signature: inspect.Signature, to_method: Callable) -> Callable:
+    """Updates the signature of a method
 
+    Parameters
+    ----------
+    signature
+        The signature with which to update the method
+    to_method
+        The method whose signature will be updated
+
+    Returns
+    -------
+    updated_method
+    """
     def wrapper(*args, **kwargs):
         return to_method(*args, **kwargs)
 
@@ -97,7 +119,7 @@ def split_signature_params_by_predicate(
     return matches_group, non_matches_group
 
 
-def clean_metric_name(name):
+def clean_metric_name(name: str) -> str:
     if not name:
         return name
     new_name = _INVALID_TAG_CHARACTERS.sub("_", name)
@@ -113,12 +135,13 @@ def get_word_tokens_ids_from_text_field_tensors(
 
     Parameters
     ----------
-    text_field_tensors: The incoming record text field tensors dictionary
+    text_field_tensors
+        The incoming record text field tensors dictionary
 
     Returns
     -------
-
-    `WordFeatures` related tensors if enable
+    tensor
+        `WordFeatures` related tensors if enable
     """
     word_features_tensors = text_field_tensors.get(WordFeatures.namespace)
     if not word_features_tensors:
@@ -139,12 +162,13 @@ def get_char_tokens_ids_from_text_field_tensors(
 
     Parameters
     ----------
-    text_field_tensors: The incoming record text field tensors dictionary
+    text_field_tensors
+        The incoming record text field tensors dictionary
 
     Returns
     -------
-
-    `CharFeatures` related tensors if enable
+    tensor
+        `CharFeatures` related tensors if enable
     """
     char_features_tensors = text_field_tensors.get(CharFeatures.namespace)
     if not char_features_tensors:

--- a/src/biome/text/metrics.py
+++ b/src/biome/text/metrics.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import torch
 from allennlp.training.metrics import Metric
 
@@ -32,11 +34,16 @@ class MultiLabelF1Measure(Metric):
         self._fp += (predictions * (1 - gold_labels)).sum().item()
         self._fn += ((1 - predictions) * gold_labels).sum().item()
 
-    def get_metric(self, reset: bool = False):
+    def get_metric(self, reset: bool = False) -> Dict[str, float]:
         """
+        Parameters
+        ----------
+        reset
+            If True, reset the metrics after getting them
+
         Returns
         -------
-        `Dict[str, float]`
+        metrics_dict
             A Dict with:
             - precision : `float`
             - recall : `float`
@@ -60,6 +67,7 @@ class MultiLabelF1Measure(Metric):
         return {"precision": precision, "recall": recall, "fscore": f1}
 
     def reset(self):
+        """Resets the metrics"""
         self._tp = 0.0
         self._fp = 0.0
         self._fn = 0.0


### PR DESCRIPTION
Another quick pass over the API doc strings.
The main additions are the TrainerConfiguration, WordFeatures and CharFeatures doc strings.
I am not sure if the arguments `cache_instances` and `in_memory_batches` are used at all at the moment, have to check this.

I also propose a slight change in the format: i would avoid specifying the type in the doc string, so this:
```python
def get_example(argument: int) -> str:
"""Gets an example name.

Parameters
----------
argument : int
    An argument

Returns
-------
example : str
    Name of the example
```
becomes this:

```python
def get_example(argument: int) -> str:
"""Gets an example name.

Parameters
----------
argument
    An argument

Returns
-------
example
    Name of the example
```
Since we consequently use type annotations the information is already in the signature of the method. Also the rendered html files look prettier without all the [colored boxes](https://gitlab.com/recognai-team/team/-/issues/122#note_362216441) in my opinion.

@dvsrepo @frascuchon what do you think? I would be willing to change the format for all present doc strings in a follow-up PR.
