### PR TITLE
Refactor: simplify spacy tokenization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             "allennlp~=1.0.0",
+            "spacy~=2.3.0",
             "gevent~=1.4.0",
             "flask~=1.1.2",
             "flask-cors~=3.0.8",

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ if __name__ == "__main__":
                 "black",
                 "GitPython",
                 "pdoc3~=0.8.1",
+                "aiohttp", # Problems with new version of fsspec
                 "pytest-notebook~=0.6.0",
             ]
         },

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             "allennlp~=1.0.0",
-            "spacy~=2.3.0",
+            "spacy~=2.2.0",
             "gevent~=1.4.0",
             "flask~=1.1.2",
             "flask-cors~=3.0.8",

--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -250,7 +250,9 @@ class PipelineModel(allennlp.models.Model):
         self.__setattr__("_predict_with_cache", predict_with_cache)
 
     def _log_predictions(
-        self, input_dicts: Iterable[Dict[str, Any]], predictions: Iterable[Dict[str, Any]]
+        self,
+        input_dicts: Iterable[Dict[str, Any]],
+        predictions: Iterable[Dict[str, Any]],
     ) -> None:
         """Log predictions to a file for a model analysis and feedback sessions.
 
@@ -302,7 +304,9 @@ class PipelineModel(allennlp.models.Model):
 
         return predictions
 
-    def _get_instances_and_predictions(self, input_dicts) -> Tuple[List[Instance], List[Dict[str, numpy.ndarray]]]:
+    def _get_instances_and_predictions(
+        self, input_dicts
+    ) -> Tuple[List[Instance], List[Dict[str, numpy.ndarray]]]:
         """Returns instances from the input_dicts and their predictions.
 
         Helper method used by the predict and explain methods.
@@ -391,7 +395,7 @@ class PipelineModel(allennlp.models.Model):
         return explained_predictions
 
     def __build_explained_prediction(
-            self, prediction: Dict[str, numpy.array], instance: Instance, n_steps: int
+        self, prediction: Dict[str, numpy.array], instance: Instance, n_steps: int
     ):
 
         explained_prediction = (

--- a/src/biome/text/backbone.py
+++ b/src/biome/text/backbone.py
@@ -7,6 +7,7 @@ from allennlp.modules.seq2seq_encoders import PassThroughEncoder
 
 from .featurizer import InputFeaturizer
 from .modules.encoders import Encoder
+from .tokenizer import Tokenizer
 
 
 class ModelBackbone(torch.nn.Module):
@@ -45,8 +46,12 @@ class ModelBackbone(torch.nn.Module):
             else PassThroughEncoder(self.embedder.get_output_dim())
         )
 
+    @property
+    def tokenizer(self) -> Tokenizer:
+        return self.featurizer.tokenizer
+
     def forward(
-        self, text: TextFieldTensors, mask: torch.Tensor, num_wrapping_dims: int = 0,
+        self, text: TextFieldTensors, mask: torch.Tensor, num_wrapping_dims: int = 0
     ) -> torch.Tensor:
         """Applies the embedding and encoding layer
 

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -74,7 +74,11 @@ class FeaturesConfiguration(FromParams):
         char = CharFeatures(**char.as_dict(quiet=True)) if char else None
 
         transformers = params.pop("transformers", None)
-        transformers = TransformersFeatures(**transformers.as_dict(quiet=True)) if transformers else None
+        transformers = (
+            TransformersFeatures(**transformers.as_dict(quiet=True))
+            if transformers
+            else None
+        )
 
         params.assert_empty("FeaturesConfiguration")
         return cls(word=word, char=char, transformers=transformers)
@@ -152,7 +156,9 @@ class FeaturesConfiguration(FromParams):
         config_dict
         """
         configuration = {
-            spec.namespace: spec.config for spec in [self.word, self.char, self.transformers] if spec
+            spec.namespace: spec.config
+            for spec in [self.word, self.char, self.transformers]
+            if spec
         }
 
         return copy.deepcopy(configuration)
@@ -173,8 +179,11 @@ class TokenizerConfiguration(FromParams):
     text_cleaning
         A `TextCleaning` configuration with pre-processing rules for cleaning up and transforming raw input text.
     segment_sentences
-        Whether to segment input texts in to sentences using the default `SentenceSplitter` or
-        providing a specific configuration for a `SentenceSplitter`.
+        Whether to segment input texts in to sentences.
+    use_spacy_tokens
+        If True, tokenized token list will return spacy tokens instead allennlp tokens
+    remove_space_tokens
+        If True, all found space tokens will be removed from resultant token list.
     start_tokens
         A list of token strings to the sequence before tokenized input text.
     end_tokens
@@ -188,7 +197,9 @@ class TokenizerConfiguration(FromParams):
         max_sequence_length: int = None,
         max_nr_of_sentences: int = None,
         text_cleaning: Optional[Dict[str, Any]] = None,
-        segment_sentences: Union[bool, Dict[str, Any]] = False,
+        segment_sentences: bool = False,
+        use_spacy_tokens: bool = True,
+        remove_space_tokens: bool = True,
         start_tokens: Optional[List[str]] = None,
         end_tokens: Optional[List[str]] = None,
     ):
@@ -199,6 +210,8 @@ class TokenizerConfiguration(FromParams):
         self.segment_sentences = segment_sentences
         self.start_tokens = start_tokens
         self.end_tokens = end_tokens
+        self.use_spacy_tokens = use_spacy_tokens
+        self.remove_space_tokens = remove_space_tokens
 
 
 class PipelineConfiguration(FromParams):
@@ -490,6 +503,7 @@ class FindLRConfiguration:
         Stop the search when the current loss exceeds the best loss recorded by
         multiple of stopping factor. If `None` search proceeds till the `end_lr`
     """
+
     start_lr: float = 1e-5
     end_lr: float = 10
     num_batches: int = 100

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -198,7 +198,7 @@ class TokenizerConfiguration(FromParams):
         max_nr_of_sentences: int = None,
         text_cleaning: Optional[Dict[str, Any]] = None,
         segment_sentences: bool = False,
-        use_spacy_tokens: bool = True,
+        use_spacy_tokens: bool = False,
         remove_space_tokens: bool = True,
         start_tokens: Optional[List[str]] = None,
         end_tokens: Optional[List[str]] = None,

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -206,8 +206,8 @@ class TokenizerConfiguration(FromParams):
         self.lang = lang
         self.max_sequence_length = max_sequence_length
         self.max_nr_of_sentences = max_nr_of_sentences
-        self.text_cleaning = text_cleaning
         self.segment_sentences = segment_sentences
+        self.text_cleaning = text_cleaning
         self.start_tokens = start_tokens
         self.end_tokens = end_tokens
         self.use_spacy_tokens = use_spacy_tokens

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -179,11 +179,11 @@ class TokenizerConfiguration(FromParams):
     text_cleaning
         A `TextCleaning` configuration with pre-processing rules for cleaning up and transforming raw input text.
     segment_sentences
-        Whether to segment input texts in to sentences.
+        Whether to segment input texts into sentences.
     use_spacy_tokens
-        If True, tokenized token list will return spacy tokens instead allennlp tokens
+        If True, the tokenized token list contains spacy tokens instead of allennlp tokens
     remove_space_tokens
-        If True, all found space tokens will be removed from resultant token list.
+        If True, all found space tokens will be removed from the final token list.
     start_tokens
         A list of token strings to the sequence before tokenized input text.
     end_tokens

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -180,7 +180,7 @@ class TransformersFeatures:
             "indexer": {
                 "type": "pretrained_transformer_mismatched",
                 "model_name": self.model_name,
-                "namespace": self.namespace
+                "namespace": self.namespace,
             },
             "embedder": {
                 "type": "pretrained_transformer_mismatched",

--- a/src/biome/text/featurizer.py
+++ b/src/biome/text/featurizer.py
@@ -118,4 +118,3 @@ class InputFeaturizer:
     def has_word_features(self) -> bool:
         """Checks if word features are already configured as part of the featurization"""
         return WordFeatures.namespace in self.indexer
-

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -466,10 +466,14 @@ class RecordPairClassification(ClassificationHead):
         # 3. Get tokens corresponding to the attributions
         field_tokens_record1 = []
         for textfield in instance.get(self._RECORD1_ARG_NAME_IN_FORWARD):
-            field_tokens_record1.append(" ".join([token.text for token in textfield.tokens]))
+            field_tokens_record1.append(
+                " ".join([token.text for token in textfield.tokens])
+            )
         field_tokens_record2 = []
         for textfield in instance.get(self._RECORD2_ARG_NAME_IN_FORWARD):
-            field_tokens_record2.append(" ".join([token.text for token in textfield.tokens]))
+            field_tokens_record2.append(
+                " ".join([token.text for token in textfield.tokens])
+            )
 
         return {
             **prediction,

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -123,7 +123,11 @@ class Tokenizer:
                 for doc in self.__nlp__.pipe(paragraphs)
                 for sentence in doc.sents
             ]
-        return self._batch_tokenize(paragraphs[: self.max_nr_of_sentences])
+
+        return [
+            self._tokenize(paragraph)
+            for paragraph in paragraphs[: self.max_nr_of_sentences]
+        ]
 
     def tokenize_record(
         self, record: Dict[str, Any], exclude_record_keys: bool
@@ -197,14 +201,6 @@ class Tokenizer:
         for end_token in self._end_tokens:
             tokens.append(Token(end_token, -1))
         return tokens
-
-    def _batch_tokenize(self, texts: List[str]) -> List[List[Token]]:
-        return [
-            self._sanitize(_remove_spaces(tokens) if self._remove_spaces else tokens)
-            for tokens in self.nlp.pipe(
-                map(lambda text: text[: self.max_sequence_length], texts), n_process=-1
-            )
-        ]
 
 
 def _fetch_spacy_model(lang: str):

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -41,9 +41,7 @@ class Tokenizer:
         # this makes sure they show up in the right order.
         self._start_tokens.reverse()
         self.max_nr_of_sentences = config.max_nr_of_sentences
-        self.segment_sentences = (
-            config.segment_sentences or self.max_nr_of_sentences is not None
-        )
+        self.segment_sentences = config.segment_sentences
         self.max_sequence_length = config.max_sequence_length
 
         self.__nlp__ = get_spacy_model(self.lang, pos_tags=True, ner=False, parse=False)
@@ -116,12 +114,12 @@ class Tokenizer:
         -------
         tokens: `List[List[Token]]`
         """
-        paragraphs = [self.text_cleaning(text) for text in document]
+        texts = [self.text_cleaning(text) for text in document]
         if not self.segment_sentences:
-            return list(map(self._tokenize, paragraphs))
+            return list(map(self._tokenize, texts[: self.max_nr_of_sentences]))
         sentences = [
             sentence.string.strip()
-            for doc in self.__nlp__.pipe(paragraphs)
+            for doc in self.__nlp__.pipe(texts)
             for sentence in doc.sents
         ]
         return list(map(self._tokenize, sentences[: self.max_nr_of_sentences]))

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -1,10 +1,12 @@
 import copy
 from typing import Any, Dict, Iterable, List
 
+import spacy
 from allennlp.common import Params
+from allennlp.common.util import get_spacy_model
 from allennlp.data import Token
-from allennlp.data.tokenizers import SentenceSplitter, SpacyTokenizer
-from allennlp.data.tokenizers.sentence_splitter import SpacySentenceSplitter
+from spacy.language import Language
+from spacy.tokens.doc import Doc
 
 from biome.text.text_cleaning import DefaultTextCleaning, TextCleaning
 
@@ -25,26 +27,31 @@ class Tokenizer:
         A `TokenizerConfiguration` object
     """
 
-    def __init__(
-        self, config: "biome.text.configuration.TokenizerConfiguration",
-    ):
+    __SPACY_SENTENCIZER__ = "sentencizer"
+
+    def __init__(self, config: "biome.text.configuration.TokenizerConfiguration"):
+        _fetch_spacy_model(config.lang)
         self.lang = config.lang
-        self._fetch_spacy_model(self.lang)
 
-        if config.segment_sentences is True:
-            self.segment_sentences = SpacySentenceSplitter(
-                language=self.lang, rule_based=True
-            )
-        elif config.segment_sentences is False:
-            self.segment_sentences = None
-        else:
-            self.segment_sentences = SentenceSplitter.from_params(
-                Params(copy.deepcopy(config.segment_sentences))
-            )
-
+        self._keep_spacy_tokens = config.use_spacy_tokens
+        self._remove_spaces = config.remove_space_tokens
+        self._end_tokens = config.end_tokens or []
+        self._start_tokens = config.start_tokens or []
+        # We reverse the tokens here because we're going to insert them with `insert(0)` later;
+        # this makes sure they show up in the right order.
+        self._start_tokens.reverse()
+        self.segment_sentences = config.segment_sentences
         self.max_nr_of_sentences = config.max_nr_of_sentences
-
         self.max_sequence_length = config.max_sequence_length
+
+        self.__nlp__ = get_spacy_model(
+            self.lang, pos_tags=False, ner=False, parse=False
+        )
+        if self.segment_sentences and not self.__nlp__.has_pipe(
+            self.__SPACY_SENTENCIZER__
+        ):
+            sentencizer = self.__nlp__.create_pipe(self.__SPACY_SENTENCIZER__)
+            self.__nlp__.add_pipe(sentencizer)
 
         if config.text_cleaning is None:
             self.text_cleaning = DefaultTextCleaning()
@@ -53,26 +60,9 @@ class Tokenizer:
                 Params(copy.deepcopy(config.text_cleaning))
             )
 
-        self._base_tokenizer = SpacyTokenizer(
-            language=self.lang,
-            start_tokens=config.start_tokens,
-            end_tokens=config.end_tokens,
-        )
-
-    @staticmethod
-    def _fetch_spacy_model(lang: str):
-        # Allennlp get_spacy_model method works only for fully named models (en_core_web_sm) but no
-        # for already linked named (en, es)
-        # This is a workaround for mitigate those kind of errors. Just loading one more time, it's ok.
-        # See https://github.com/allenai/allennlp/issues/4201
-        import spacy
-
-        try:
-            spacy.load(
-                lang, disable=["vectors", "textcat", "tagger" "parser" "ner"]
-            )
-        except OSError:
-            spacy.cli.download(lang)
+    @property
+    def nlp(self) -> Language:
+        return self.__nlp__
 
     def tokenize_text(self, text: str) -> List[List[Token]]:
         """
@@ -109,48 +99,46 @@ class Tokenizer:
         tokens: `List[Token]`
 
         """
-        return self._base_tokenizer.tokenize(text[: self.max_sequence_length])
+        tokens = self.nlp(text[: self.max_sequence_length])
+        return self._sanitize(_remove_spaces(tokens) if self._remove_spaces else tokens)
 
     def tokenize_document(self, document: List[str]) -> List[List[Token]]:
         """ Tokenizes a document-like structure containing lists of text inputs
 
-        Use this to account for hierarchical text structures (e.g., a paragraph is a list of sentences)
+        Use this to account for hierarchical text structures (e.g., a paragraph)
 
         Parameters
         ----------
         document: `List[str]`
-            A `List` with text inputs, e.g., sentences
-            
+            A `List` with text inputs, e.g., paragraphs
+
         Returns
         -------
         tokens: `List[List[Token]]`
         """
-        sentences = [self.text_cleaning(text) for text in document]
+        paragraphs = [self.text_cleaning(text) for text in document]
         if self.segment_sentences:
-            sentences = [
-                sentence
-                for sentences in self.segment_sentences.batch_split_sentences(sentences)
-                for sentence in sentences
+            paragraphs = [
+                sentence.string.strip()
+                for doc in self.__nlp__.pipe(paragraphs)
+                for sentence in doc.sents
             ]
-        return [
-            self._tokenize(sentence)
-            for sentence in sentences[: self.max_nr_of_sentences]
-        ]
+        return self._batch_tokenize(paragraphs[: self.max_nr_of_sentences])
 
     def tokenize_record(
         self, record: Dict[str, Any], exclude_record_keys: bool
     ) -> List[List[Token]]:
         """ Tokenizes a record-like structure containing text inputs
-        
+
         Use this to keep information about the record-like data structure as input features to the model.
-        
+
         Parameters
         ----------
         record: `Dict[str, Any]`
             A `Dict` with arbitrary "fields" containing text.
         exclude_record_keys: `bool`
             If enabled, exclude tokens related to record key text
-            
+
         Returns
         -------
         tokens: `List[List[Token]]`
@@ -184,3 +172,53 @@ class Tokenizer:
     def _sanitize_dict(self, data: Dict[str, Any]) -> Dict[str, str]:
         """Transforms an data dictionary into a dictionary of strings values"""
         return {key: self._value_as_string(value) for key, value in data.items()}
+
+    def _sanitize(self, tokens: List[spacy.tokens.Token]) -> List[Token]:
+        """
+        Converts spaCy tokens to allennlp tokens. Is a no-op if
+        keep_spacy_tokens is True
+        """
+        if not self._keep_spacy_tokens:
+            tokens = [
+                Token(
+                    token.text,
+                    token.idx,
+                    token.idx + len(token.text),
+                    token.lemma_,
+                    token.pos_,
+                    token.tag_,
+                    token.dep_,
+                    token.ent_type_,
+                )
+                for token in tokens
+            ]
+        for start_token in self._start_tokens:
+            tokens.insert(0, Token(start_token, 0))
+        for end_token in self._end_tokens:
+            tokens.append(Token(end_token, -1))
+        return tokens
+
+    def _batch_tokenize(self, texts: List[str]) -> List[List[Token]]:
+        return [
+            self._sanitize(_remove_spaces(tokens) if self._remove_spaces else tokens)
+            for tokens in self.nlp.pipe(
+                map(lambda text: text[: self.max_sequence_length], texts), n_process=-1
+            )
+        ]
+
+
+def _fetch_spacy_model(lang: str):
+    # Allennlp get_spacy_model method works only for fully named models (en_core_web_sm) but no
+    # for already linked named (en, es)
+    # This is a workaround for mitigate those kind of errors. Just loading one more time, it's ok.
+    # See https://github.com/allenai/allennlp/issues/4201
+    import spacy
+
+    try:
+        spacy.load(lang, disable=["vectors", "textcat", "tagger" "parser" "ner"])
+    except OSError:
+        spacy.cli.download(lang)
+
+
+def _remove_spaces(tokens: List[spacy.tokens.Token]) -> List[spacy.tokens.Token]:
+    return [token for token in tokens if not token.is_space]

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -45,7 +45,7 @@ class Tokenizer:
         self.max_sequence_length = config.max_sequence_length
 
         self.__nlp__ = get_spacy_model(
-            self.lang, pos_tags=False, ner=False, parse=False
+            self.lang, pos_tags=True, ner=False, parse=False
         )
         if self.segment_sentences and not self.__nlp__.has_pipe(
             self.__SPACY_SENTENCIZER__

--- a/tests/integration/test_text_classification.py
+++ b/tests/integration/test_text_classification.py
@@ -128,7 +128,7 @@ def test_text_classification(
     with (output / "metrics.json").open() as file:
         metrics = json.load(file)
 
-    assert metrics["training_loss"] == pytest.approx(0.670, abs=0.003)
+    assert metrics["training_loss"] == pytest.approx(0.705, abs=0.003)
 
     # test vocab from a pretrained file
     pl = Pipeline.from_pretrained(str(output / "model.tar.gz"))

--- a/tests/integration/test_text_classification.py
+++ b/tests/integration/test_text_classification.py
@@ -28,7 +28,7 @@ def pipeline_dict() -> dict:
     pipeline_dict = {
         "name": "german_business_names",
         "features": {
-            "word": {"embedding_dim": 16, "lowercase_tokens": True,},
+            "word": {"embedding_dim": 16, "lowercase_tokens": True},
             "char": {
                 "embedding_dim": 16,
                 "encoder": {
@@ -89,7 +89,7 @@ def trainer_dict() -> dict:
     return {
         "batch_size": 64,
         "num_epochs": 5,
-        "optimizer": {"type": "adam", "lr": 0.01,},
+        "optimizer": {"type": "adam", "lr": 0.01},
     }
 
 
@@ -104,10 +104,10 @@ def test_text_classification(
         torch.cuda.manual_seed_all(4222)
 
     pl = Pipeline.from_config(pipeline_dict)
+    train_ds = pl.create_dataset(train_valid_data_source[0])
+    valid_ds = pl.create_dataset(train_valid_data_source[1])
     trainer = TrainerConfiguration(**trainer_dict)
-    vocab = VocabularyConfiguration(
-        sources=[train_valid_data_source[0]], max_vocab_size={"word": 50}
-    )
+    vocab = VocabularyConfiguration(sources=[train_ds], max_vocab_size={"word": 50})
 
     pl.create_vocabulary(vocab)
 
@@ -117,10 +117,7 @@ def test_text_classification(
     output = tmp_path / "output"
 
     pl.train(
-        output=str(output),
-        trainer=trainer,
-        training=train_valid_data_source[0],
-        validation=train_valid_data_source[1],
+        output=str(output), trainer=trainer, training=train_ds, validation=valid_ds
     )
 
     assert pl.trainable_parameters == 22070
@@ -128,7 +125,7 @@ def test_text_classification(
     with (output / "metrics.json").open() as file:
         metrics = json.load(file)
 
-    assert metrics["training_loss"] == pytest.approx(0.705, abs=0.003)
+    assert metrics["training_loss"] == pytest.approx(0.670, abs=0.003)
 
     # test vocab from a pretrained file
     pl = Pipeline.from_pretrained(str(output / "model.tar.gz"))

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -65,7 +65,7 @@ def test_document_cleaning():
 
 
 def test_using_spacy_tokens():
-    tokenizer = Tokenizer(TokenizerConfiguration())
+    tokenizer = Tokenizer(TokenizerConfiguration(use_spacy_tokens=True))
     tokenized = tokenizer.tokenize_text("This is a text")
     assert len(tokenized) == 1
     assert len(tokenized[0]) == 4

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -78,3 +78,16 @@ def test_using_allennlp_tokens():
     assert len(tokenized) == 1
     assert len(tokenized[0]) == 4
     assert all(map(lambda t: isinstance(t, AllennlpToken), tokenized[0]))
+
+
+def test_set_sentence_segmentation_with_max_number_of_sentences():
+    tokenizer = Tokenizer(TokenizerConfiguration(max_nr_of_sentences=2))
+    assert tokenizer.segment_sentences
+
+    tokenized = tokenizer.tokenize_text(
+        """
+This is a sentence. This is another sentence.
+One more sentence here. Last sentence here.
+"""
+    )
+    assert len(tokenized) == 2

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -65,7 +65,7 @@ def test_document_cleaning():
 
 
 def test_using_spacy_tokens():
-    tokenizer = Tokenizer(TokenizerConfiguration(use_spacy_tokens=True))
+    tokenizer = Tokenizer(TokenizerConfiguration())
     tokenized = tokenizer.tokenize_text("This is a text")
     assert len(tokenized) == 1
     assert len(tokenized[0]) == 4
@@ -73,7 +73,7 @@ def test_using_spacy_tokens():
 
 
 def test_using_allennlp_tokens():
-    tokenizer = Tokenizer(TokenizerConfiguration())
+    tokenizer = Tokenizer(TokenizerConfiguration(use_spacy_tokens=False))
     tokenized = tokenizer.tokenize_text("This is a text")
     assert len(tokenized) == 1
     assert len(tokenized[0]) == 4

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -82,12 +82,11 @@ def test_using_allennlp_tokens():
 
 def test_set_sentence_segmentation_with_max_number_of_sentences():
     tokenizer = Tokenizer(TokenizerConfiguration(max_nr_of_sentences=2))
-    assert tokenizer.segment_sentences
-
-    tokenized = tokenizer.tokenize_text(
-        """
-This is a sentence. This is another sentence.
-One more sentence here. Last sentence here.
-"""
+    tokenized = tokenizer.tokenize_document(
+        [
+            "This is a sentence. This is another sentence.",
+            "One more sentence here.",
+            "Last sentence here.",
+        ]
     )
     assert len(tokenized) == 2

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,4 +1,6 @@
-from biome.text.text_cleaning import DefaultTextCleaning
+from allennlp.data import Token as AllennlpToken
+from spacy.tokens.token import Token as SpacyToken
+
 from biome.text.configuration import TokenizerConfiguration
 from biome.text.tokenizer import Tokenizer
 
@@ -60,3 +62,19 @@ def test_document_cleaning():
         len(tokenized[0]) == 7
     ), "Expected [My, First, Heading, My, first, paragraph, .]"
     assert len(tokenized[1]) == 4, "Expected [My, second, paragraph, .]"
+
+
+def test_using_spacy_tokens():
+    tokenizer = Tokenizer(TokenizerConfiguration(use_spacy_tokens=True))
+    tokenized = tokenizer.tokenize_text("This is a text")
+    assert len(tokenized) == 1
+    assert len(tokenized[0]) == 4
+    assert all(map(lambda t: isinstance(t, SpacyToken), tokenized[0]))
+
+
+def test_using_allennlp_tokens():
+    tokenizer = Tokenizer(TokenizerConfiguration())
+    tokenized = tokenizer.tokenize_text("This is a text")
+    assert len(tokenized) == 1
+    assert len(tokenized[0]) == 4
+    assert all(map(lambda t: isinstance(t, AllennlpToken), tokenized[0]))

--- a/tests/text/modules/heads/test_record_pair_classification.py
+++ b/tests/text/modules/heads/test_record_pair_classification.py
@@ -167,7 +167,8 @@ def test_explain(pipeline_dict):
 
     with pytest.raises(RuntimeError):
         pipeline.explain(
-            record1={"first_name": "Hans", "last_name": "Zimmermann"}, record2={"first_name": "Hansel"},
+            record1={"first_name": "Hans", "last_name": "Zimmermann"},
+            record2={"first_name": "Hansel"},
         )
 
 

--- a/tests/text/test_configuration.py
+++ b/tests/text/test_configuration.py
@@ -24,7 +24,7 @@ def pipeline_yaml(tmp_path):
         "name": "test_pipeline_config",
         "tokenizer": {
             "text_cleaning": {"rules": ["strip_spaces"]},
-            "use_spacy_tokens": True
+            "use_spacy_tokens": True,
         },
         "features": {
             "word": {"embedding_dim": 2, "lowercase_tokens": True},

--- a/tests/text/test_configuration.py
+++ b/tests/text/test_configuration.py
@@ -1,5 +1,7 @@
 import pytest
 import yaml
+from allennlp.data.fields import ListField, TextField
+from spacy.tokens.token import Token
 
 from biome.text import Pipeline
 from biome.text.configuration import (
@@ -132,6 +134,15 @@ def test_pipeline_config(pipeline_yaml):
     assert pl.trainable_parameters == pl_yaml.trainable_parameters
 
     sample_text = "My simple text"
-    assert pl.backbone.featurizer(sample_text) == pl_yaml.backbone.featurizer(
-        sample_text
-    )
+    for instance in [
+        pl.backbone.featurizer(sample_text),
+        pl_yaml.backbone.featurizer(sample_text),
+    ]:
+        for key, value in instance.items():
+            assert key == "record"
+            assert isinstance(value, ListField)
+            assert len(value) == 1
+            for text in value:
+                assert isinstance(text, TextField)
+                assert all(map(lambda t: isinstance(t, Token), text.tokens))
+                assert sample_text == " ".join([t.text for t in text.tokens])

--- a/tests/text/test_configuration.py
+++ b/tests/text/test_configuration.py
@@ -22,9 +22,12 @@ from biome.text.modules.configuration.allennlp_configuration import (
 def pipeline_yaml(tmp_path):
     pipeline_dict = {
         "name": "test_pipeline_config",
-        "tokenizer": {"text_cleaning": {"rules": ["strip_spaces"]},},
+        "tokenizer": {
+            "text_cleaning": {"rules": ["strip_spaces"]},
+            "use_spacy_tokens": True
+        },
         "features": {
-            "word": {"embedding_dim": 2, "lowercase_tokens": True,},
+            "word": {"embedding_dim": 2, "lowercase_tokens": True},
             "char": {
                 "embedding_dim": 2,
                 "encoder": {
@@ -45,7 +48,7 @@ def pipeline_yaml(tmp_path):
         "head": {
             "type": "TextClassification",
             "labels": ["duplicate", "not_duplicate"],
-            "pooler": {"type": "boe",},
+            "pooler": {"type": "boe"},
         },
     }
 
@@ -93,7 +96,9 @@ def test_pipeline_without_word_features():
 
 
 def test_pipeline_config(pipeline_yaml):
-    tokenizer_config = TokenizerConfiguration(text_cleaning={"rules": ["strip_spaces"]})
+    tokenizer_config = TokenizerConfiguration(
+        text_cleaning={"rules": ["strip_spaces"]}, use_spacy_tokens=True
+    )
 
     word_features = WordFeatures(embedding_dim=2, lowercase_tokens=True)
     char_features = CharFeatures(

--- a/tests/text/test_features_transformers.py
+++ b/tests/text/test_features_transformers.py
@@ -24,9 +24,7 @@ def train_data_source() -> DataSource:
 def pipeline_dict() -> dict:
     pipeline_dict = {
         "name": "emotions_with_transformers",
-        "features": {
-            "transformers": {"model_name": "distilroberta-base"},
-        },
+        "features": {"transformers": {"model_name": "distilroberta-base"},},
         "head": {
             "type": "TextClassification",
             "labels": ["anger", "fear", "joy", "love", "sadness", "surprise",],

--- a/tests/text/test_loggers.py
+++ b/tests/text/test_loggers.py
@@ -14,7 +14,9 @@ from biome.text.training_results import TrainingResults
 def test_mlflow_logger():
 
     logger = MlflowLogger(
-        experiment_name="test-experiment", run_name="test_run", tag1="my-tag"
+        experiment_name="test-experiment",
+        run_name="test_run",
+        tag1="my-tag"
     )
 
     pipeline = Pipeline.from_config(
@@ -53,6 +55,7 @@ def test_mlflow_logger():
         "trainer.patience": "2",
         "trainer.num_epochs": "20",
         "trainer.cuda_device": "-1",
+        'pipeline.tokenizer.use_spacy_tokens': 'True',
     }
     assert expected_parmams == run.data.params
     # Artifacts

--- a/tests/text/test_loggers.py
+++ b/tests/text/test_loggers.py
@@ -14,9 +14,7 @@ from biome.text.training_results import TrainingResults
 def test_mlflow_logger():
 
     logger = MlflowLogger(
-        experiment_name="test-experiment",
-        run_name="test_run",
-        tag1="my-tag"
+        experiment_name="test-experiment", run_name="test_run", tag1="my-tag"
     )
 
     pipeline = Pipeline.from_config(
@@ -55,7 +53,7 @@ def test_mlflow_logger():
         "trainer.patience": "2",
         "trainer.num_epochs": "20",
         "trainer.cuda_device": "-1",
-        'pipeline.tokenizer.use_spacy_tokens': 'True',
+        "pipeline.tokenizer.remove_space_tokens": "True",
     }
     assert expected_parmams == run.data.params
     # Artifacts

--- a/tests/tutorials/test_tutorials.py
+++ b/tests/tutorials/test_tutorials.py
@@ -48,7 +48,9 @@ def test_slot_filling_tutorial(tmp_path):
     for cell in notebook["cells"]:
         if cell["source"].startswith("!pip install"):
             cell["source"] = re.sub(r"!pip install", r"#!pip install", cell["source"])
-        if cell["source"].startswith("from biome.text.configuration import FeaturesConfiguration"):
+        if cell["source"].startswith(
+            "from biome.text.configuration import FeaturesConfiguration"
+        ):
             cell["source"] = re.sub(
                 r"https://dl.fbaipublicfiles.com/fasttext/vectors-english/wiki-news-300d-1M.vec.zip",
                 r"https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/token_classifier/wiki-news-300d-1M.head.vec",
@@ -62,7 +64,9 @@ def test_slot_filling_tutorial(tmp_path):
             )
         if cell["source"].startswith("pl.train("):
             cell["source"] = re.sub(
-                r"pl.train", r"from biome.text.configuration import TrainerConfiguration\npl.train", cell["source"],
+                r"pl.train",
+                r"from biome.text.configuration import TrainerConfiguration\npl.train",
+                cell["source"],
             )
             cell["source"] = re.sub(
                 r"training=train_ds", r"training=valid_ds", cell["source"],


### PR DESCRIPTION
This PR tries to simplify integration with spacy at tokenization leve. By discarding all intermediate allennlp components, we gain in spacy dependency control and flow. This can be important for complex pipeline integrations (for data extraction) and some classification problems where tokenization affects to gold labels (Token classification)