### PR TITLE
Feat/add epoch callback

### DIFF
--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -5,7 +5,7 @@ import os
 import re
 import time
 from threading import Thread
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, List
 from urllib.error import URLError
 from urllib.parse import urlparse
 
@@ -224,6 +224,9 @@ class PipelineTrainer:
     embedding_sources_mapping:
         mapping from model paths to the pretrained embedding filepaths
         used during fine-tuning.
+    epoch_callbacks:
+        A list of callbacks that will be called at the end of every epoch, and at the start of
+        training (with epoch = -1).
     """
 
     __LOGGER = logging.getLogger(__name__)
@@ -238,6 +241,7 @@ class PipelineTrainer:
         test: Optional[InstancesDataset] = None,
         batch_weight_key: str = "",
         embedding_sources_mapping: Dict[str, str] = None,
+        epoch_callbacks: List["allennlp.training.EpochCallback"] = None,
     ):
         self._pipeline = pipeline
         self._trainer_config = copy.deepcopy(trainer_config)
@@ -248,6 +252,7 @@ class PipelineTrainer:
         self._training = training
         self._validation = validation
         self._test = test
+        self._epoch_callbacks = epoch_callbacks
 
         self._setup()
 
@@ -308,6 +313,7 @@ class PipelineTrainer:
             data_loader=training_data_loader,
             validation_data_loader=validation_data_loader,
             params=trainer_params,
+            epoch_callbacks=self._epoch_callbacks,
         )
 
     @staticmethod

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -154,6 +154,7 @@ class Pipeline:
         validation: Optional[Union[DataSource, InstancesDataset]] = None,
         test: Optional[Union[DataSource, InstancesDataset]] = None,
         extend_vocab: Optional[VocabularyConfiguration] = None,
+        epoch_callbacks: List["allennlp.training.EpochCallback"] = None,
         restore: bool = False,
     ) -> TrainingResults:
         """Launches a training run with the specified configurations and data sources
@@ -172,6 +173,9 @@ class Pipeline:
             The test DataSource (optional)
         extend_vocab:
             Extends the vocabulary tokens with the provided VocabularyConfiguration
+        epoch_callbacks:
+            A list of callbacks that will be called at the end of every epoch, and at the start of
+            training (with epoch = -1).
         restore:
             If enabled, tries to read previous training status from the `output` folder and
             continues the training process
@@ -222,7 +226,11 @@ class Pipeline:
                     datasets[name] = train_pipeline.create_dataset(dataset)
 
             trainer = PipelineTrainer(
-                train_pipeline, trainer_config=trainer, output_dir=output, **datasets
+                train_pipeline,
+                trainer_config=trainer,
+                output_dir=output,
+                epoch_callbacks=epoch_callbacks,
+                **datasets,
             )
 
             model_path, metrics = trainer.train()


### PR DESCRIPTION
This PR adds the feature to add "epoch callbacks" to your training.

I also removed the overriding `train` method of the `_BlankPipeline` and added the check to the `Pipeline.train()` method. In this way we avoid just passing on parameters and reduce duplication. 