### PR TITLE
sanitize input from ray tune for allennlp's from_params machinery

### DIFF
--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -248,7 +248,6 @@ class PipelineTrainer:
         self._output_dir = output_dir
         self._batch_weight_key = batch_weight_key
         self._embedding_sources_mapping = embedding_sources_mapping
-        self._batch_size = self._trainer_config.batch_size
         self._training = training
         self._validation = validation
         self._test = test
@@ -279,7 +278,9 @@ class PipelineTrainer:
                 dataset.index_with(self._pipeline.backbone.vocab)
 
         trainer_params = Params(
-            self._trainer_as_allennlp_configuration(self._trainer_config)
+            helpers.sanitize_for_params(
+                self._trainer_as_allennlp_configuration(self._trainer_config)
+            )
         )
 
         no_grad_regexes = trainer_params.pop(
@@ -351,7 +352,9 @@ class PipelineTrainer:
         self.__LOGGER.info("The model will be evaluated using the best epoch weights.")
         return evaluate(
             self._pipeline._model,
-            data_loader=DataLoader(test_data, batch_size=self._batch_size),
+            data_loader=DataLoader(
+                test_data, batch_size=self._trainer_config.batch_size
+            ),
             cuda_device=self._trainer.cuda_device,
             batch_weight_key=self._batch_weight_key,
         )

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -11,7 +11,7 @@ from biome.text.data import DataSource, InstancesDataset
 from . import vocabulary
 from .features import CharFeatures, WordFeatures
 from .featurizer import InputFeaturizer
-from .helpers import save_dict_as_yaml
+from .helpers import save_dict_as_yaml, sanitize_for_params
 from .modules.encoders import Encoder
 from .modules.heads.task_head import TaskHeadConfiguration
 from .tokenizer import Tokenizer
@@ -252,6 +252,7 @@ class PipelineConfiguration(FromParams):
         -------
         pipeline_configuration
         """
+        config_dict = sanitize_for_params(copy.deepcopy(config_dict))
         return PipelineConfiguration.from_params(Params(config_dict))
 
     def as_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
This PR allows us to simplify the usage of ray tune's parameter choices.

For example: `tune.choice()` returns numpy types, and providing a `numpy.int32` as parameter for the hidden size fails, since it expects a python `int`.