### PR TITLE
Add WandBLogger

### DIFF
--- a/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb
+++ b/docs/docs/documentation/tutorials/Training_a_sequence_tagger_for_Slot_Filling.ipynb
@@ -712,7 +712,7 @@
     }
    ],
    "source": [
-    "pl.trainable_parameters"
+    "pl.num_trainable_parameters"
    ]
   },
   {

--- a/docs/docs/documentation/tutorials/Training_a_text_classifier.ipynb
+++ b/docs/docs/documentation/tutorials/Training_a_text_classifier.ipynb
@@ -514,7 +514,7 @@
     }
    ],
    "source": [
-    "pl.trainable_parameters"
+    "pl.num_trainable_parameters"
    ]
   },
   {

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -159,16 +159,21 @@ class MlflowLogger(BaseTrainLogger):
     ):
         from pandas import json_normalize
 
-        # fmt: off
         for prefix, params_set in [
             ("pipeline", json_normalize(pipeline.config.as_dict())),
-            ("trainer", json_normalize(dataclasses.asdict(trainer_configuration)))
+            ("trainer", json_normalize(dataclasses.asdict(trainer_configuration))),
         ]:
             for key, value in params_set.to_dict(orient="records")[0].items():
                 if value:
                     self._client.log_param(self._run_id, f"{prefix}.{key}", value)
-        self._client.log_param(self._run_id, key="pipeline.num_parameters", value=pipeline.trainable_parameters)
-        # fmt: on
+        self._client.log_param(
+            self._run_id, key="pipeline.num_parameters", value=pipeline.num_parameters
+        )
+        self._client.log_param(
+            self._run_id,
+            key="pipeline.num_trainable_parameters",
+            value=pipeline.num_trainable_parameters,
+        )
 
     def log_epoch_metrics(self, epoch: int, metrics: Dict[str, Any]):
 
@@ -203,10 +208,14 @@ class WandBLogger(BaseTrainLogger):
         Extra arguments used as tags to created experiment run
     """
 
-    def __init__(self, project_name: str = "biome", run_name: str = None, tags: List[str] = None):
+    def __init__(
+        self, project_name: str = "biome", run_name: str = None, tags: List[str] = None
+    ):
         if wandb.api.api_key is None:
-            wandb.termwarn("W&B installed but not logged in. "
-                           "Run `wandb login` or `import wandb; wandb.login()` or set the WANDB_API_KEY env variable.")
+            wandb.termwarn(
+                "W&B installed but not logged in. "
+                "Run `wandb login` or `import wandb; wandb.login()` or set the WANDB_API_KEY env variable."
+            )
 
         self.project_name = project_name
         self.run_name = run_name
@@ -224,8 +233,11 @@ class WandBLogger(BaseTrainLogger):
             "pipeline": pipeline.config.as_dict(),
             "trainer": dataclasses.asdict(trainer_configuration),
         }
-        config["pipeline"]["trainable_parameters"] = pipeline.trainable_parameters
-        wandb.init(project=self.project_name, name=self.run_name, tags=self.tags, config=config)
+        config["pipeline"]["num_parameters"] = pipeline.num_parameters
+        config["pipeline"]["num_trainable_parameters"] = pipeline.num_trainable_parameters
+        wandb.init(
+            project=self.project_name, name=self.run_name, tags=self.tags, config=config
+        )
 
     def log_epoch_metrics(self, epoch: int, metrics: Dict[str, Any]):
         wandb.log(metrics)
@@ -244,12 +256,11 @@ def add_default_wandb_logger_if_needed(loggers: List[BaseTrainLogger]) -> None:
     elif any([isinstance(logger, WandBLogger) for logger in loggers]):
         pass
     elif wandb.api.api_key is None:
-        wandb.termwarn("W&B installed but not logged in. "
-                       "Run `wandb login` or `import wandb; wandb.login()` or set the WANDB_API_KEY env variable.")
+        wandb.termwarn(
+            "W&B installed but not logged in. "
+            "Run `wandb login` or `import wandb; wandb.login()` or set the WANDB_API_KEY env variable."
+        )
     else:
         loggers.append(WandBLogger())
 
     return None
-
-
-

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -224,6 +224,7 @@ class WandBLogger(BaseTrainLogger):
             "pipeline": pipeline.config.as_dict(),
             "trainer": dataclasses.asdict(trainer_configuration),
         }
+        config["pipeline"]["trainable_parameters"] = pipeline.trainable_parameters
         wandb.init(project=self.project_name, name=self.run_name, tags=self.tags, config=config)
 
     def log_epoch_metrics(self, epoch: int, metrics: Dict[str, Any]):

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -1,6 +1,6 @@
 import dataclasses
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 from allennlp.training import EpochCallback, GradientDescentTrainer
 from mlflow.entities import Experiment
@@ -10,6 +10,15 @@ from mlflow.utils import mlflow_tags
 
 from biome.text.data import InstancesDataset
 from biome.text.training_results import TrainingResults
+
+# We do not require wandb
+try:
+    import wandb
+except ImportError:
+    _HAS_WANDB = False
+else:
+    wandb.ensure_configured()
+    _HAS_WANDB = True
 
 
 class BaseTrainLogger(EpochCallback):
@@ -179,3 +188,67 @@ class MlflowLogger(BaseTrainLogger):
             ]
         finally:
             self._client.set_terminated(self._run_id)
+
+
+class WandBLogger(BaseTrainLogger):
+    """Logger for WandB
+
+    Parameters
+    ----------
+    project_name
+        Name of your WandB project
+    run_name
+        Name of your run
+    tags
+        Extra arguments used as tags to created experiment run
+    """
+
+    def __init__(self, project_name: str = "biome", run_name: str = None, tags: List[str] = None):
+        if wandb.api.api_key is None:
+            wandb.termwarn("W&B installed but not logged in. "
+                           "Run `wandb login` or `import wandb; wandb.login()` or set the WANDB_API_KEY env variable.")
+
+        self.project_name = project_name
+        self.run_name = run_name
+        self.tags = tags
+
+    def init_train(
+        self,
+        pipeline: "Pipeline",
+        trainer_configuration: "TrainerConfiguration",
+        training: InstancesDataset,
+        validation: Optional[InstancesDataset] = None,
+        test: Optional[InstancesDataset] = None,
+    ):
+        config = {
+            "pipeline": pipeline.config.as_dict(),
+            "trainer": dataclasses.asdict(trainer_configuration),
+        }
+        wandb.init(project=self.project_name, name=self.run_name, tags=self.tags, config=config)
+
+    def log_epoch_metrics(self, epoch: int, metrics: Dict[str, Any]):
+        wandb.log(metrics)
+
+
+def add_default_wandb_logger_if_needed(loggers: List[BaseTrainLogger]) -> None:
+    """Adds the default WandBLogger if a WandB login is detected and no WandBLogger is found in `loggers`.
+
+    Parameters
+    ----------
+    loggers
+        List of loggers used in the training
+    """
+    if not _HAS_WANDB:
+        pass
+    elif any([isinstance(logger, WandBLogger) for logger in loggers]):
+        pass
+    elif wandb.api.api_key is None:
+        wandb.termwarn("W&B installed but not logged in. "
+                       "Run `wandb login` or `import wandb; wandb.login()` or set the WANDB_API_KEY env variable.")
+    else:
+        loggers.append(WandBLogger())
+
+    return None
+
+
+

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -668,9 +668,8 @@ class Pipeline:
         return self.head.__class__.__name__
 
     @property
-    def trainable_parameters(self) -> int:
-        """
-        Returns the number of trainable parameters.
+    def num_trainable_parameters(self) -> int:
+        """Number of trainable parameters present in the model.
 
         At training time, this number can change when freezing/unfreezing certain parameter groups.
         """
@@ -682,7 +681,17 @@ class Pipeline:
         return sum(p.numel() for p in self._model.parameters() if p.requires_grad)
 
     @property
-    def trainable_parameter_names(self) -> List[str]:
+    def num_parameters(self) -> int:
+        """Number of parameters present in the model."""
+        if vocabulary.is_empty(self._model.vocab, self.config.features.keys):
+            self.__LOGGER.warning(
+                "Your vocabulary is still empty! "
+                "The number of trainable parameters usually depend on the size of your vocabulary."
+            )
+        return sum(p.numel() for p in self._model.parameters())
+
+    @property
+    def named_trainable_parameters(self) -> List[str]:
         """Returns the names of the trainable parameters in the pipeline"""
         return [name for name, p in self._model.named_parameters() if p.requires_grad]
 

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -16,7 +16,7 @@ from allennlp.data import (
     Vocabulary,
     Token,
 )
-from allennlp.models import load_archive, Model
+from allennlp.models import load_archive
 from allennlp.models.archival import Archive
 from allennlp.commands.find_learning_rate import search_learning_rate
 from dask import dataframe as dd
@@ -37,7 +37,7 @@ from . import constants
 from ._configuration import ElasticsearchExplore, ExploreConfiguration
 from ._model import PipelineModel
 from .backbone import ModelBackbone
-from .loggers import BaseTrainLogger
+from .loggers import BaseTrainLogger, add_default_wandb_logger_if_needed
 from .modules.heads import TaskHead, TaskHeadConfiguration
 from .training_results import TrainingResults
 
@@ -256,8 +256,8 @@ class Pipeline:
 
         Returns
         -------
-
-        Training results information, containing the generated model path and the related metrics
+        training_results
+            Training results including the generated model path and the related metrics
         """
         if extend_vocab is not None and isinstance(self, _BlankPipeline):
             raise ActionNotSupportedError(
@@ -300,6 +300,7 @@ class Pipeline:
                     datasets[name] = train_pipeline.create_dataset(dataset)
 
             loggers = loggers or []
+            add_default_wandb_logger_if_needed(loggers)
 
             pipeline_trainer = PipelineTrainer(
                 train_pipeline,

--- a/tests/integration/test_text_classification.py
+++ b/tests/integration/test_text_classification.py
@@ -120,7 +120,7 @@ def test_text_classification(
         output=str(output), trainer=trainer, training=train_ds, validation=valid_ds
     )
 
-    assert pl.trainable_parameters == 22070
+    assert pl.num_trainable_parameters == 22070
 
     with (output / "metrics.json").open() as file:
         metrics = json.load(file)

--- a/tests/text/test_configuration.py
+++ b/tests/text/test_configuration.py
@@ -135,8 +135,9 @@ def test_pipeline_config(pipeline_yaml):
 
     pl_yaml = Pipeline.from_yaml(pipeline_yaml)
 
-    assert pl.trainable_parameter_names == pl_yaml.trainable_parameter_names
-    assert pl.trainable_parameters == pl_yaml.trainable_parameters
+    assert pl.named_trainable_parameters == pl_yaml.named_trainable_parameters
+    assert pl.num_trainable_parameters == pl_yaml.num_trainable_parameters
+    assert pl.num_parameters == pl_yaml.num_parameters
 
     sample_text = "My simple text"
     for instance in [

--- a/tests/text/test_pipeline_datasets.py
+++ b/tests/text/test_pipeline_datasets.py
@@ -145,7 +145,8 @@ def test_training_from_pretrained_with_head_replace(
     trained.config.tokenizer.max_nr_of_sentences = 3
     copied = trained._make_copy()
     assert isinstance(copied.head, TestHead)
-    assert copied.trainable_parameters == trained.trainable_parameters
+    assert copied.num_parameters == trained.num_parameters
+    assert copied.num_trainable_parameters == trained.num_trainable_parameters
     copied_model_state = copied._model.state_dict()
     original_model_state = trained._model.state_dict()
     for key, value in copied_model_state.items():


### PR DESCRIPTION
This PR adds a simple `WandBLogger`.
If the `wandb` module can be imported and if a login is detected, all training runs will be logged automatically to your wandb account. 