### PR TITLE
Accept huggingface's datasets as input

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ if __name__ == "__main__":
             "captum~=0.2.0",
             "ipywidgets~=7.5.1",
             "mlflow~=1.9.0",
-            "ray~=1.0.0"
+            "ray~=1.0.0",
+            "datasets~=1.1.0"
         ],
         extras_require={
             "testing": [

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -6,6 +6,7 @@ import yaml
 from allennlp.common import FromParams, Params
 from allennlp.data import TokenIndexer, Vocabulary
 from allennlp.modules import TextFieldEmbedder
+from datasets import Dataset
 
 from biome.text.data import DataSource, InstancesDataset
 from . import vocabulary
@@ -432,7 +433,12 @@ class TrainerConfiguration:
         allennlp_trainer_config
         """
         # Data loader and prepare_env attributes
-        __excluded_keys = ["data_bucketing", "batch_size", "batches_per_epoch", "random_seed"]
+        __excluded_keys = [
+            "data_bucketing",
+            "batch_size",
+            "batches_per_epoch",
+            "random_seed",
+        ]
         trainer_config = {
             k: v for k, v in vars(self).items() if k not in __excluded_keys
         }
@@ -455,7 +461,7 @@ class VocabularyConfiguration:
     Parameters
     ----------
     sources: 
-        List of DataSource or InstancesDataset objects to be used for data creation
+        List of DataSource, Dataset or InstancesDataset objects to be used for data creation
     min_count: `Dict[str, int]`, optional (default=None)
         Minimum number of appearances of a token to be included in the vocabulary.
         The key in the dictionary refers to the namespace of the input feature
@@ -480,7 +486,7 @@ class VocabularyConfiguration:
 
     def __init__(
         self,
-        sources: Union[List[DataSource], List[InstancesDataset]],
+        sources: Union[List[DataSource], List[InstancesDataset], List[Dataset]],
         min_count: Dict[str, int] = None,
         max_vocab_size: Union[int, Dict[str, int]] = None,
         pretrained_files: Optional[Dict[str, str]] = None,


### PR DESCRIPTION
With this PR on can use [Huggingface's datasets](https://huggingface.co/docs/datasets/index.html) as input.

I tried to do some profiling to compare the two cases: using a `datasets.dataset` and our current `DataSource`:

**datasource**
```terminal
Line #    Mem usage    Increment   Line Contents
================================================
     2     53.8 MiB     53.8 MiB   def my_func():
     3    419.5 MiB    365.7 MiB       from biome.text import Pipeline
     4    419.5 MiB      0.0 MiB       from biome.text.configuration import VocabularyConfiguration, TrainerConfiguration
     5    419.5 MiB      0.0 MiB       from biome.text.data import DataSource
     6    419.5 MiB      0.0 MiB       from biome.text import loggers
     7    423.3 MiB      3.8 MiB       from datasets import load_dataset
     8                                 
     9    423.3 MiB      0.0 MiB       loggers._HAS_WANDB = False
    10                                 
    11                             #     ds = load_dataset("json", data_files="./arxiv-dataset-train_small.json", split="train")
    12                             #     ds.cleanup_cache_files()
    13                             #     ds = ds.map(lambda x: {"text": x["abstract"], "label": x["categories"]})
    14                             #     labels = list(set(ds["label"]))
    15                                 
    16    425.6 MiB      2.3 MiB       ds = DataSource("/home/david/recognai/biome/hf_datasets/arxiv-dataset-train_small.json", mapping={"text": "abstract", "label": "categories"})
    17    426.1 MiB      0.6 MiB       labels = list(set(ds.to_dataframe()["categories"]))
    18                                 
    19    426.1 MiB      0.0 MiB       pl = Pipeline.from_config({
    20    426.1 MiB      0.0 MiB           "name": "datasets_test",
    21                                     "features": {
    22    426.1 MiB      0.0 MiB               "word": {"embedding_dim": 16, "lowercase_tokens": True},
    23                                     },
    24                                     "head": {
    25    426.1 MiB      0.0 MiB               "type": "TextClassification",
    26    536.4 MiB    110.2 MiB               "labels": labels,
    27                                     },
    28                                 })
    29                                 
    30    536.4 MiB      0.0 MiB       vocab_config = VocabularyConfiguration(sources=[ds])
    31   1273.3 MiB    736.9 MiB       pl.create_vocabulary(vocab_config)
    32                                 
    33   1273.3 MiB      0.0 MiB       trainer_config = TrainerConfiguration(
    34                                     optimizer={
    35   1273.3 MiB      0.0 MiB               "type": "adam",
    36   1273.3 MiB      0.0 MiB               "lr": 0.01,
    37                                     },
    38   1273.3 MiB      0.0 MiB           num_epochs=1,
    39   1273.3 MiB      0.0 MiB           cuda_device=-1,
    40                                 )
    41                                 
    42   1273.3 MiB      0.0 MiB       pl.train(
    43   1273.3 MiB      0.0 MiB           output="output",
    44   1273.3 MiB      0.0 MiB           training=ds,
    45   1970.8 MiB    697.5 MiB           trainer=trainer_config,
    46                                 )
```
*5 executions: 2 min 55s*

**dataset**
```terminal
Line #    Mem usage    Increment   Line Contents
================================================
     1     53.0 MiB     53.0 MiB   def my_func():
     2    423.2 MiB    370.2 MiB       from biome.text import Pipeline
     3    423.2 MiB      0.0 MiB       from biome.text.configuration import VocabularyConfiguration, TrainerConfiguration
     4    423.2 MiB      0.0 MiB       from biome.text.data import DataSource
     5    423.2 MiB      0.0 MiB       from biome.text import loggers
     6    423.2 MiB      0.0 MiB       from datasets import load_dataset
     7                                 
     8    423.2 MiB      0.0 MiB       loggers._HAS_WANDB = False
     9                                 
    10    426.6 MiB      3.4 MiB       ds = load_dataset("json", data_files="./arxiv-dataset-train_small.json", split="train")
    11    426.6 MiB      0.0 MiB       ds.cleanup_cache_files()
    12    427.7 MiB      0.8 MiB       ds = ds.map(lambda x: {"text": x["abstract"], "label": x["categories"]})
    13    427.7 MiB      0.0 MiB       labels = list(set(ds["label"]))
    14                                 
    15                             #     ds = DataSource("/home/david/recognai/biome/hf_datasets/arxiv-dataset-train_small.json", mapping={"text": "abstract", "label": "categories"})
    16                             #     labels = list(set(ds.to_dataframe()["categories"]))
    17                                 
    18    427.7 MiB      0.0 MiB       pl = Pipeline.from_config({
    19    427.7 MiB      0.0 MiB           "name": "datasets_test",
    20                                     "features": {
    21    427.7 MiB      0.0 MiB               "word": {"embedding_dim": 16, "lowercase_tokens": True},
    22                                     },
    23                                     "head": {
    24    427.7 MiB      0.0 MiB               "type": "TextClassification",
    25    539.7 MiB    112.1 MiB               "labels": labels,
    26                                     },
    27                                 })
    28                                 
    29    539.7 MiB      0.0 MiB       vocab_config = VocabularyConfiguration(sources=[ds])
    30    548.1 MiB      8.3 MiB       pl.create_vocabulary(vocab_config)
    31                                 
    32    548.1 MiB      0.0 MiB       trainer_config = TrainerConfiguration(
    33                                     optimizer={
    34    548.1 MiB      0.0 MiB               "type": "adam",
    35    548.1 MiB      0.0 MiB               "lr": 0.01,
    36                                     },
    37    548.1 MiB      0.0 MiB           num_epochs=1,
    38    548.1 MiB      0.0 MiB           cuda_device=-1,
    39                                 )
    40                                 
    41    548.1 MiB      0.0 MiB       pl.train(
    42    548.1 MiB      0.0 MiB           output="output",
    43    548.1 MiB      0.0 MiB           training=ds,
    44    568.5 MiB     20.5 MiB           trainer=trainer_config,
    45                                 )
```
*5 executions: 2min 40s*

The memory footprint in the DataSource case is very strange, the dataset is really small (32 examples), but when creating the instances it takes a huge amount of memory, which is not the case in the Dataset case. Also when i timed it (5 executions), the notebook with the DataSource ended up with almost 8 GB of usage, while the Dataset notebook had a very small footprint, looks like some leakage.

The Dataset is faster when creating the instances since it uses multiprocessing, dask could do the same with our DataSources but it is not implemented at the moment. The training is a bit slower, since Dataset is loading the data from disk, while the instances from the DataSource are kept in memory (for the timing i used a bigger dataset).

The implementation here is minimal and should not be the final one. For a cleaner implementation i vote for completely removing our `DataSource` class, and provide the possibility of maybe saving an `InstanceDataset` to disk.
@frascuchon let's talk about this tomorrow.