### PR TITLE
Feature: Train loggers integration

### DIFF
--- a/docs/docs/documentation/tutorials/Hyperparameter_optimization_with_Ray_Tune.ipynb
+++ b/docs/docs/documentation/tutorials/Hyperparameter_optimization_with_Ray_Tune.ipynb
@@ -305,7 +305,7 @@
    "source": [
     "In this tutorial we will use a trial scheduler that adaptively allocates resources to promising hyperparameter configurations by terminating less promising candidates early.\n",
     "The early stopping mechanism requires the reporting of some metric during a trial.\n",
-    "For this we use an `EpochCallback` that is executed after each epoch and pass it on to the `Pipeline.train()` method.\n",
+    "For this we use a `BaseTrainLogger` that defines a method `log_epoch_metrics()` which is executed after each epoch, and pass it on to the `Pipeline.train()` method.\n",
     "\n",
     "Our `TuneReport` class simply reports some metrics back to tune, which in turn are used to define promising trials during the hyperparameter search."
    ]
@@ -316,7 +316,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from allennlp.training import EpochCallback\n",
+    "from biome.text.loggers import BaseTrainLogger\n",
     "from ray import tune"
    ]
   },
@@ -326,11 +326,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "class TuneReport(EpochCallback):\n",
-    "    def __call__(self, trainer, metrics, epoch, is_master):\n",
-    "        # The EpochCallback is also called before the training starts (at epoch = -1)\n",
-    "        if epoch > -1:\n",
-    "            tune.report(validation_loss=metrics[\"validation_loss\"], validation_accuracy=metrics[\"validation_accuracy\"])"
+    "class TuneReport(BaseTrainLogger):\n",
+    "    def log_epoch_metrics(self, epoch, metrics):\n",
+    "        tune.report(validation_loss=metrics[\"validation_loss\"], validation_accuracy=metrics[\"validation_accuracy\"])"
    ]
   },
   {
@@ -388,7 +386,7 @@
     "        training=train_ds,\n",
     "        validation=valid_ds,\n",
     "        trainer=trainer_config,\n",
-    "        epoch_callbacks=[tune_report],\n",
+    "        loggers=[tune_report],\n",
     "        quiet=True,\n",
     "    )"
    ]

--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ if __name__ == "__main__":
             "s3fs~=0.4.0",
             "captum~=0.2.0",
             "ipywidgets~=7.5.1",
+            "mlflow~=1.9.0",
         ],
         extras_require={
             "testing": [
@@ -112,7 +113,7 @@ if __name__ == "__main__":
                 for file in glob.glob("src/biome/text/ui/webapp/**/*.*", recursive=True)
             ]
         },
-        entry_points={"console_scripts": ["biome=biome.text.cli:main",]},
+        entry_points={"console_scripts": ["biome=biome.text.cli:main"]},
         python_requires=">=3.6.1",  # taken from AllenNLP
         zip_safe=False,
     )

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -66,7 +66,9 @@ def get_env_cuda_device() -> int:
     return cuda_device
 
 
-def update_method_signature(signature: inspect.Signature, to_method: Callable) -> Callable:
+def update_method_signature(
+    signature: inspect.Signature, to_method: Callable
+) -> Callable:
     """Updates the signature of a method
 
     Parameters
@@ -80,6 +82,7 @@ def update_method_signature(signature: inspect.Signature, to_method: Callable) -
     -------
     updated_method
     """
+
     def wrapper(*args, **kwargs):
         return to_method(*args, **kwargs)
 

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -23,7 +23,6 @@ class BaseTrainLogger(EpochCallback):
 
         Parameters
         ----------
-
         pipeline:
             The training pipeline
         trainer_configuration:

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -58,7 +58,6 @@ class BaseTrainLogger(EpochCallback):
             The current epoch
         metrics:
             The metrics related to current epoch
-
         """
         pass
 

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -54,7 +54,6 @@ class BaseTrainLogger(EpochCallback):
 
         Parameters
         ----------
-
         epoch:
             The current epoch
         metrics:

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -33,7 +33,6 @@ class BaseTrainLogger(EpochCallback):
             Validation dataset
         test:
             Test dataset
-
         """
         pass
 

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -8,8 +8,8 @@ from biome.text.data import InstancesDataset
 from biome.text.training_results import TrainingResults
 
 
-class BaseTrainingLogger(EpochCallback):
-    """Base training logger for pipeline training"""
+class BaseTrainLogger(EpochCallback):
+    """Base train logger for pipeline training"""
 
     def init_train(
         self,
@@ -79,7 +79,7 @@ class BaseTrainingLogger(EpochCallback):
             self.log_epoch_metrics(epoch, metrics)
 
 
-class MlflowLogger(BaseTrainingLogger):
+class MlflowLogger(BaseTrainLogger):
     """A common mlflow logger for pipeline training"""
 
     def __init__(self, experiment_name: str = None, artifact_location: str = None):

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -1,0 +1,132 @@
+from typing import Any, Dict, Optional
+
+from allennlp.training import EpochCallback, GradientDescentTrainer
+from mlflow.tracking import MlflowClient
+
+from biome.text import Pipeline, TrainerConfiguration
+from biome.text.data import InstancesDataset
+from biome.text.training_results import TrainingResults
+
+
+class BaseTrainingLogger(EpochCallback):
+    """Base training logger for pipeline training"""
+
+    def init_training(
+        self,
+        pipeline: Pipeline,
+        trainer_configuration: TrainerConfiguration,
+        train: InstancesDataset,
+        validation: Optional[InstancesDataset] = None,
+        test: Optional[InstancesDataset] = None,
+    ):
+        """
+        Init training logging
+
+        Parameters
+        ----------
+
+        pipeline:
+            The training pipeline
+        trainer_configuration:
+            The trainer configuration
+        train:
+            Train dataset
+        validation:
+            Validation dataset
+        test:
+            Test dataset
+
+        """
+        pass
+
+    def end_training(self, results: TrainingResults):
+        """
+        End training logging
+
+        Parameters
+        ----------
+
+        results:
+            The training result set
+
+        """
+        pass
+
+    def log_epoch_metrics(self, epoch: int, metrics: Dict[str, Any]):
+        """
+        Log epoch metrics
+
+        Parameters
+        ----------
+
+        epoch:
+            The current epoch
+        metrics:
+            The metrics related to current epoch
+
+        """
+        pass
+
+    def __call__(
+        self,
+        trainer: GradientDescentTrainer,
+        metrics: Dict[str, Any],
+        epoch: int,
+        is_master: bool,
+    ):
+
+        if epoch >= 0:
+            self.log_epoch_metrics(epoch, metrics)
+
+
+class MlflowLogger(BaseTrainingLogger):
+    """A common mlflow logger for pipeline training"""
+
+    def __init__(self, experiment_name: str = None, artifact_location: str = None):
+        self._client = MlflowClient()
+        self._experiment = self._client.get_experiment_by_name(
+            experiment_name or "default"
+        )
+        if not self._experiment:
+            self._experiment = self._client.get_experiment(
+                self._client.create_experiment(experiment_name, artifact_location)
+            )
+
+        self._run_id = self._client.create_run(
+            self._experiment.experiment_id
+        ).info.run_id
+        self._skipped_metrics = ["training_duration"]
+
+    def init_training(
+        self,
+        pipeline: Pipeline,
+        trainer_configuration: TrainerConfiguration,
+        train: InstancesDataset,
+        validation: Optional[InstancesDataset] = None,
+        test: Optional[InstancesDataset] = None,
+    ):
+        # fmt: off
+        self._client.log_param(self._run_id, key="name", value=pipeline.name)
+        self._client.log_param(self._run_id, key="pipeline", value=pipeline.config.as_dict())
+        self._client.log_param(self._run_id, key="num_parameters", value=pipeline.trainable_parameters)
+        self._client.log_param(self._run_id, key="trainer", value=trainer_configuration)
+        # fmt: on
+
+    def log_epoch_metrics(self, epoch: int, metrics: Dict[str, Any]):
+
+        [
+            self._client.log_metric(self._run_id, key=k, value=v, step=epoch)
+            for k, v in metrics.items()
+            if k not in self._skipped_metrics
+        ]
+
+    def end_training(self, results: TrainingResults):
+        try:
+            self._client.log_artifact(self._run_id, local_path=results.model_path)
+            [
+                self._client.log_metric(self._run_id, key=k, value=v)
+                for k, v in results.metrics.items()
+                if k not in self._skipped_metrics
+            ]
+        finally:
+            self._client.set_terminated(self._run_id)

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Optional
 from allennlp.training import EpochCallback, GradientDescentTrainer
 from mlflow.tracking import MlflowClient
 
-from biome.text import Pipeline, TrainerConfiguration
 from biome.text.data import InstancesDataset
 from biome.text.training_results import TrainingResults
 
@@ -13,8 +12,8 @@ class BaseTrainLogger(EpochCallback):
 
     def init_train(
         self,
-        pipeline: Pipeline,
-        trainer_configuration: TrainerConfiguration,
+        pipeline: "Pipeline",
+        trainer_configuration: "TrainerConfiguration",
         training: InstancesDataset,
         validation: Optional[InstancesDataset] = None,
         test: Optional[InstancesDataset] = None,
@@ -99,8 +98,8 @@ class MlflowLogger(BaseTrainLogger):
 
     def init_train(
         self,
-        pipeline: Pipeline,
-        trainer_configuration: TrainerConfiguration,
+        pipeline: "Pipeline",
+        trainer_configuration: "TrainerConfiguration",
         training: InstancesDataset,
         validation: Optional[InstancesDataset] = None,
         test: Optional[InstancesDataset] = None,

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -68,7 +68,6 @@ class BaseTrainLogger(EpochCallback):
         epoch: int,
         is_master: bool,
     ):
-
         if epoch >= 0:
             self.log_epoch_metrics(epoch, metrics)
 

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -11,16 +11,16 @@ from biome.text.training_results import TrainingResults
 class BaseTrainingLogger(EpochCallback):
     """Base training logger for pipeline training"""
 
-    def init_training(
+    def init_train(
         self,
         pipeline: Pipeline,
         trainer_configuration: TrainerConfiguration,
-        train: InstancesDataset,
+        training: InstancesDataset,
         validation: Optional[InstancesDataset] = None,
         test: Optional[InstancesDataset] = None,
     ):
         """
-        Init training logging
+        Init train logging
 
         Parameters
         ----------
@@ -29,8 +29,8 @@ class BaseTrainingLogger(EpochCallback):
             The training pipeline
         trainer_configuration:
             The trainer configuration
-        train:
-            Train dataset
+        training:
+            Training dataset
         validation:
             Validation dataset
         test:
@@ -39,9 +39,9 @@ class BaseTrainingLogger(EpochCallback):
         """
         pass
 
-    def end_training(self, results: TrainingResults):
+    def end_train(self, results: TrainingResults):
         """
-        End training logging
+        End train logging
 
         Parameters
         ----------
@@ -97,11 +97,11 @@ class MlflowLogger(BaseTrainingLogger):
         ).info.run_id
         self._skipped_metrics = ["training_duration"]
 
-    def init_training(
+    def init_train(
         self,
         pipeline: Pipeline,
         trainer_configuration: TrainerConfiguration,
-        train: InstancesDataset,
+        training: InstancesDataset,
         validation: Optional[InstancesDataset] = None,
         test: Optional[InstancesDataset] = None,
     ):
@@ -120,7 +120,7 @@ class MlflowLogger(BaseTrainingLogger):
             if k not in self._skipped_metrics
         ]
 
-    def end_training(self, results: TrainingResults):
+    def end_train(self, results: TrainingResults):
         try:
             self._client.log_artifact(self._run_id, local_path=results.model_path)
             [

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -43,7 +43,6 @@ class BaseTrainLogger(EpochCallback):
 
         Parameters
         ----------
-
         results:
             The training result set
 

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -28,6 +28,7 @@ from . import constants
 from ._configuration import ElasticsearchExplore, ExploreConfiguration
 from ._model import PipelineModel
 from .backbone import ModelBackbone
+from .loggers import BaseTrainingLogger
 from .modules.heads import TaskHead, TaskHeadConfiguration
 from .training_results import TrainingResults
 
@@ -155,6 +156,7 @@ class Pipeline:
         test: Optional[Union[DataSource, InstancesDataset]] = None,
         extend_vocab: Optional[VocabularyConfiguration] = None,
         epoch_callbacks: List["allennlp.training.EpochCallback"] = None,
+        loggers: List[BaseTrainingLogger] = None,
         restore: bool = False,
         quiet: bool = False,
     ) -> TrainingResults:
@@ -177,6 +179,8 @@ class Pipeline:
         epoch_callbacks:
             A list of callbacks that will be called at the end of every epoch, and at the start of
             training (with epoch = -1).
+        loggers:
+            A list of training loggers used in training. See `MlflowLogger` as example
         restore:
             If enabled, tries to read previous training status from the `output` folder and
             continues the training process
@@ -227,16 +231,41 @@ class Pipeline:
                 if isinstance(dataset, DataSource):
                     datasets[name] = train_pipeline.create_dataset(dataset)
 
-            trainer = PipelineTrainer(
+            epoch_callbacks = epoch_callbacks or []
+            loggers = loggers or []
+
+            pipeline_trainer = PipelineTrainer(
                 train_pipeline,
                 trainer_config=trainer,
                 output_dir=output,
-                epoch_callbacks=epoch_callbacks,
+                epoch_callbacks=epoch_callbacks + loggers,
                 **datasets,
             )
 
-            model_path, metrics = trainer.train()
-            return TrainingResults(model_path, metrics)
+            for logger in loggers:
+                try:
+                    logger.init_train(
+                        pipeline=train_pipeline,
+                        trainer_configuration=trainer,
+                        **datasets,
+                    )
+                except Exception as e:
+                    self.__LOGGER.warning(
+                        "Logger %s failed on init_train: %s", logger, e
+                    )
+
+            model_path, metrics = pipeline_trainer.train()
+            train_results = TrainingResults(model_path, metrics)
+
+            for logger in loggers:
+                try:
+                    logger.end_train(train_results)
+                except Exception as e:
+                    self.__LOGGER.warning(
+                        "Logger %s failed on end_traing: %s", logger, e
+                    )
+
+            return train_results
 
         finally:
             self.__restore_training_logging()

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -180,7 +180,7 @@ class Pipeline:
             A list of callbacks that will be called at the end of every epoch, and at the start of
             training (with epoch = -1).
         loggers:
-            A list of training loggers used in training. See `MlflowLogger` as example
+            A list of loggers that execute a callback before the training, after each epoch, and at the end of the training (see `biome.text.logger.MlflowLogger`, for example)```
         restore:
             If enabled, tries to read previous training status from the `output` folder and
             continues the training process

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -28,7 +28,7 @@ from . import constants
 from ._configuration import ElasticsearchExplore, ExploreConfiguration
 from ._model import PipelineModel
 from .backbone import ModelBackbone
-from .loggers import BaseTrainingLogger
+from .loggers import BaseTrainLogger
 from .modules.heads import TaskHead, TaskHeadConfiguration
 from .training_results import TrainingResults
 
@@ -156,7 +156,7 @@ class Pipeline:
         test: Optional[Union[DataSource, InstancesDataset]] = None,
         extend_vocab: Optional[VocabularyConfiguration] = None,
         epoch_callbacks: List["allennlp.training.EpochCallback"] = None,
-        loggers: List[BaseTrainingLogger] = None,
+        loggers: List[BaseTrainLogger] = None,
         restore: bool = False,
         quiet: bool = False,
     ) -> TrainingResults:

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -155,7 +155,6 @@ class Pipeline:
         validation: Optional[Union[DataSource, InstancesDataset]] = None,
         test: Optional[Union[DataSource, InstancesDataset]] = None,
         extend_vocab: Optional[VocabularyConfiguration] = None,
-        epoch_callbacks: List["allennlp.training.EpochCallback"] = None,
         loggers: List[BaseTrainLogger] = None,
         restore: bool = False,
         quiet: bool = False,
@@ -176,11 +175,9 @@ class Pipeline:
             The test DataSource (optional)
         extend_vocab:
             Extends the vocabulary tokens with the provided VocabularyConfiguration
-        epoch_callbacks:
-            A list of callbacks that will be called at the end of every epoch, and at the start of
-            training (with epoch = -1).
         loggers:
-            A list of loggers that execute a callback before the training, after each epoch, and at the end of the training (see `biome.text.logger.MlflowLogger`, for example)```
+            A list of loggers that execute a callback before the training, after each epoch,
+            and at the end of the training (see `biome.text.logger.MlflowLogger`, for example)
         restore:
             If enabled, tries to read previous training status from the `output` folder and
             continues the training process
@@ -231,14 +228,13 @@ class Pipeline:
                 if isinstance(dataset, DataSource):
                     datasets[name] = train_pipeline.create_dataset(dataset)
 
-            epoch_callbacks = epoch_callbacks or []
             loggers = loggers or []
 
             pipeline_trainer = PipelineTrainer(
                 train_pipeline,
                 trainer_config=trainer,
                 output_dir=output,
-                epoch_callbacks=epoch_callbacks + loggers,
+                epoch_callbacks=loggers,
                 **datasets,
             )
 

--- a/tests/text/loggers.py
+++ b/tests/text/loggers.py
@@ -38,7 +38,9 @@ def test_mlflow_logger():
     assert str(trainer) == run.data.params["trainer"]
     assert str(pipeline.config.as_dict()) == run.data.params["pipeline"]
     # Artifacts
-    assert os.path.basename(model_path) in os.listdir(urlparse(run.info.artifact_uri).path)
+    assert os.path.basename(model_path) in os.listdir(
+        urlparse(run.info.artifact_uri).path
+    )
     # Metrics
     for metric in metrics:
         assert (

--- a/tests/text/loggers.py
+++ b/tests/text/loggers.py
@@ -22,13 +22,13 @@ def test_mlflow_logger():
     )
     trainer = TrainerConfiguration()
 
-    logger.init_training(pipeline, trainer, train=None)
+    logger.init_train(pipeline, trainer, training=None)
     for epoch in range(0, 10):
         logger.log_epoch_metrics(epoch, metrics={"key": 10 * epoch})
 
     model_path = mkdtemp()
     metrics = {"metric": 200}
-    logger.end_training(TrainingResults(model_path, metrics))
+    logger.end_train(TrainingResults(model_path, metrics))
 
     run = mlflow.get_run(logger._run_id)
     assert run

--- a/tests/text/loggers.py
+++ b/tests/text/loggers.py
@@ -1,0 +1,46 @@
+import os
+from tempfile import mkdtemp
+from urllib.parse import urlparse
+
+import mlflow
+
+from biome.text import Pipeline, PipelineConfiguration, TrainerConfiguration
+from biome.text.loggers import MlflowLogger
+from biome.text.modules.heads import TaskHeadConfiguration, TextClassification
+from biome.text.training_results import TrainingResults
+
+
+def test_mlflow_logger():
+
+    logger = MlflowLogger(experiment_name="test-experiment")
+
+    pipeline = Pipeline.from_config(
+        PipelineConfiguration(
+            name="test-pipeline",
+            head=TaskHeadConfiguration(type=TextClassification, labels=["A", "B"]),
+        )
+    )
+    trainer = TrainerConfiguration()
+
+    logger.init_training(pipeline, trainer, train=None)
+    for epoch in range(0, 10):
+        logger.log_epoch_metrics(epoch, metrics={"key": 10 * epoch})
+
+    model_path = mkdtemp()
+    metrics = {"metric": 200}
+    logger.end_training(TrainingResults(model_path, metrics))
+
+    run = mlflow.get_run(logger._run_id)
+    assert run
+    # Parameters
+    assert pipeline.name == run.data.params["name"]
+    assert str(pipeline.trainable_parameters) == run.data.params["num_parameters"]
+    assert str(trainer) == run.data.params["trainer"]
+    assert str(pipeline.config.as_dict()) == run.data.params["pipeline"]
+    # Artifacts
+    assert os.path.basename(model_path) in os.listdir(urlparse(run.info.artifact_uri).path)
+    # Metrics
+    for metric in metrics:
+        assert (
+            metric in run.data.metrics and run.data.metrics[metric] == metrics[metric]
+        )


### PR DESCRIPTION
This PR adds a new train component: The training logger

This component adds extra functionality to EpochCallback's (indeed, its implementation is based on callbacks) since define init and end training mechanisms that callbacks doesn't 

Also implements a `MlflowLogger`  using this new component for mlflow train logging as experiment runs.

