### PR TITLE
Skip tutorial tests in CI

### DIFF
--- a/tests/tutorials/test_tutorials.py
+++ b/tests/tutorials/test_tutorials.py
@@ -5,6 +5,14 @@ from pytest_notebook.nb_regression import NBRegressionFixture
 from pytest_notebook.notebook import load_notebook, dump_notebook
 
 from tests import TUTORIALS_PATH
+import pytest
+
+
+pytestmark = pytest.mark.skip(
+    reason="The pytest-notebook package is not actively maintained and "
+    "the tutorial tests are quite heavy on resources. "
+    "The idea is to run those tests locally and manually from time to time."
+)
 
 
 def test_text_classifier_tutorial(tmp_path):


### PR DESCRIPTION
This PR removes the tutorial tests from the CI. The current fails are caused by the `pytest-notebook` package that is not actively maintained right now. Given this situation and the fact that these tests are quite heavy on resources, i vote for removing them from the CI and run them manually from time to time on our local machines (or even better on Colab), like once a month.