### PR TITLE
Fix/record pair classification explain

### DIFF
--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -142,58 +142,6 @@ def sanitize_metric_name(name: str) -> str:
     return new_name
 
 
-def get_word_tokens_ids_from_text_field_tensors(
-    text_field_tensors: TextFieldTensors,
-) -> Optional[torch.Tensor]:
-    """
-    Given a text field tensor structure, tries to extract word features related tensors
-
-    Parameters
-    ----------
-    text_field_tensors
-        The incoming record text field tensors dictionary
-
-    Returns
-    -------
-    tensor
-        `WordFeatures` related tensors if enable
-    """
-    word_features_tensors = text_field_tensors.get(WordFeatures.namespace)
-    if not word_features_tensors:
-        return None
-
-    for argument_name, tensor in word_features_tensors.items():
-        if argument_name in ["tokens", "token_ids", "input_ids"]:
-            return tensor
-
-
-def get_char_tokens_ids_from_text_field_tensors(
-    text_field_tensors: TextFieldTensors,
-) -> Optional[torch.Tensor]:
-    """
-    Given a text field tensor structure, tries to extract character features related tensors
-
-    See `TokenCharactersIndexer.tokens_to_indices` for more info
-
-    Parameters
-    ----------
-    text_field_tensors
-        The incoming record text field tensors dictionary
-
-    Returns
-    -------
-    tensor
-        `CharFeatures` related tensors if enable
-    """
-    char_features_tensors = text_field_tensors.get(CharFeatures.namespace)
-    if not char_features_tensors:
-        return None
-
-    for argument_name, tensor in char_features_tensors.items():
-        if argument_name in ["token_characters"]:
-            return tensor
-
-
 def save_dict_as_yaml(dictionary: dict, path: str) -> str:
     """Save a cfg dict to path as yaml
 

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -13,11 +13,6 @@ from allennlp.nn import InitializerApplicator, util
 from captum.attr import IntegratedGradients
 
 from biome.text.backbone import ModelBackbone
-from biome.text.configuration import CharFeatures, WordFeatures
-from biome.text.helpers import (
-    get_char_tokens_ids_from_text_field_tensors,
-    get_word_tokens_ids_from_text_field_tensors,
-)
 from biome.text.modules.encoders import TimeDistributedEncoder
 from biome.text.modules.configuration import (
     BiMpmMatchingConfiguration,

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -67,6 +67,9 @@ class RecordPairClassification(ClassificationHead):
         If provided, will be used to initialize the model parameters.
     """
 
+    _RECORD1_ARG_NAME_IN_FORWARD = "record1"
+    _RECORD2_ARG_NAME_IN_FORWARD = "record2"
+
     def __init__(
         self,
         backbone: ModelBackbone,
@@ -156,8 +159,8 @@ class RecordPairClassification(ClassificationHead):
         )
         instance = Instance(
             {
-                "record1": record1_instance.get("record"),
-                "record2": record2_instance.get("record"),
+                self._RECORD1_ARG_NAME_IN_FORWARD: record1_instance.get("record"),
+                self._RECORD2_ARG_NAME_IN_FORWARD: record2_instance.get("record"),
             }
         )
         instance = self.add_label(instance, label)
@@ -388,22 +391,22 @@ class RecordPairClassification(ClassificationHead):
         prediction_dict
             The prediction dictionary with a newly added "explain" key
         """
-        # TODO(dcfidalgo): optimize: for the prediction we already embedded and field encoded the records.
-        #     Also, the forward passes here are always done on cpu!
-
         batch = Batch([instance])
         tokens_ids = batch.as_tensor_dict()
 
-        # get attributions for each field
+        # 1. Get field encodings
+        # TODO(dcfidalgo): optimize: for the prediction we already embedded and field encoded the records.
+        #     Also, the forward passes here are always done on cpu!
         field_encoded_record1, record_mask_record1 = self._field_encoding(
-            tokens_ids.get("record1")
+            tokens_ids.get(self._RECORD1_ARG_NAME_IN_FORWARD)
         )
         field_encoded_record2, record_mask_record2 = self._field_encoding(
-            tokens_ids.get("record2")
+            tokens_ids.get(self._RECORD2_ARG_NAME_IN_FORWARD)
         )
-        if not field_encoded_record2.size() == field_encoded_record2.size():
+        if not field_encoded_record1.size() == field_encoded_record2.size():
             raise RuntimeError("Both records must have the same number of data fields!")
 
+        # 2. Get attributes
         ig = IntegratedGradients(self._bimpm_forward)
 
         prediction_target = int(np.argmax(prediction["probs"]))
@@ -465,20 +468,24 @@ class RecordPairClassification(ClassificationHead):
             ig_attribute_record2, 1
         )
 
-        # get tokens corresponding to the attributions
-        field_tokens_record1 = self._get_field_tokens(tokens_ids.get("record1"))
-        field_tokens_record2 = self._get_field_tokens(tokens_ids.get("record2"))
+        # 3. Get tokens corresponding to the attributions
+        field_tokens_record1 = []
+        for textfield in instance.get(self._RECORD1_ARG_NAME_IN_FORWARD):
+            field_tokens_record1.append(" ".join([token.text for token in textfield.tokens]))
+        field_tokens_record2 = []
+        for textfield in instance.get(self._RECORD2_ARG_NAME_IN_FORWARD):
+            field_tokens_record2.append(" ".join([token.text for token in textfield.tokens]))
 
         return {
             **prediction,
             "explain": {
-                "record1": [
+                self._RECORD1_ARG_NAME_IN_FORWARD: [
                     {"token": token, "attribution": attribution}
                     for token, attribution in zip(
                         field_tokens_record1, attributions_record1
                     )
                 ],
-                "record2": [
+                self._RECORD2_ARG_NAME_IN_FORWARD: [
                     {"token": token, "attribution": attribution}
                     for token, attribution in zip(
                         field_tokens_record2, attributions_record2
@@ -486,57 +493,6 @@ class RecordPairClassification(ClassificationHead):
                 ],
             },
         }
-
-    def _get_field_tokens(self, record_token_ids: TextFieldTensors) -> List[str]:
-        """
-        TODO(dcfidalgo): This can very likely be optimised!
-        Parameters
-        ----------
-        record_token_ids
-
-        Returns
-        -------
-
-        """
-        field_tokens = []
-
-        if WordFeatures.namespace in record_token_ids:
-            # batch size is 1 -> [0]
-            for field in get_word_tokens_ids_from_text_field_tensors(record_token_ids)[
-                0
-            ]:
-                tokens = []
-                for word_idx in field:
-                    # skipp padding
-                    if word_idx.item() == 0:
-                        continue
-                    token = self.backbone.vocab.get_token_from_index(
-                        word_idx.item(), namespace=WordFeatures.namespace
-                    )
-                    tokens.append(token)
-                field_tokens.append(" ".join(tokens))
-
-        elif CharFeatures.namespace in record_token_ids:
-            # batch size is 1 -> [0]
-            for field in get_char_tokens_ids_from_text_field_tensors(record_token_ids)[
-                0
-            ]:
-                tokens = []
-                for word in field:
-                    token = []
-                    for char_idx in word:
-                        # skipp padding
-                        if char_idx.item() == 0:
-                            continue
-                        char = self.backbone.vocab.get_token_from_index(
-                            char_idx.item(), namespace=CharFeatures.namespace
-                        )
-                        token.append(char)
-                    if token:
-                        tokens.append("".join(token))
-                field_tokens.append(" ".join(tokens))
-
-        return field_tokens
 
     @staticmethod
     def _get_attributions_and_delta(

--- a/tests/text/modules/heads/test_record_pair_classification.py
+++ b/tests/text/modules/heads/test_record_pair_classification.py
@@ -34,7 +34,7 @@ def training_data_source(tmp_path) -> DataSource:
 
 
 @pytest.fixture
-def path_to_pipeline_yaml(tmp_path) -> str:
+def pipeline_dict() -> Dict:
     pipeline_dict = {
         "name": "biome-bimpm",
         "tokenizer": {"text_cleaning": {"rules": ["strip_spaces"]}},
@@ -141,11 +141,8 @@ def path_to_pipeline_yaml(tmp_path) -> str:
             },
         },
     }
-    pipeline_yaml = tmp_path / "pipeline.yml"
-    with pipeline_yaml.open("w") as f:
-        yaml.safe_dump(pipeline_dict, f)
 
-    return str(pipeline_yaml)
+    return pipeline_dict
 
 
 @pytest.fixture
@@ -158,16 +155,24 @@ def trainer_dict() -> Dict:
     return trainer_dict
 
 
-def test_explain(path_to_pipeline_yaml):
-    pipeline = Pipeline.from_yaml(path_to_pipeline_yaml)
+def test_explain(pipeline_dict):
+    pipeline = Pipeline.from_config(pipeline_dict)
     explain = pipeline.explain(
         record1={"first_name": "Hans"}, record2={"first_name": "Hansel"},
     )
+
     assert len(explain["explain"]["record1"]) == len(explain["explain"]["record2"])
+    assert explain["explain"]["record1"][0]["token"] == "first_name Hans"
+    assert explain["explain"]["record2"][0]["token"] == "first_name Hansel"
+
+    with pytest.raises(RuntimeError):
+        pipeline.explain(
+            record1={"first_name": "Hans", "last_name": "Zimmermann"}, record2={"first_name": "Hansel"},
+        )
 
 
-def test_train(path_to_pipeline_yaml, training_data_source, trainer_dict, tmp_path):
-    pipeline = Pipeline.from_yaml(path_to_pipeline_yaml,)
+def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
+    pipeline = Pipeline.from_yaml(pipeline_dict, )
     pipeline.predict(record1={"first_name": "Hans"}, record2={"first_name": "Hansel"})
     pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_data_source]))
 

--- a/tests/text/modules/heads/test_record_pair_classification.py
+++ b/tests/text/modules/heads/test_record_pair_classification.py
@@ -172,7 +172,7 @@ def test_explain(pipeline_dict):
 
 
 def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
-    pipeline = Pipeline.from_yaml(pipeline_dict, )
+    pipeline = Pipeline.from_config(pipeline_dict)
     pipeline.predict(record1={"first_name": "Hans"}, record2={"first_name": "Hansel"})
     pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_data_source]))
 


### PR DESCRIPTION
This PR simplifies the `explain` method for the `RecordPairClassification` head, by a lot. Not sure why i did this crazy thing in the first place. I also fixed a small bug when comparing sizes, and removed the hard coded "record1"/"record2" strings.

I also updated the tests a bit.

@frascuchon i also removed two helper functions in `helpers.py` that i think were only used in the `RecordPairClassification`. But i think you co-authored them, so please let me know if you prefer to keep them.