### PR TITLE
feat(mlflow): logger accepts run name and tags

### DIFF
--- a/tests/text/test_loggers.py
+++ b/tests/text/test_loggers.py
@@ -3,6 +3,7 @@ from tempfile import mkdtemp
 from urllib.parse import urlparse
 
 import mlflow
+from mlflow.utils import mlflow_tags
 
 from biome.text import Pipeline, PipelineConfiguration, TrainerConfiguration
 from biome.text.loggers import MlflowLogger
@@ -12,7 +13,7 @@ from biome.text.training_results import TrainingResults
 
 def test_mlflow_logger():
 
-    logger = MlflowLogger(experiment_name="test-experiment")
+    logger = MlflowLogger(experiment_name="test-experiment", run_name="test_run", tag1="my-tag")
 
     pipeline = Pipeline.from_config(
         PipelineConfiguration(
@@ -32,6 +33,9 @@ def test_mlflow_logger():
 
     run = mlflow.get_run(logger._run_id)
     assert run
+    # Tags
+    assert "test_run" == run.data.tags[mlflow_tags.MLFLOW_RUN_NAME]
+    assert "my-tag" == run.data.tags["tag1"]
     # Parameters
     assert pipeline.name == run.data.params["name"]
     assert str(pipeline.trainable_parameters) == run.data.params["num_parameters"]


### PR DESCRIPTION
Enable configure `run_name` and run tags for mlflow logger