### PR TITLE
Add `max_length` parameter to transformers feature

### DIFF
--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -157,13 +157,18 @@ class TransformersFeatures:
         Name of one of the [transformers models](https://huggingface.co/models).
     trainable
         If false, freeze the transformer weights
+    max_length
+        If positive, split the document into segments of this many tokens (including special tokens)
+        before feeding into the embedder. The embedder embeds these segments independently and
+        concatenate the results to get the original document representation.
     """
 
     namespace = "transformers"
 
-    def __init__(self, model_name: str, trainable: bool = False):
+    def __init__(self, model_name: str, trainable: bool = False, max_length: Optional[int] = None):
         self.model_name = model_name
         self.trainable = trainable
+        self.max_length = max_length
 
     @property
     def config(self) -> Dict:
@@ -173,11 +178,13 @@ class TransformersFeatures:
                 "type": "pretrained_transformer_mismatched",
                 "model_name": self.model_name,
                 "namespace": self.namespace,
+                "max_length": self.max_length,
             },
             "embedder": {
                 "type": "pretrained_transformer_mismatched",
                 "model_name": self.model_name,
                 "train_parameters": self.trainable,
+                "max_length": self.max_length,
             },
         }
 

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -195,4 +195,5 @@ class TransformersFeatures:
         return {
             "model_name": self.model_name,
             "trainable": self.trainable,
+            "max_length": self.max_length,
         }

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -197,3 +197,6 @@ class TransformersFeatures:
             "trainable": self.trainable,
             "max_length": self.max_length,
         }
+
+    def __eq__(self, other):
+        return all([a == b for a, b in zip(vars(self), vars(other))])

--- a/tests/text/test_features_transformers.py
+++ b/tests/text/test_features_transformers.py
@@ -63,3 +63,17 @@ def test_train(tmp_path, pipeline_dict, trainer_dict, train_data_source):
     pl = Pipeline.from_pretrained(str(output / "model.tar.gz"))
 
     assert pl.backbone.vocab.get_vocab_size("transformers") == 50265
+
+
+def test_max_length_not_affecting_shorter_sequences(pipeline_dict):
+    pl = Pipeline.from_config(pipeline_dict)
+    state_dict = pl._model.state_dict()
+    probs = pl.predict("Test this")["probs"]
+
+    pipeline_dict["features"]["transformers"]["max_length"] = 100
+    pl = Pipeline.from_config(pipeline_dict)
+    pl._model.load_state_dict(state_dict)
+    probs_max_length = pl.predict("Test this")["probs"]
+
+    assert all([log1 == log2 for log1, log2 in zip(probs, probs_max_length)])
+

--- a/tests/text/test_features_transformers.py
+++ b/tests/text/test_features_transformers.py
@@ -1,6 +1,7 @@
 import pytest
 
 from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration
+from biome.text.features import TransformersFeatures
 from biome.text.data import DataSource
 from pathlib import Path
 
@@ -76,4 +77,11 @@ def test_max_length_not_affecting_shorter_sequences(pipeline_dict):
     probs_max_length = pl.predict("Test this")["probs"]
 
     assert all([log1 == log2 for log1, log2 in zip(probs, probs_max_length)])
+
+
+def test_serialization(pipeline_dict):
+    feature = TransformersFeatures(**pipeline_dict["features"]["transformers"])
+    
+    assert feature == TransformersFeatures(**feature.to_json())
+
 


### PR DESCRIPTION
This PR adds the `max_length` parameter of AllenNLP's `PretrainedTransformerIndexer`/`*Embedder` to our transformers feature.