### PR TITLE
Feature/using instance dataset

### DIFF
--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -207,7 +207,7 @@ class PipelineTrainer:
     """
     Default trainer for `PipelineModel`
 
-    Arguments
+    Attributes
     ----------
     pipeline:
         The trainable pipeline

--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -29,7 +29,7 @@ from biome.text._configuration import (
 )
 from biome.text._model import PipelineModel
 from biome.text.constants import EXPLORE_APP_ENDPOINT
-from biome.text.data import DataSource
+from biome.text.data import DataSource, InstancesDataset
 from biome.text.errors import http_error_handling
 from biome.text.ui import launch_ui
 
@@ -209,13 +209,21 @@ class PipelineTrainer:
 
     Arguments
     ----------
-    pipeline : `Pipeline`
-        The trainable model
-    trainer_config: `TrainerConfiguration`
+    pipeline:
+        The trainable pipeline
+    trainer_config:
         The trainer configuration
-    batch_weight_key : ``str``, optional (default="")
+    output_dir:
+        The used training folder
+    training:
+        The training instances dataset
+    validation:
+        The validation instances dataset. Optional
+    test:
+        The test instances dataset. Optional
+    batch_weight_key:
         If non-empty, name of metric used to weight the loss on a per-batch basis.
-    embedding_sources_mapping: ``Dict[str, str]``, optional (default=None)
+    embedding_sources_mapping:
         mapping from model paths to the pretrained embedding filepaths
         used during fine-tuning.
     """
@@ -227,9 +235,9 @@ class PipelineTrainer:
         pipeline: Pipeline,
         trainer_config: TrainerConfiguration,
         output_dir: str,
-        training: str,
-        validation: Optional[str] = None,
-        test: Optional[str] = None,
+        training: InstancesDataset,
+        validation: Optional[InstancesDataset] = None,
+        test: Optional[InstancesDataset] = None,
         batch_weight_key: str = "",
         embedding_sources_mapping: Dict[str, str] = None,
     ):
@@ -240,7 +248,11 @@ class PipelineTrainer:
         self._batch_weight_key = batch_weight_key
         self._embedding_sources_mapping = embedding_sources_mapping
         self._batch_size = self._trainer_config.batch_size
-        self._all_datasets = self.datasets_from_params(training, validation, test)
+        self._all_datasets = {
+            "training": training,
+            "validation": validation,
+            "test": test,
+        }
 
         self._setup()
 
@@ -284,8 +296,8 @@ class PipelineTrainer:
             if any(re.search(regex, name) for regex in no_grad_regexes):
                 parameter.requires_grad_(False)
 
-        train_data_loader = DataLoader(
-            self._all_datasets["train"], batch_size=self._batch_size
+        training_data_loader = DataLoader(
+            self._all_datasets["training"], batch_size=self._batch_size
         )
         validation_ds = self._all_datasets.get("validation")
         validation_data_loader = (
@@ -297,34 +309,10 @@ class PipelineTrainer:
         self._trainer = Trainer.from_params(
             model=self._model,
             serialization_dir=self._output_dir,
-            data_loader=train_data_loader,
+            data_loader=training_data_loader,
             validation_data_loader=validation_data_loader,
             params=trainer_params,
         )
-
-    def datasets_from_params(
-        self,
-        training: str,
-        validation: Optional[str] = None,
-        test: Optional[str] = None,
-    ) -> Dict[str, Dataset]:
-        """
-        Load all the datasets specified by the config.
-
-        """
-
-        self.__LOGGER.info("Reading training data from %s", training)
-        datasets: Dict[str, Dataset] = {"train": self._model.read(training)}
-
-        if validation is not None:
-            self.__LOGGER.info("Reading validation data from %s", validation)
-            datasets["validation"] = self._model.read(validation)
-
-        if test is not None:
-            self.__LOGGER.info("Reading test data from %s", test)
-            datasets["test"] = self._model.read(test)
-
-        return datasets
 
     def test_evaluation(self) -> Dict[str, Any]:
         """

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -6,7 +6,7 @@ from allennlp.common import FromParams, Params
 from allennlp.data import TokenIndexer, Vocabulary
 from allennlp.modules import TextFieldEmbedder
 
-from biome.text.data import DataSource
+from biome.text.data import DataSource, InstancesDataset
 from . import vocabulary
 from .features import CharFeatures, WordFeatures
 from .featurizer import InputFeaturizer
@@ -45,7 +45,7 @@ class FeaturesConfiguration(FromParams):
     __DEFAULT_CONFIG = WordFeatures(embedding_dim=50)
 
     def __init__(
-        self, word: Optional[WordFeatures] = None, char: Optional[CharFeatures] = None,
+        self, word: Optional[WordFeatures] = None, char: Optional[CharFeatures] = None
     ):
         self.word = word or None
         self.char = char or None
@@ -166,6 +166,7 @@ class TokenizerConfiguration(FromParams):
     end_tokens
         A list of token strings to the sequence after tokenized input text.
     """
+
     # note: It's important that it inherits from FromParas so that `Pipeline.from_pretrained()` works!
     def __init__(
         self,
@@ -401,8 +402,8 @@ class VocabularyConfiguration:
 
     Parameters
     ----------
-    sources: `List[DataSource]`
-        Datasource to be used for data creation
+    sources: `Union[List[DataSource], List[InstancesDataset]]`
+        Datasource or instance datasets to be used for data creation
     min_count: `Dict[str, int]`, optional (default=None)
         Minimum number of appearances of a token to be included in the vocabulary.
         The key in the dictionary refers to the namespace of the input feature.
@@ -425,7 +426,7 @@ class VocabularyConfiguration:
 
     def __init__(
         self,
-        sources: List[DataSource],
+        sources: Union[List[DataSource], List[InstancesDataset]],
         min_count: Dict[str, int] = None,
         max_vocab_size: Union[int, Dict[str, int]] = None,
         pretrained_files: Optional[Dict[str, str]] = None,

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -403,7 +403,7 @@ class VocabularyConfiguration:
     Parameters
     ----------
     sources: 
-        Datasource or instance datasets to be used for data creation
+        List of DataSource or InstancesDataset objects to be used for data creation
     min_count: `Dict[str, int]`, optional (default=None)
         Minimum number of appearances of a token to be included in the vocabulary.
         The key in the dictionary refers to the namespace of the input feature.

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -402,7 +402,7 @@ class VocabularyConfiguration:
 
     Parameters
     ----------
-    sources: `Union[List[DataSource], List[InstancesDataset]]`
+    sources: 
         Datasource or instance datasets to be used for data creation
     min_count: `Dict[str, int]`, optional (default=None)
         Minimum number of appearances of a token to be included in the vocabulary.

--- a/src/biome/text/data/__init__.py
+++ b/src/biome/text/data/__init__.py
@@ -1,1 +1,8 @@
+from typing import Union
+
+from allennlp.data import AllennlpDataset, AllennlpLazyDataset
+
 from .datasource import DataSource
+
+
+InstancesDataset = Union[AllennlpDataset, AllennlpLazyDataset]

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -170,7 +170,7 @@ class Pipeline:
         validation:
             The validation DataSource (optional)
         test:
-            The test data source
+            The test DataSource (optional)
         extend_vocab:
             Extends vocab tokens with provided configuration
         restore:

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -164,7 +164,7 @@ class Pipeline:
         output:
             The experiment output path
         training:
-            The training data source
+            The training DataSource
         trainer:
             The trainer file path
         validation:

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -172,7 +172,7 @@ class Pipeline:
         test:
             The test DataSource (optional)
         extend_vocab:
-            Extends vocab tokens with provided configuration
+            Extends the vocabulary tokens with the provided VocabularyConfiguration
         restore:
             If enabled, tries to read previous training status from the `output` folder and
             continues the training process

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -168,7 +168,7 @@ class Pipeline:
         trainer:
             The trainer file path
         validation:
-            The validation data source
+            The validation DataSource (optional)
         test:
             The test data source
         extend_vocab:

--- a/tests/text/test_pipeline_datasets.py
+++ b/tests/text/test_pipeline_datasets.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import pytest
+from allennlp.data import AllennlpDataset, Instance, AllennlpLazyDataset
+
+from biome.text import Pipeline, PipelineConfiguration
+from biome.text.data import DataSource
+from biome.text.modules.heads import TextClassificationConfiguration
+
+
+@pytest.fixture
+def datasource_test(tmp_path) -> DataSource:
+    data_file = tmp_path / "classifier.parquet"
+    df = pd.DataFrame(
+        {"text": ["A common text", "This is why you get", "Seriosly?, I'm not sure"], "label": ["one", "zero", "zero"]}
+    )
+    df.to_parquet(data_file)
+
+    return DataSource(source=str(data_file))
+
+
+@pytest.fixture
+def pipeline_test() -> Pipeline:
+    config = PipelineConfiguration(
+        name="test-classifier",
+        head=TextClassificationConfiguration(labels=["one", "zero"])
+    )
+    return Pipeline.from_config(config)
+
+
+def test_datasets_creation(pipeline_test: Pipeline, datasource_test: DataSource):
+
+    df = datasource_test.to_dataframe()
+    dataset = pipeline_test.create_dataset(datasource_test)
+    assert isinstance(dataset, AllennlpDataset)
+    assert len(dataset) == len(df.text)
+
+    for instance in dataset:
+        assert isinstance(instance, Instance)
+
+
+def test_lazy_dataset_creation(pipeline_test: Pipeline, datasource_test:DataSource):
+    df = datasource_test.to_dataframe()
+    dataset = pipeline_test.create_dataset(datasource_test, lazy=True)
+    assert isinstance(dataset, AllennlpLazyDataset)
+    assert len([x for x in dataset]) == len(df.text)
+
+    for instance in dataset:
+        assert isinstance(instance, Instance)
+        assert "text" in instance.fields
+        assert "label" in instance.fields

--- a/tests/text/test_pipeline_datasets.py
+++ b/tests/text/test_pipeline_datasets.py
@@ -11,7 +11,10 @@ from biome.text.modules.heads import TextClassificationConfiguration
 def datasource_test(tmp_path) -> DataSource:
     data_file = tmp_path / "classifier.parquet"
     df = pd.DataFrame(
-        {"text": ["A common text", "This is why you get", "Seriosly?, I'm not sure"], "label": ["one", "zero", "zero"]}
+        {
+            "text": ["A common text", "This is why you get", "Seriosly?, I'm not sure"],
+            "label": ["one", "zero", "zero"],
+        }
     )
     df.to_parquet(data_file)
 
@@ -22,7 +25,7 @@ def datasource_test(tmp_path) -> DataSource:
 def pipeline_test() -> Pipeline:
     config = PipelineConfiguration(
         name="test-classifier",
-        head=TextClassificationConfiguration(labels=["one", "zero"])
+        head=TextClassificationConfiguration(labels=["one", "zero"]),
     )
     return Pipeline.from_config(config)
 
@@ -38,7 +41,7 @@ def test_datasets_creation(pipeline_test: Pipeline, datasource_test: DataSource)
         assert isinstance(instance, Instance)
 
 
-def test_lazy_dataset_creation(pipeline_test: Pipeline, datasource_test:DataSource):
+def test_lazy_dataset_creation(pipeline_test: Pipeline, datasource_test: DataSource):
     df = datasource_test.to_dataframe()
     dataset = pipeline_test.create_dataset(datasource_test, lazy=True)
     assert isinstance(dataset, AllennlpLazyDataset)


### PR DESCRIPTION
This PR addresses discussion commented in #294, adding a new pipeline method for instances dataset creation:

```python
instances_ds = pipeline.create_dataset(whatever_datasource)
```

that can be used for vocabulary creation and pipeline training.

```python
train_ds = pipeline.create_dataset(train_datasource)
validation_ds = pipeline.create_dataset(validation_datasource)

pipeline.train(
  trainer,
  output_folder, 
  training=train_ds, 
  validation=validation_ds
)
```

Closes #294