### PR TITLE
Add `Pipeline.predict_batch` method

### DIFF
--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -354,6 +354,21 @@ class Pipeline:
         """
         return self._model.predict(*args, **kwargs)
 
+    def predict_batch(
+        self, input_dicts: Iterable[Dict[str, Any]]
+    ) -> List[Dict[str, numpy.ndarray]]:
+        """Returns predictions given some input data based on the current state of the model
+
+        The predictions will be computed batch-wise, which is faster
+        than calling `self.predict` for every single input data.
+
+        Parameters
+        ----------
+        input_dicts
+            The input data. The keys of the dicts must comply with the `self.inputs` attribute
+        """
+        return self._model.predict_batch(input_dicts)
+
     def explain(self, *args, n_steps: int = 5, **kwargs) -> Dict[str, Any]:
         """Returns a prediction given some input data including the attribution of each token to the prediction.
 

--- a/tests/text/test_pipeline_model.py
+++ b/tests/text/test_pipeline_model.py
@@ -58,3 +58,17 @@ def test_explain_without_steps():
         "This is a simple test with only tokens in explain", n_steps=0
     )
     assert "explain" in prediction
+
+
+def test_predict_batch():
+    pipeline_config = PipelineConfiguration(
+        name="test-classifier",
+        head=TaskHeadConfiguration(type=TestHead),
+        features=FeaturesConfiguration(),
+    )
+    pipeline = Pipeline.from_config(pipeline_config)
+    predictions = pipeline.predict_batch([{"text": "test1"}, {"text": "test2"}])
+
+    assert len(predictions) == 2
+    assert all([isinstance(prediction, dict) for prediction in predictions])
+


### PR DESCRIPTION
This PR adds a simple `Pipeline.predict_batch` method to process the input data as a batch.

I made a little comparison with the `Pipeline.predict()` method, and for a simple text classifier with 100 instances of a one token input, the `predict_batch` is 5-6 times faster. 

I would prefer to merge a simple `predict_batch()` version first, before adding further functionality (like batch_size, for example) in follow-up PRs.

As a side note: Depending on the input, using `predict` with the prediction cache can be much faster than `predict_batch`, just to keep this in mind.