### PR TITLE
Fix tests when the wandb client is installed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+from biome.text import loggers
+
+
+def pytest_configure(config):
+    # In case you have wandb installed, there is an issue with tests:
+    # https://github.com/wandb/client/issues/1138
+    loggers._HAS_WANDB = False


### PR DESCRIPTION
Just a small fix when running tests locally with the `wandb` client installed, see https://github.com/wandb/client/issues/1138