### PR TITLE
Output entities for token classification

### DIFF
--- a/src/biome/text/modules/heads/task_head.py
+++ b/src/biome/text/modules/heads/task_head.py
@@ -31,7 +31,7 @@ class TaskOutput:
         self.__dict__[key] = value
 
     def as_dict(self) -> Dict[str, torch.Tensor]:
-        """Dict reprentation of task output"""
+        """Dict representation of task output"""
         return {k: v for k, v in self.__dict__.items() if v is not None}
 
 

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -169,7 +169,7 @@ class TokenClassification(TaskHead):
     def forward(  # type: ignore
         self,
         text: TextFieldTensors,
-        raw_text: Union[str, List[str]],
+        raw_text: Union[List[str], List[List[str]]],
         labels: torch.IntTensor = None,
     ) -> TaskOutput:
         mask = get_text_field_mask(text)

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -59,7 +59,14 @@ def trainer_dict() -> Dict:
 
 def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
     pipeline = Pipeline.from_config(pipeline_dict)
-    pipeline.predict(text="Test this NER machine")
+    predictions = pipeline.predict(["test", "this", "pretokenized", "text"])
+    assert "entities" not in predictions
+    assert "tags" in predictions
+
+    predictions = pipeline.predict_batch([{"text": "Test this NER system"}, {"text": "and this"}])
+    assert "entities" in predictions[0]
+    assert "tags" in predictions[0]
+
     pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_data_source]))
 
     pipeline.train(


### PR DESCRIPTION
This PR introduces entities in the output of the `TokenClassification` if the input text is a `str`.

For now the format of the entities is: `{"start": int, "end": int, "label": str}`. This format is also used as "label input" during training. 