### PR TITLE
feat: quiet train and train logging file

### DIFF
--- a/src/biome/text/__init__.py
+++ b/src/biome/text/__init__.py
@@ -1,8 +1,33 @@
+import logging
 import warnings
 from warnings import warn_explicit
-import logging
 
 import pkg_resources
+
+try:
+    import tqdm
+
+    class TqdmWrapper(tqdm.tqdm):
+        """
+        A tqdm wrapper for progress bar disable control
+
+        We must use this wrapper before any tqdm import (so, before any allennlp import). It's why we
+        must define at top package module level
+
+        We could discard this behaviour when this PR is merged: https://github.com/tqdm/tqdm/pull/950
+        and then just environment vars instead.
+
+        """
+
+        disable: bool = False
+
+        def __init__(self, *args, **kwargs):
+            kwargs["disable"] = TqdmWrapper.disable
+            super(TqdmWrapper, self).__init__(*args, **kwargs)
+
+    tqdm.tqdm = TqdmWrapper
+except ModuleNotFoundError:
+    pass
 
 from .pipeline import (
     Pipeline,

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -156,6 +156,7 @@ class Pipeline:
         extend_vocab: Optional[VocabularyConfiguration] = None,
         epoch_callbacks: List["allennlp.training.EpochCallback"] = None,
         restore: bool = False,
+        quiet: bool = False,
     ) -> TrainingResults:
         """Launches a training run with the specified configurations and data sources
 
@@ -179,6 +180,9 @@ class Pipeline:
         restore:
             If enabled, tries to read previous training status from the `output` folder and
             continues the training process
+        quiet:
+            If enabled, disables most logging messages keeping only warning and error messages.
+            In any case, all logging info will be stored into a file at ${output}/train.log
 
         Returns
         -------
@@ -191,13 +195,11 @@ class Pipeline:
             )
 
         trainer = trainer or TrainerConfiguration()
-
-        allennlp_logger = logging.getLogger("allennlp")
         try:
-            allennlp_logger.setLevel(logging.INFO)
-
             if not restore and os.path.isdir(output):
                 shutil.rmtree(output)
+
+            self.__configure_allennlp_logger(output, quiet)
 
             # The original pipeline keeps unchanged
             train_pipeline = copy.deepcopy(self)
@@ -237,7 +239,37 @@ class Pipeline:
             return TrainingResults(model_path, metrics)
 
         finally:
-            allennlp_logger.setLevel(logging.ERROR)
+            self.__restore_allennlp_logger()
+
+    @staticmethod
+    def __restore_allennlp_logger():
+        logger = logging.getLogger("allennlp")
+        logger.propagate = True
+        logger.handlers = []
+        logger.setLevel(logging.ERROR)
+
+    @staticmethod
+    def __configure_allennlp_logger(output_dir: str, quiet: bool = False) -> None:
+        """Configures allennlp logging"""
+        os.makedirs(output_dir, exist_ok=True)
+        logger = logging.getLogger("allennlp")
+        logger.propagate = False
+        logger.setLevel(logging.DEBUG)
+        # create file handler which logs even debug messages
+        file_handler = logging.FileHandler(os.path.join(output_dir, "train.log"))
+        file_handler.setLevel(logging.INFO)
+        # create console handler with a higher log level
+        console_handler = logging.StreamHandler()
+        console_handler.setLevel(logging.WARNING if quiet else logging.INFO)
+        # create formatter and add it to the handlers
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        file_handler.setFormatter(formatter)
+        console_handler.setFormatter(formatter)
+        # add the handlers to the logger
+        logger.addHandler(file_handler)
+        logger.addHandler(console_handler)
 
     def create_dataset(
         self, datasource: DataSource, lazy: bool = False

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -252,12 +252,14 @@ class Pipeline:
         except ModuleNotFoundError:
             pass
 
-        for logger_name in ["allennlp", "biome"]:
+        for logger_name, level in [
+            ("allennlp", logging.ERROR),
+            ("biome", logging.INFO),
+        ]:
             logger = logging.getLogger(logger_name)
-            logger.setLevel(logging.ERROR)
+            logger.setLevel(level)
             logger.propagate = True
             logger.handlers = []
-
 
     @staticmethod
     def __configure_training_logging(output_dir: str, quiet: bool = False) -> None:

--- a/tests/text/test_pipeline_datasets.py
+++ b/tests/text/test_pipeline_datasets.py
@@ -1,9 +1,10 @@
+import logging
 import os
 
 import pandas as pd
 import pytest
-from allennlp.data import AllennlpDataset, Instance, AllennlpLazyDataset
 
+# fmt: off
 from biome.text import (
     Pipeline,
     PipelineConfiguration,
@@ -12,6 +13,9 @@ from biome.text import (
 )
 from biome.text.data import DataSource
 from biome.text.modules.heads import TextClassificationConfiguration
+
+from allennlp.data import AllennlpDataset, Instance, AllennlpLazyDataset
+# fmt: on
 
 
 @pytest.fixture
@@ -138,3 +142,6 @@ def test_training_with_logging(
     with open(os.path.join(output_dir, "train.log")) as train_log:
         for line in train_log.readlines():
             assert "allennlp" in line
+
+    assert logging.getLogger("allennlp").level == logging.ERROR
+    assert logging.getLogger("biome").level == logging.INFO

--- a/tests/text/test_pipeline_datasets.py
+++ b/tests/text/test_pipeline_datasets.py
@@ -118,3 +118,23 @@ def test_training_with_data_bucketing(
         training=non_lazy_ds,
         validation=lazy_ds,
     )
+
+
+def test_training_with_logging(
+    pipeline_test: Pipeline, datasource_test: DataSource, tmp_path: str
+):
+    training = pipeline_test.create_dataset(datasource_test)
+    pipeline_test.create_vocabulary(VocabularyConfiguration(sources=[training]))
+
+    configuration = TrainerConfiguration(
+        data_bucketing=True, batch_size=2, num_epochs=5
+    )
+    output_dir = os.path.join(tmp_path, "output")
+    pipeline_test.train(
+        output=output_dir, trainer=configuration, training=training, quiet=True
+    )
+
+    assert os.path.exists(os.path.join(output_dir, "train.log"))
+    with open(os.path.join(output_dir, "train.log")) as train_log:
+        for line in train_log.readlines():
+            assert "allennlp" in line


### PR DESCRIPTION
This PR 
- Adds a `quiet` train param for disable common logging info (keeping only warnings and errors)
- Logs to file training process logging messages