### PR TITLE
Add descriptive error messages for the predict/explain methods

### DIFF
--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -273,7 +273,7 @@ class PipelineModel(allennlp.models.Model):
         try:
             prediction = self.forward_on_instance(instance)
         except Exception as error:
-            raise RuntimeError(f"Failed to make a prediction for '{inputs}'") from error
+            raise WrongValueError(f"Failed to make a prediction for '{inputs}'") from error
         self.log_prediction(inputs, prediction)
 
         return prediction
@@ -307,7 +307,7 @@ class PipelineModel(allennlp.models.Model):
         try:
             predictions = self.forward_on_instances(instances)
         except Exception as error:
-            raise RuntimeError(f"Failed to make predictions for '{input_dicts}'") from error
+            raise WrongValueError(f"Failed to make predictions for '{input_dicts}'") from error
         for input_dict, prediction in zip(input_dicts, predictions):
             self.log_prediction(input_dict, prediction)
 
@@ -334,7 +334,7 @@ class PipelineModel(allennlp.models.Model):
         try:
             prediction = self.forward_on_instance(instance)
         except Exception as error:
-            raise RuntimeError(f"Failed to make a prediction for '{inputs}'") from error
+            raise WrongValueError(f"Failed to make a prediction for '{inputs}'") from error
         explained_prediction = (
             prediction
             if n_steps <= 0

--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -270,7 +270,10 @@ class PipelineModel(allennlp.models.Model):
 
         inputs = self._model_inputs_from_args(*args, **kwargs)
         instance = self.text_to_instance(**inputs)
-        prediction = self.forward_on_instance(instance)
+        try:
+            prediction = self.forward_on_instance(instance)
+        except Exception as error:
+            raise RuntimeError(f"Failed to make a prediction for '{inputs}'") from error
         self.log_prediction(inputs, prediction)
 
         return prediction
@@ -301,7 +304,10 @@ class PipelineModel(allennlp.models.Model):
             self.eval()
 
         instances = [self.text_to_instance(**input_dict) for input_dict in input_dicts]
-        predictions = self.forward_on_instances(instances)
+        try:
+            predictions = self.forward_on_instances(instances)
+        except Exception as error:
+            raise RuntimeError(f"Failed to make predictions for '{input_dicts}'") from error
         for input_dict, prediction in zip(input_dicts, predictions):
             self.log_prediction(input_dict, prediction)
 
@@ -325,7 +331,10 @@ class PipelineModel(allennlp.models.Model):
         """
         inputs = self._model_inputs_from_args(*args, **kwargs)
         instance = self.text_to_instance(**inputs)
-        prediction = self.forward_on_instance(instance)
+        try:
+            prediction = self.forward_on_instance(instance)
+        except Exception as error:
+            raise RuntimeError(f"Failed to make a prediction for '{inputs}'") from error
         explained_prediction = (
             prediction
             if n_steps <= 0


### PR DESCRIPTION
This PR adds descriptive error messages to the `predict`, `predict_batch` and `explain` method in case the model could not make a prediction for the provided input. This is only really useful when calling `Pipeline.explore()` that uses those methods under the hood. Closes #250 