### PR TITLE
Add transformers vocab on pipeline creation

### DIFF
--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -93,7 +93,7 @@ class PipelineModel(allennlp.models.Model):
         if not isinstance(config, PipelineConfiguration):
             config = PipelineConfiguration.from_params(config)
 
-        vocab = vocab or vocabulary.empty_vocabulary(namespaces=config.features.keys)
+        vocab = vocab or vocabulary.create_empty_vocabulary()
         tokenizer = config.build_tokenizer()
         featurizer = config.features.compile_featurizer(tokenizer)
         embedder = config.build_embedder(vocab)

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -3,16 +3,13 @@ import os
 import os.path
 import re
 from inspect import Parameter
-from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, Iterable, List, Tuple, Type
 
-import torch
 import yaml
-from allennlp.data import TextFieldTensors
 from allennlp.common import util
 from elasticsearch import Elasticsearch
 
 from . import environment
-from .features import CharFeatures, WordFeatures
 
 _INVALID_TAG_CHARACTERS = re.compile(r"[^-/\w\.]")
 

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -744,13 +744,11 @@ class _BlankPipeline(Pipeline):
         # If we do not do this, then writing the vocab to a file and loading it will fail, since AllenNLP will
         # look for its default OVV token in the vocab unless it is flagged as non_padded_namespace.
         # (see the doc string of `allennlp.data.token_indexers.PretrainedTransformerIndexer`)
-        if self._config.features.transformers is not None:
-            empty_vocab = Vocabulary(
-                non_padded_namespaces=DEFAULT_NON_PADDED_NAMESPACES
-                + (TransformersFeatures.namespace,)
-            )
-        else:
-            empty_vocab = Vocabulary()
+        
+        empty_vocab = Vocabulary(
+            non_padded_namespaces=DEFAULT_NON_PADDED_NAMESPACES
+            + (TransformersFeatures.namespace,)
+        )
 
         return empty_vocab
 


### PR DESCRIPTION
With this PR you do not have to call `Pipeline.create_vocab()` if your features do not require it, that is if you only have a `transformers` feature (shortly discussed this with @dvsrepo this morning). Otherwise you would have to make an awkward call to `Pipeline.create_vocab()` with a basically empty argument:

```python
pipeline_dict = { ... }
pl = Pipeline.from_config(pipeline_dict)
pl.create_vocabulary(VocabularyConfiguration(sources=[]))
```

@frascuchon what do you think about the solution presented in this PR? I also left an inline comment.