### PR TITLE
Feature/cuda device

### DIFF
--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -411,7 +411,7 @@ class TrainerConfiguration:
     validation_metric: str = "-loss"
     patience: Optional[int] = 2
     num_epochs: int = 20
-    cuda_device: int = -1
+    cuda_device: int = None
     grad_norm: Optional[float] = None
     grad_clipping: Optional[float] = None
     learning_rate_scheduler: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
This PR changes the default behavior when you don't specify a `cuda_device` in the config.
Before: By default it used the CPU
After: If a cuda device is available, it will be used automatically.