### PR TITLE
Feat/transformer

### DIFF
--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -104,6 +104,7 @@ class FeaturesConfiguration(FromParams):
             embedder_cfg = configuration["word"]["embedder"]
             if "pretrained_file" in embedder_cfg:
                 embedder_cfg["pretrained_file"] = None
+
         return TextFieldEmbedder.from_params(
             Params(
                 {
@@ -140,6 +141,7 @@ class FeaturesConfiguration(FromParams):
             feature: TokenIndexer.from_params(Params(config["indexer"]))
             for feature, config in configuration.items()
         }
+
         return InputFeaturizer(tokenizer, indexer=indexer)
 
     def _make_allennlp_config(self) -> Dict[str, Any]:

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -294,16 +294,9 @@ class PipelineConfiguration(FromParams):
             Path to the output file
         """
         config_dict = copy.deepcopy(self.as_dict())
-        config_dict["features"]["word"] = (
-            config_dict["features"]["word"].to_dict()
-            if config_dict["features"]["word"] is not None
-            else None
-        )
-        config_dict["features"]["char"] = (
-            config_dict["features"]["char"].to_dict()
-            if config_dict["features"]["char"] is not None
-            else None
-        )
+        for feature_name, feature in config_dict["features"]:
+            if feature is not None:
+                config_dict["features"][feature_name] = feature.to_dict()
 
         save_dict_as_yaml(config_dict, path)
 

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -156,3 +156,53 @@ class CharFeatures:
             "dropout": self.dropout,
             **self.extra_params,
         }
+
+
+class TransformersFeatures:
+    """Configuration of the feature extracted with the [transformers models](https://huggingface.co/models).
+
+    We use AllenNLPs "mismatched" indexer and embedder to get word-level representations.
+    Most of the transformers models work with word-piece tokenizers.
+
+    Parameters
+    ----------
+    model_name
+        Name of one of the [transformers models](https://huggingface.co/models).
+    trainable
+        If false, freeze the transformer weights
+    """
+
+    namespace = "transformers"
+
+    def __init__(self, model_name: str, trainable: bool = False):
+        self.model_name = model_name
+        self.trainable = trainable
+
+    @property
+    def config(self) -> Dict:
+        """Returns the config in AllenNLP format"""
+        config = {
+            "indexer": {
+                "type": "pretrained_transformer_mismatched",
+                "model_name": self.model_name,
+                "namespace": self.namespace
+            },
+            "embedder": {
+                "type": "pretrained_transformer_mismatched",
+                "model_name": self.model_name,
+                "train_parameters": self.trainable,
+            },
+        }
+
+        return config
+
+    def to_dict(self) -> Dict:
+        """Returns the config as dict"""
+        return {
+            "model_name": self.model_name,
+            "trainable": self.trainable,
+        }
+
+    def to_json(self) -> Dict:
+        """Returns the config as dict for the serialized json config file"""
+        return self.to_dict()

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -644,22 +644,21 @@ class Pipeline:
         """
         Extends a data vocabulary from a given configuration.
 
-        The source vocabulary won't be changed, instead of that, a new vocabulary will be created
-        including source vocab with extended configuration
+        The source vocabulary `vocab` won't be changed, instead a new vocabulary is created
+        that includes the source vocabulary `vocab` and a vocabulary created from `vocab_config`
 
         Parameters
         ----------
-        vocab: `Vocabulary`
+        vocab
             The source vocabulary
-        vocab_config: `VocabularyConfiguration`
+        vocab_config
             The vocab extension configuration
 
         Returns
         -------
-        vocab: `Vocabulary`
+        extended_vocab
             An extended `Vocabulary` using the provided configuration
         """
-
         datasets = [
             self.create_dataset(source) if isinstance(source, DataSource) else source
             for source in vocab_config.sources
@@ -675,6 +674,7 @@ class Pipeline:
             tokens_to_add=vocab_config.tokens_to_add,
         )
         instances_vocab.extend_from_vocab(vocab)
+
         return instances_vocab
 
 

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -203,7 +203,8 @@ class Pipeline:
             self.__configure_training_logging(output, quiet)
 
             # The original pipeline keeps unchanged
-            train_pipeline = copy.deepcopy(self)
+            #train_pipeline = copy.deepcopy(self)
+            train_pipeline = self
             vocab = None
             if restore:
                 vocab = vocabulary.load_vocabulary(os.path.join(output, "vocabulary"))

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -203,19 +203,20 @@ class Pipeline:
             self.__configure_training_logging(output, quiet)
 
             # The original pipeline keeps unchanged
-            #train_pipeline = copy.deepcopy(self)
-            train_pipeline = self
+            train_pipeline = self.__make_copy()
             vocab = None
+
             if restore:
                 vocab = vocabulary.load_vocabulary(os.path.join(output, "vocabulary"))
             if extend_vocab is not None and not vocab:
                 vocab = train_pipeline._extend_vocabulary(
-                    train_pipeline._model.vocab, vocab_config=extend_vocab
+                    train_pipeline.backbone.vocab, vocab_config=extend_vocab
                 )
             if vocab:
-                train_pipeline._model.set_vocab(vocab)
+                train_pipeline._set_vocab(vocab)
+
             if vocabulary.is_empty(
-                train_pipeline._model.vocab, self.config.features.keys
+                train_pipeline.backbone.vocab, self.config.features.keys
             ):
                 raise EmptyVocabError(
                     "Found an empty vocabulary. "
@@ -266,6 +267,28 @@ class Pipeline:
 
         finally:
             self.__restore_training_logging()
+
+    def _set_vocab(self, vocab: Vocabulary):
+        """
+        Updates pipeline vocabulary with passed one. This method will overwrite the current vocab.
+
+        Parameters
+        ----------
+        vocab:
+            The vocabulary to set
+
+        """
+        self._model.set_vocab(vocab)
+
+    def __make_copy(self) -> "Pipeline":
+        """
+        Creates a copy of current pipeline instance
+        """
+        if isinstance(self, _BlankPipeline):
+            return _BlankPipeline(config=self.config, vocab=self.backbone.vocab)
+        if isinstance(self, _PreTrainedPipeline):
+            return Pipeline.from_pretrained(self.trained_path)
+        raise ValueError(f"Cannot clone pipeline {self}")
 
     @staticmethod
     def __restore_training_logging():
@@ -619,7 +642,10 @@ class Pipeline:
         self, vocab: Vocabulary, vocab_config: VocabularyConfiguration
     ) -> Vocabulary:
         """
-        Extends a data vocabulary from a given configuration
+        Extends a data vocabulary from a given configuration.
+
+        The source vocabulary won't be changed, instead of that, a new vocabulary will be created
+        including source vocab with extended configuration
 
         Parameters
         ----------
@@ -648,8 +674,8 @@ class Pipeline:
             min_pretrained_embeddings=vocab_config.min_pretrained_embeddings,
             tokens_to_add=vocab_config.tokens_to_add,
         )
-        vocab.extend_from_vocab(instances_vocab)
-        return vocab
+        instances_vocab.extend_from_vocab(vocab)
+        return instances_vocab
 
 
 class _BlankPipeline(Pipeline):

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -483,10 +483,6 @@ class Pipeline:
         """
         self._model.vocab.save_to_files(directory)
 
-    def create_vocabulary(self, config: VocabularyConfiguration) -> None:
-        """Creates a vocabulary an set it to pipeline"""
-        raise NotImplementedError
-
     def explore(
         self,
         data_source: DataSource,
@@ -759,11 +755,6 @@ class _PreTrainedPipeline(Pipeline):
         if not isinstance(self._model, PipelineModel):
             raise TypeError(f"Cannot load model. Wrong format of {self._model}")
         self._update_prediction_signatures()
-
-    def create_vocabulary(self, config: VocabularyConfiguration) -> None:
-        raise ActionNotSupportedError(
-            "Cannot create a vocabulary for an already pretrained model!!!"
-        )
 
     @staticmethod
     def __model_from_archive(archive: Archive) -> PipelineModel:

--- a/tests/integration/test_text_classification.py
+++ b/tests/integration/test_text_classification.py
@@ -39,6 +39,9 @@ def pipeline_dict() -> dict:
                 },
                 "dropout": 0.1,
             },
+            "transformers": {
+                "model_name": "distilbert-base-multilingual-cased"
+            }
         },
         "head": {
             "type": "TextClassification",
@@ -88,7 +91,7 @@ def pipeline_dict() -> dict:
 def trainer_dict() -> dict:
     return {
         "batch_size": 64,
-        "num_epochs": 5,
+        "num_epochs": 1,
         "optimizer": {"type": "adam", "lr": 0.01,},
     }
 
@@ -119,7 +122,7 @@ def test_text_classification(
     pl.train(
         output=str(output),
         trainer=trainer,
-        training=train_valid_data_source[0],
+        training=train_valid_data_source[1],
         validation=train_valid_data_source[1],
     )
 

--- a/tests/integration/test_text_classification.py
+++ b/tests/integration/test_text_classification.py
@@ -128,7 +128,7 @@ def test_text_classification(
     with (output / "metrics.json").open() as file:
         metrics = json.load(file)
 
-    assert metrics["training_loss"] == pytest.approx(0.642, abs=0.003)
+    assert metrics["training_loss"] == pytest.approx(0.670, abs=0.003)
 
     # test vocab from a pretrained file
     pl = Pipeline.from_pretrained(str(output / "model.tar.gz"))

--- a/tests/integration/test_text_classification.py
+++ b/tests/integration/test_text_classification.py
@@ -39,9 +39,6 @@ def pipeline_dict() -> dict:
                 },
                 "dropout": 0.1,
             },
-            "transformers": {
-                "model_name": "distilbert-base-multilingual-cased"
-            }
         },
         "head": {
             "type": "TextClassification",
@@ -91,7 +88,7 @@ def pipeline_dict() -> dict:
 def trainer_dict() -> dict:
     return {
         "batch_size": 64,
-        "num_epochs": 1,
+        "num_epochs": 5,
         "optimizer": {"type": "adam", "lr": 0.01,},
     }
 
@@ -122,7 +119,7 @@ def test_text_classification(
     pl.train(
         output=str(output),
         trainer=trainer,
-        training=train_valid_data_source[1],
+        training=train_valid_data_source[0],
         validation=train_valid_data_source[1],
     )
 

--- a/tests/resources/data/emotions_with_transformers.txt
+++ b/tests/resources/data/emotions_with_transformers.txt
@@ -1,0 +1,32 @@
+i didnt feel humiliated;sadness
+i can go from feeling so hopeless to so damned hopeful just from being around someone who cares and is awake;sadness
+im grabbing a minute to post i feel greedy wrong;anger
+i am ever feeling nostalgic about the fireplace i will know that it is still on the property;love
+i am feeling grouchy;anger
+ive been feeling a little burdened lately wasnt sure why that was;sadness
+ive been taking or milligrams or times recommended amount and ive fallen asleep a lot faster but i also feel like so funny;surprise
+i feel as confused about life as a teenager or as jaded as a year old man;fear
+i have been with petronas for years i feel that petronas has performed well and made a huge profit;joy
+i feel romantic too;love
+i feel like i have to make the suffering i m seeing mean something;sadness
+i do feel that running is a divine experience and that i can expect to have some type of spiritual encounter;joy
+i think it s the easiest time of year to feel dissatisfied;anger
+i feel low energy i m just thirsty;sadness
+i have immense sympathy with the general point but as a possible proto writer trying to find time to write in the corners of life and with no sign of an agent let alone a publishing contract this feels a little precious;joy
+i do not feel reassured anxiety is on each side;joy
+i didnt really feel that embarrassed;sadness
+i feel pretty pathetic most of the time;sadness
+i started feeling sentimental about dolls i had as a child and so began a collection of vintage barbie dolls from the sixties;sadness
+i now feel compromised and skeptical of the value of every unit of work i put in;fear
+i feel irritated and rejected without anyone doing anything or saying anything;anger
+i am feeling completely overwhelmed i have two strategies that help me to feel grounded pour my heart out in my journal in the form of a letter to god and then end with a list of five things i am most grateful for;fear
+i have the feeling she was amused and delighted;joy
+i was able to help chai lifeline with your support and encouragement is a great feeling and i am so glad you were able to help me;joy
+i already feel like i fucked up though because i dont usually eat at all in the morning;anger
+i still love my so and wish the best for him i can no longer tolerate the effect that bm has on our lives and the fact that is has turned my so into a bitter angry person who is not always particularly kind to the people around him when he is feeling stressed;sadness
+i feel so inhibited in someone elses kitchen like im painting on someone elses picture;sadness
+i become overwhelmed and feel defeated;sadness
+i feel kinda appalled that she feels like she needs to explain in wide and lenghth her body measures etc pp;anger
+i feel more superior dead chicken or grieving child;joy
+i get giddy over feeling elegant in a perfectly fitted pencil skirt;joy
+i remember feeling acutely distressed for a few days;fear

--- a/tests/text/test_features_transformers.py
+++ b/tests/text/test_features_transformers.py
@@ -1,0 +1,67 @@
+import pytest
+
+from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration
+from biome.text.data import DataSource
+from pathlib import Path
+
+
+@pytest.fixture
+def train_data_source() -> DataSource:
+    source = (
+        Path(__file__).parent.parent
+        / "resources"
+        / "data"
+        / "emotions_with_transformers.txt"
+    )
+    training_ds = DataSource(
+        source=str(source), format="csv", sep=";", names=["text", "label"]
+    )
+
+    return training_ds
+
+
+@pytest.fixture
+def pipeline_dict() -> dict:
+    pipeline_dict = {
+        "name": "emotions_with_transformers",
+        "features": {
+            "transformers": {"model_name": "distilroberta-base"},
+        },
+        "head": {
+            "type": "TextClassification",
+            "labels": ["anger", "fear", "joy", "love", "sadness", "surprise",],
+        },
+    }
+
+    return pipeline_dict
+
+
+@pytest.fixture
+def trainer_dict() -> dict:
+    return {
+        "batch_size": 16,
+        "num_epochs": 1,
+        "optimizer": {"type": "adam", "lr": 0.0001,},
+    }
+
+
+def test_train(tmp_path, pipeline_dict, trainer_dict, train_data_source):
+    pl = Pipeline.from_config(pipeline_dict)
+    trainer = TrainerConfiguration(**trainer_dict)
+    vocab = VocabularyConfiguration(sources=[train_data_source])
+    pl.create_vocabulary(vocab)
+
+    assert pl.backbone.vocab.get_vocab_size("transformers") == 50265
+
+    pl.predict(text="test")
+
+    output = tmp_path / "output"
+
+    training_results = pl.train(
+        output=str(output), trainer=trainer, training=train_data_source,
+    )
+
+    # test vocab from a pretrained file
+    pl = Pipeline.from_pretrained(str(output / "model.tar.gz"))
+
+    assert pl.backbone.vocab.get_vocab_size("transformers") == 50265


### PR DESCRIPTION
I think this branch is finally ready to be merged. There was a tedious issue with how the transformers vocab is treated in allennlp.
With this PR we can start using the pretrained transformers in a simple way and check if we need a more fine-grained control over their usage.

@frascuchon In the end i add the transformers namespace to the `non_padded_namespaces`. I did not see this before, but by default the PretrainedTransformerIndexer gets the `tags` namespace, which is included in the default `non_padded_namespaces` ... I left a big comment in the `create_vocabulary` method explaining the hack.

@frascuchon i also moved the `create_vocabulary` to the `_BlankPipeline` class only.

Also added a simple integration test for the new feature.

