### PR TITLE
Add batches_per_epoch argument to TrainerConfiguration

### DIFF
--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -293,6 +293,7 @@ class PipelineTrainer:
             self._training,
             self._trainer_config.batch_size,
             self._trainer_config.data_bucketing,
+            self._trainer_config.batches_per_epoch,
         )
 
         validation_data_loader = (
@@ -389,7 +390,10 @@ class PipelineTrainer:
 
 
 def create_dataloader(
-    dataset: InstancesDataset, batch_size: int, data_bucketing: bool
+    dataset: InstancesDataset,
+    batch_size: int,
+    data_bucketing: bool = False,
+    batches_per_epoch: Optional[int] = None,
 ) -> DataLoader:
     """Returns a pytorch DataLoader for AllenNLP
 
@@ -401,6 +405,11 @@ def create_dataloader(
         Size of the batch.
     data_bucketing
         If enabled, try to apply data bucketing over training batches.
+    batches_per_epoch
+        Determines the number of batches after which an epoch ends.
+        If the number is smaller than the total amount of batches in your data,
+        the second "epoch" will take off where the first "epoch" ended.
+        If this is `None`, then an epoch is set to be one full pass through your data.
 
     Returns
     -------
@@ -412,9 +421,12 @@ def create_dataloader(
             batch_sampler=BucketBatchSampler(
                 data_source=dataset, batch_size=batch_size
             ),
+            batches_per_epoch=batches_per_epoch,
         )
         if data_bucketing and not isinstance(dataset, IterableDataset)
-        else DataLoader(dataset, batch_size=batch_size)
+        else DataLoader(
+            dataset, batch_size=batch_size, batches_per_epoch=batches_per_epoch
+        )
     )
 
 

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -389,6 +389,13 @@ class TrainerConfiguration:
     data_bucketing: `bool`, optional (default=False)
         If enabled, try to apply data bucketing over training batches.
 
+    batches_per_epoch
+        Determines the number of batches after which a training epoch ends.
+        If the number is smaller than the total amount of batches in your training data,
+        the second "epoch" will take off where the first "epoch" ended.
+        If this is `None`, then an epoch is set to be one full pass through your training data.
+        This is useful if you want to evaluate your data more frequently on your validation data set during training.
+
     no_grad
         Freeze a list of parameters.
         The parameter names have to match those of the `Pipeline.trainable_parameter_names`.
@@ -409,6 +416,7 @@ class TrainerConfiguration:
     # Data loader parameters
     batch_size: Optional[int] = 16
     data_bucketing: bool = False
+    batches_per_epoch: Optional[int] = None
     no_grad: List[str] = None
 
     def to_allennlp_trainer(self) -> Dict[str, Any]:
@@ -418,7 +426,7 @@ class TrainerConfiguration:
         -------
         allennlp_trainer_config
         """
-        __excluded_keys = ["data_bucketing", "batch_size"]  # Data loader attributes
+        __excluded_keys = ["data_bucketing", "batch_size", "batches_per_epoch"]  # Data loader attributes
         trainer_config = {
             k: v for k, v in vars(self).items() if k not in __excluded_keys
         }


### PR DESCRIPTION
This PR adds the `batches_per_epoch` argument to the `TrainerConfiguration`.
This option is useful if you want to validate more frequently on your validation data set during the training. 