### PR TITLE
Introduction of a TransformersTokenizer

### DIFF
--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -169,19 +169,24 @@ class TransformersFeatures:
         self.model_name = model_name
         self.trainable = trainable
         self.max_length = max_length
+        self.is_mismatched = True
 
     @property
     def config(self) -> Dict:
         """Returns the config in AllenNLP format"""
         config = {
             "indexer": {
-                "type": "pretrained_transformer_mismatched",
+                "type": "pretrained_transformer_mismatched"
+                if self.is_mismatched
+                else "pretrained_transformer",
                 "model_name": self.model_name,
                 "namespace": self.namespace,
                 "max_length": self.max_length,
             },
             "embedder": {
-                "type": "pretrained_transformer_mismatched",
+                "type": "pretrained_transformer_mismatched"
+                if self.is_mismatched
+                else "pretrained_transformer",
                 "model_name": self.model_name,
                 "train_parameters": self.trainable,
                 "max_length": self.max_length,

--- a/tests/text/test_configuration.py
+++ b/tests/text/test_configuration.py
@@ -65,17 +65,13 @@ def transformers_pipeline_config():
     return {
         "name": "transformers_tokenizer_plus_tokenclassification",
         "features": {
-            "transformers": {
-                "model_name": "sshleifer/tiny-distilroberta-base"
-            }
+            "transformers": {"model_name": "sshleifer/tiny-distilroberta-base"}
         },
         "head": {
-            "type": "TokenClassification",
-            "labels": ["NER"],
-            "label_encoding": "BIOUL",
+            "type": "TextClassification",
+            "labels": ["duplicate", "not_duplicate"],
         },
     }
-
 
 
 def test_pipeline_without_word_features():
@@ -175,16 +171,31 @@ def test_pipeline_config(pipeline_yaml):
 
 def test_invalid_tokenizer_features_combination(transformers_pipeline_config):
     transformers_pipeline_config["features"].update({"word": {"embedding_dim": 2}})
-    transformers_pipeline_config["tokenizer"] = {"transformers_kwargs": {"model_name": "sshleifer/tiny-distilroberta-base"}}
+    transformers_pipeline_config["tokenizer"] = {
+        "transformers_kwargs": {"model_name": "sshleifer/tiny-distilroberta-base"}
+    }
 
     with pytest.raises(ConfigurationError):
         Pipeline.from_config(transformers_pipeline_config)
 
 
-def test_transformers_with_tokenclassification(transformers_pipeline_config):
+def test_not_implemented_transformers_with_tokenclassification(
+    transformers_pipeline_config,
+):
+    transformers_pipeline_config["head"] = {
+        "type": "TokenClassification",
+        "labels": ["NER"],
+    }
     with pytest.raises(NotImplementedError):
         Pipeline.from_config(transformers_pipeline_config)
 
 
+def test_invalid_transformers_tokenizer_indexer_embedder_combination(
+    transformers_pipeline_config,
+):
+    transformers_pipeline_config["tokenizer"] = {
+        "transformers_kwargs": {"model_name": "distilroberta-base"}
+    }
 
-
+    with pytest.raises(ConfigurationError):
+        Pipeline.from_config(transformers_pipeline_config)

--- a/tests/text/test_pipeline_datasets.py
+++ b/tests/text/test_pipeline_datasets.py
@@ -142,7 +142,7 @@ def test_training_from_pretrained_with_head_replace(
 
     trained = Pipeline.from_pretrained(results.model_path)
     trained.set_head(TestHead)
-    trained.config.tokenizer.max_nr_of_sentences = 3
+    trained.config.tokenizer_config.max_nr_of_sentences = 3
     copied = trained._make_copy()
     assert isinstance(copied.head, TestHead)
     assert copied.num_parameters == trained.num_parameters

--- a/tests/text/test_pipeline_tokenizer.py
+++ b/tests/text/test_pipeline_tokenizer.py
@@ -1,0 +1,55 @@
+from biome.text import Pipeline
+from biome.text.configuration import TokenizerConfiguration
+from biome.text.tokenizer import Tokenizer, TransformersTokenizer
+from allennlp.data.token_indexers import PretrainedTransformerIndexer, PretrainedTransformerMismatchedIndexer
+from allennlp.common.checks import ConfigurationError
+import pytest
+
+
+@pytest.fixture
+def pipeline_dict(request) -> dict:
+    """Pipeline config dict. You need to update the labels!"""
+    pipeline_dict = {
+        "name": "transformers_tokenizer_test",
+        "features": {
+            "transformers": {
+                "model_name": "sshleifer/tiny-distilroberta-base"
+            }
+        },
+        "head": {
+            "type": "TextClassification",
+            "labels": ["a", "b"],
+        },
+    }
+    return pipeline_dict
+
+
+def test_pipeline_transformers_tokenizer(pipeline_dict):
+    pl = Pipeline.from_config(pipeline_dict)
+
+    assert pl.config.tokenizer_config.transformers_kwargs == {"model_name": "sshleifer/tiny-distilroberta-base"}
+    assert not pl.config.features.transformers.is_mismatched
+    assert type(pl.backbone.featurizer.indexer["transformers"]) is PretrainedTransformerIndexer
+    assert type(pl.backbone.tokenizer) is TransformersTokenizer
+
+    prediction = pl.predict("Test this!")
+
+
+def test_pipeline_default_tokenizer(pipeline_dict):
+    pipeline_dict["features"].update({"word": {"embedding_dim": 2}})
+    pl = Pipeline.from_config(pipeline_dict)
+
+    assert pl.config.tokenizer_config == TokenizerConfiguration()
+    assert pl.config.features.transformers.is_mismatched
+    assert type(pl.backbone.featurizer.indexer["transformers"]) is PretrainedTransformerMismatchedIndexer
+    assert type(pl.backbone.tokenizer) is Tokenizer
+
+    prediction = pl.predict("Test this!")
+
+
+def test_invalid_tokenizer_features_combination(pipeline_dict):
+    pipeline_dict["features"].update({"word": {"embedding_dim": 2}})
+    pipeline_dict["tokenizer"] = {"transformers_kwargs": {"model_name": "sshleifer/tiny-distilroberta-base"}}
+
+    with pytest.raises(ConfigurationError):
+        pl = Pipeline.from_config(pipeline_dict)

--- a/tests/text/test_pipeline_tokenizer.py
+++ b/tests/text/test_pipeline_tokenizer.py
@@ -2,7 +2,6 @@ from biome.text import Pipeline
 from biome.text.configuration import TokenizerConfiguration
 from biome.text.tokenizer import Tokenizer, TransformersTokenizer
 from allennlp.data.token_indexers import PretrainedTransformerIndexer, PretrainedTransformerMismatchedIndexer
-from allennlp.common.checks import ConfigurationError
 import pytest
 
 
@@ -45,11 +44,3 @@ def test_pipeline_default_tokenizer(pipeline_dict):
     assert type(pl.backbone.tokenizer) is Tokenizer
 
     prediction = pl.predict("Test this!")
-
-
-def test_invalid_tokenizer_features_combination(pipeline_dict):
-    pipeline_dict["features"].update({"word": {"embedding_dim": 2}})
-    pipeline_dict["tokenizer"] = {"transformers_kwargs": {"model_name": "sshleifer/tiny-distilroberta-base"}}
-
-    with pytest.raises(ConfigurationError):
-        pl = Pipeline.from_config(pipeline_dict)


### PR DESCRIPTION
This PR introduces a `TransformersTokenizer` that enables us to directly process subword tokens usually used in the pretrained transformer models.

Until now, we bypassed a direct processing of subword tokens using AllenNLP mismatched indexer/embedder. With these changes here, if you only use the `transformers` feature, by default it will use the new `TransformersTokenizer` returning word pieces, and it will automatically use the matched indexer/embedder for the transformers feature.

This also allows us to use special tokens like for example the `CLS` token (used in many BERT-like models) for classification. You can check out the tests to see how to use the `bert_pooler` as pooler in our ClassificationHead.

The idea is that @ignacioct makes some comparisons between only subword tokens + bert_pooler, word tokens + gru pooler, word tokens with scalar mix + gru pooler ... etc with the new tutorial data. I think it will be interesting to see how they compare with each other.

(A lot of the additions are due to the tests, so don't be scared of reviewing the 183 lines of changes ...)