### PR TITLE
Adding a Dataset class based on HuggingFace's datasets.Dataset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install: ## install package
 	@pip install .
 
 dev: ## install package in development mode
-	@pip install --upgrade -e .[testing]
+	@pip install --use-feature=2020-resolver --upgrade -e .[testing]
 
 ui: ## build the ui pages
 	@cd ui && npm install && npm run build

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ if __name__ == "__main__":
             "captum~=0.2.0",
             "ipywidgets~=7.5.1",
             "mlflow~=1.9.0",
-            "ray~=1.0.0"
+            "ray~=1.0.0",
+            "datasets~=1.1.2"
         ],
         extras_require={
             "testing": [

--- a/src/biome/text/__init__.py
+++ b/src/biome/text/__init__.py
@@ -35,6 +35,7 @@ from .pipeline import (
     TrainerConfiguration,
     VocabularyConfiguration,
 )
+from .dataset import Dataset
 
 warnings.showwarning = warn_explicit
 logging.basicConfig()

--- a/src/biome/text/__init__.py
+++ b/src/biome/text/__init__.py
@@ -29,13 +29,13 @@ try:
 except ModuleNotFoundError:
     pass
 
-from .pipeline import (
-    Pipeline,
+from .dataset import Dataset
+from .pipeline import Pipeline
+from .configuration import (
     PipelineConfiguration,
     TrainerConfiguration,
     VocabularyConfiguration,
 )
-from .dataset import Dataset
 
 warnings.showwarning = warn_explicit
 logging.basicConfig()

--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -317,4 +317,4 @@ def create_trainer_for_finding_lr(
         data_loader=training_data_loader,
         params=trainer_params,
         serialization_dir=None,
-    )
+    ))

--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -135,7 +135,8 @@ class PipelineTrainer:
         self._pipeline.save_vocabulary(os.path.join(self._output_dir, "vocabulary"))
 
         for dataset in [self._training, self._validation, self._test]:
-            dataset.index_with(self._pipeline.backbone.vocab)
+            if dataset is not None:
+                dataset.index_with(self._pipeline.backbone.vocab)
 
         trainer_params = Params(
             helpers.sanitize_for_params(self._trainer_config.to_allennlp_trainer())

--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -2,7 +2,7 @@ import copy
 import json
 import logging
 import os
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 import uvicorn
 from allennlp.common import Params
@@ -135,8 +135,7 @@ class PipelineTrainer:
         self._pipeline.save_vocabulary(os.path.join(self._output_dir, "vocabulary"))
 
         for dataset in [self._training, self._validation, self._test]:
-            if dataset and hasattr(dataset, "index_with"):
-                dataset.index_with(self._pipeline.backbone.vocab)
+            dataset.index_with(self._pipeline.backbone.vocab)
 
         trainer_params = Params(
             helpers.sanitize_for_params(self._trainer_config.to_allennlp_trainer())
@@ -303,8 +302,7 @@ def create_trainer_for_finding_lr(
     """
     prepare_environment(Params({}))
 
-    if hasattr(training_data, "index_with"):
-        training_data.index_with(pipeline.backbone.vocab)
+    training_data.index_with(pipeline.backbone.vocab)
 
     trainer_params = Params(
         helpers.sanitize_for_params(trainer_config.to_allennlp_trainer())
@@ -314,7 +312,7 @@ def create_trainer_for_finding_lr(
         training_data, trainer_config.batch_size, trainer_config.data_bucketing
     )
 
-    return Trainer.from_params(
+    return cast("GradientDescentTrainer", Trainer.from_params(
         model=pipeline._model,
         data_loader=training_data_loader,
         params=trainer_params,

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -9,6 +9,7 @@ from allennlp.common.checks import ConfigurationError
 from allennlp.data import TokenIndexer, Vocabulary
 from allennlp.modules import TextFieldEmbedder
 
+from biome.text.dataset import Dataset
 from biome.text.data import DataSource, InstancesDataset
 from . import vocabulary
 from .features import CharFeatures, TransformersFeatures, WordFeatures
@@ -544,7 +545,7 @@ class VocabularyConfiguration:
 
     def __init__(
         self,
-        sources: Union[List[DataSource], List[InstancesDataset]],
+        sources: Union[List[DataSource], List[Dataset], List[InstancesDataset]],
         min_count: Dict[str, int] = None,
         max_vocab_size: Union[int, Dict[str, int]] = None,
         pretrained_files: Optional[Dict[str, str]] = None,

--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -81,6 +81,40 @@ class Dataset:
         """
         return cls.load_dataset("csv", data_files=paths, split="train", **kwargs)
 
+    @classmethod
+    def from_pandas(cls, df: "pandas.DataFrame", **kwargs):
+        """Convenient method to create a Dataset from a `pandas.DataFrame`
+
+        Parameters
+        ----------
+        df
+            The data frame
+        **kwargs
+            Passed on to `datasets.Dataset.from_pandas` method
+
+        Returns
+        -------
+        dataset
+        """
+        return cls(datasets.Dataset.from_pandas(df=df, **kwargs))
+
+    @classmethod
+    def from_dict(cls, mapping: dict, **kwargs):
+        """Convenient method to create a Dataset from a python dictionary
+
+        Parameters
+        ----------
+        mapping
+            A mapping of strings to arrays or python lists.
+        **kwargs
+            Passed on to `datasets.Dataset.from_dict` method
+
+        Returns
+        -------
+        dataset
+        """
+        return cls(datasets.Dataset.from_dict(mapping=mapping, **kwargs))
+
     def to_instances(self, pipeline: "biome.text.Pipeline", lazy=True) -> InstancesDataset:
         """Convert input to instances for the pipeline
 

--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -6,8 +6,6 @@ from typing import Union, Dict, Iterable, List
 import datasets
 from allennlp.data import AllennlpDataset, AllennlpLazyDataset, Instance
 
-from biome.text import Pipeline
-
 InstancesDataset = Union[AllennlpDataset, AllennlpLazyDataset]
 
 
@@ -42,7 +40,7 @@ class Dataset:
     def read_csv(cls, paths: Union[str, List[str]]):
         return cls.load_dataset("csv", data_file=paths, split="train")
 
-    def to_instances(self, pipeline: Pipeline, lazy=True) -> InstancesDataset:
+    def to_instances(self, pipeline: "biome.text.Pipeline", lazy=True) -> InstancesDataset:
         """Convert input to instances for the pipeline
 
         Parameters

--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -29,16 +29,57 @@ class Dataset:
         self.dataset: datasets.Dataset = dataset
 
     @classmethod
-    def load_dataset(cls, *args, split, **kwargs):
+    def load_dataset(cls, *args, split, **kwargs) -> "Dataset":
+        """Load a dataset using Huggingface's `datasets.load_dataset` method.
+
+        See https://huggingface.co/docs/datasets/loading_datasets.html
+
+        Parameters
+        ----------
+        split
+            See https://huggingface.co/docs/datasets/splits.html
+        *args/**kwargs
+            Passed on to the `dataset.load_dataset` method
+
+        Returns
+        -------
+        dataset
+        """
         return cls(datasets.load_dataset(*args, split=split, **kwargs))
 
     @classmethod
-    def read_json(cls, paths: Union[str, List[str]]):
-        return cls.load_dataset("json", data_file=paths, split="train")
+    def from_json(cls, paths: Union[str, List[str]], **kwargs) -> "Dataset":
+        """Convenient method to create a Dataset from a json file
+
+        Parameters
+        ----------
+        paths
+            One or several paths to json files
+        **kwargs
+            Passed on to the `datasets.load_dataset` method
+
+        Returns
+        -------
+        dataset
+        """
+        return cls.load_dataset("json", data_files=paths, split="train", **kwargs)
 
     @classmethod
-    def read_csv(cls, paths: Union[str, List[str]]):
-        return cls.load_dataset("csv", data_file=paths, split="train")
+    def from_csv(cls, paths: Union[str, List[str]], **kwargs) -> "Dataset":
+        """Convenient method to create a Dataset from a csv file
+
+        Parameters
+        ----------
+        paths
+            One or several paths to csv files
+        **kwargs
+            Passed on to the `datasets.load_dataset` method
+
+        Returns
+        -------
+        dataset
+        """
+        return cls.load_dataset("csv", data_files=paths, split="train", **kwargs)
 
     def to_instances(self, pipeline: "biome.text.Pipeline", lazy=True) -> InstancesDataset:
         """Convert input to instances for the pipeline

--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -1,0 +1,120 @@
+import logging
+import multiprocessing
+import pickle
+from typing import Union, Dict, Iterable, List
+
+import datasets
+from allennlp.data import AllennlpDataset, AllennlpLazyDataset, Instance
+
+from biome.text import Pipeline
+
+InstancesDataset = Union[AllennlpDataset, AllennlpLazyDataset]
+
+
+class Dataset:
+    """A dataset to be used with biome.text Pipelines
+
+    Basically a light wrapper around HuggingFace's `datasets.Dataset`
+
+    Parameters
+    ----------
+    dataset
+        A HuggingFace `datasets.Dataset`
+    """
+
+    _LOGGER = logging.getLogger(__name__)
+    _PICKLED_INSTANCES_COL_NAME = "PICKLED_INSTANCES_FOR_BIOME_PIPELINE"
+
+    def __init__(
+        self, dataset: datasets.Dataset,
+    ):
+        self.dataset: datasets.Dataset = dataset
+
+    @classmethod
+    def load_dataset(cls, *args, split, **kwargs):
+        return cls(datasets.load_dataset(*args, split=split, **kwargs))
+
+    @classmethod
+    def read_json(cls, paths: Union[str, List[str]]):
+        return cls.load_dataset("json", data_file=paths, split="train")
+
+    @classmethod
+    def read_csv(cls, paths: Union[str, List[str]]):
+        return cls.load_dataset("csv", data_file=paths, split="train")
+
+    def to_instances(self, pipeline: Pipeline, lazy=True) -> InstancesDataset:
+        """Convert input to instances for the pipeline
+
+        Parameters
+        ----------
+        pipeline
+            The pipeline for which to create the instances.
+        lazy
+            If true, instanes are lazily read from disk, otherwise they are kept in memory.
+        """
+        self._LOGGER.info("Creating instances ...")
+
+        input_columns = [col for col in pipeline.inputs + [pipeline.output] if col]
+        dataset_with_pickled_instances = self.dataset.map(
+            self._create_and_pickle_instances,
+            fn_kwargs={
+                "input_columns": input_columns,
+                "featurize": pipeline.head.featurize,
+                "instances_col_name": self._PICKLED_INSTANCES_COL_NAME,
+            },
+            # trying to be smart about multiprocessing,
+            # at least 1000 examples per process to avoid overhead,
+            # but 1000 is a pretty random number, can surely be optimized
+            num_proc=min(
+                max(1, int(len(self.dataset) / 1000)),
+                int(multiprocessing.cpu_count() / 2),
+            ),
+        )
+
+        if lazy:
+            return AllennlpLazyDataset(
+                instance_generator=self._build_instance_generator(
+                    dataset_with_pickled_instances
+                ),
+                file_path=self._PICKLED_INSTANCES_COL_NAME,
+            )
+
+        return AllennlpDataset(
+            list(
+                self._build_instance_generator(dataset_with_pickled_instances)(
+                    self._PICKLED_INSTANCES_COL_NAME
+                )
+            )
+        )
+
+    @staticmethod
+    def _create_and_pickle_instances(row, input_columns, featurize, instances_col_name):
+        """Helper function to be used together with the `datasets.Dataset.map` method"""
+        instance = featurize(**{key: row[key] for key in input_columns})
+
+        return {instances_col_name: pickle.dumps(instance)}
+
+    @staticmethod
+    def _build_instance_generator(pickled_instances: datasets.Dataset):
+        """Helper function to be used together with the `allennlp.data.AllennlpLazyDataset`"""
+
+        def instance_unpickler(instances_col_name: str) -> Iterable[Instance]:
+            for row in pickled_instances:
+                yield pickle.loads(row[instances_col_name])
+
+        return instance_unpickler
+
+    def __del__(self):
+        self.dataset.__del__()
+
+    def __getitem__(self, key: Union[int, slice, str]) -> Union[Dict, List]:
+        return self.dataset.__getitem__(key)
+
+    def __len__(self):
+        return self.dataset.__len__()
+
+    def __iter__(self):
+        yield from self.dataset.__iter__()
+
+    def __repr__(self):
+        return self.dataset.__repr__()

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -705,10 +705,14 @@ class Pipeline:
         extended_vocab
             An extended `Vocabulary` using the provided configuration
         """
-        datasets = [
-            self.create_dataset(source) if isinstance(source, DataSource) else source
-            for source in vocab_config.sources
-        ]
+        datasets = []
+        for source in vocab_config.sources:
+            if isinstance(source, DataSource):
+                datasets.append(self.create_dataset(source))
+            elif isinstance(source, Dataset):
+                datasets.append(source.to_instances(pipeline=self))
+            else:
+                datasets.append(source)
 
         instances_vocab = Vocabulary.from_instances(
             instances=(instance for dataset in datasets for instance in dataset),

--- a/tests/resources/data/dataset_sequence.json
+++ b/tests/resources/data/dataset_sequence.json
@@ -1,0 +1,25 @@
+{
+  "version": "0.1.0",
+  "data": [
+    {
+      "hypothesis": "Irmalotte  Schneider  Poggenburg  4  48485  Neuenkirchen, Kreis Steinfurt  Irmalotte-S92@freemail.de  22.4.1992  01636496234",
+      "premise": " DE  Frau Dr.  Iramlotte  Schneider  Poggenburg  4  48485  Neuenkirchen, Kreis Steinfurt  Irmalotte-S92@freemail.de 17. Juli 1967  01636496234",
+      "label": "duplicate"
+    },
+    {
+      "hypothesis": "Irmalotte  Schneider  Poggenburg  4  48485  Neuenkirchen, Kreis Steinfurt  Irmalotte-S92@freemail.de  22.4.1992  01636496234",
+      "premise": "Herr  Karlheinz  Hofmann  Seglerweg  5  48485  Neuenkirchen, Kreis Steinfurt  karlheinz-hofmann@hotmail.de 3.10.1952  0152359493301",
+      "label": "not_duplicate"
+    },
+    {
+      "hypothesis": "Herr  Karlheinz  Hofmann  Seglerweg  5  48485  Neuenkirchen, Kreis Steinfurt  karlheinz-hofmann@hotmail.de 3.10.1952  0152359493301",
+      "premise": "Frau Dr.  Iramlotte  Schneider  Poggenburg  4  48485  Neuenkirchen, Kreis Steinfurt  Irmalotte-S92@freemail.de 17. Juli 1967  01636496234",
+      "label": "not_duplicate"
+    },
+    {
+      "hypothesis": "Herr  Karlheinz  Hofmann  Seglerweg  5  48485  Neuenkirchen, Kreis Steinfurt  karlheinz-hofmann@hotmail.de 3.10.1952  0152359493301",
+      "premise": " DE  Herr  Karlheinz   Hofamnn  Seglerweg  5  48485  Neuenkirchen, Kreis Steinfurt  karlheinz-hofmann@hotmail.de 3. October 52  0152359493301",
+      "label": "duplicate"
+    }
+  ]
+}

--- a/tests/text/test_dataset.py
+++ b/tests/text/test_dataset.py
@@ -1,0 +1,68 @@
+import os
+
+from biome.text import Pipeline, Dataset
+from biome.text.configuration import VocabularyConfiguration, TrainerConfiguration
+from tests import RESOURCES_PATH
+
+
+def test_from_json():
+    json_path = os.path.join(RESOURCES_PATH, "data", "dataset_sequence.jsonl")
+    ds = Dataset.from_json(paths=json_path)
+    ds2 = Dataset.from_json(paths=[json_path, json_path])
+
+    assert len(ds) == 4
+    assert len(ds2) == 8
+
+    json_path = os.path.join(RESOURCES_PATH, "data", "dataset_sequence.json")
+    ds = Dataset.from_json(paths=json_path, field="data")
+
+    assert len(ds) == 4
+
+
+def test_from_csv():
+    csv_path = os.path.join(RESOURCES_PATH, "data", "business.cat.2k.valid.csv")
+    ds = Dataset.from_csv(paths=csv_path)
+    ds2 = Dataset.from_csv(paths=[csv_path, csv_path])
+
+    assert len(ds) == 400
+    assert len(ds2) == 800
+    assert ds.dataset.column_names == ["label", "text"]
+
+
+def test_training_with_dataset():
+    # TODO: this test can go away once we replace our DataSource with Dataset
+    ds = Dataset.read_json(paths=os.path.join(RESOURCES_PATH, "data", "dataset_sequence.jsonl"))
+    ds.dataset.rename_column_("hypothesis", "text")
+    # or to keep the 'hypothesis' column and add the new 'text' column:
+    # ds.dataset = ds.dataset.map(lambda x: {"text": x["hypothesis"]})
+
+    labels = list(set(ds["label"]))
+
+    pl = Pipeline.from_config({
+        "name": "datasets_test",
+        "features": {
+            "word": {"embedding_dim": 2},
+        },
+        "head": {
+            "type": "TextClassification",
+            "labels": labels,
+        },
+    })
+
+    vocab_config = VocabularyConfiguration(sources=[ds])
+    pl.create_vocabulary(vocab_config)
+
+    trainer_config = TrainerConfiguration(
+        optimizer={
+            "type": "adam",
+            "lr": 0.01,
+        },
+        num_epochs=1,
+        cuda_device=-1,
+    )
+
+    pl.train(
+        output="output",
+        training=ds,
+        trainer=trainer_config
+    )

--- a/tests/text/test_dataset.py
+++ b/tests/text/test_dataset.py
@@ -31,7 +31,7 @@ def test_from_csv():
 
 def test_training_with_dataset():
     # TODO: this test can go away once we replace our DataSource with Dataset
-    ds = Dataset.read_json(paths=os.path.join(RESOURCES_PATH, "data", "dataset_sequence.jsonl"))
+    ds = Dataset.from_json(paths=os.path.join(RESOURCES_PATH, "data", "dataset_sequence.jsonl"))
     ds.dataset.rename_column_("hypothesis", "text")
     # or to keep the 'hypothesis' column and add the new 'text' column:
     # ds.dataset = ds.dataset.map(lambda x: {"text": x["hypothesis"]})


### PR DESCRIPTION
This PR adds a new class `Dataset` intended to replace the current `DataSource`. It is basically a thin wrapper around HuggingFace's `datasets.Dataset` class enhanced by the for us crucial `to_instances` method, and a few convenient methods. See the advantages of this approach in #397 . 

In most cases i think we will use the `from_json` or `from_csv` class methods, but you have access to the whole `load_dataset` method, which is also used to create [HF datasets](https://huggingface.co/docs/datasets/loading_datasets.html). This gives us instant access to a lot of NLP datasets!

Indexing and iterating works directly with this class, but you have all the `datasets` utilities accessible via the underlying `dataset` attribute:

```python
from biome.text import Dataset

ds = Dataset.from_json(paths="my_json_file.jsonl")

# a nice repr for the dataset
print(ds)

# First 10 entries of the dataset
ds[:10]

# iterating over the dataset
for row in ds:
    print(row)

# advanced utilities for working with your dataset 
# (see https://huggingface.co/docs/datasets/master/processing.html)
ds.dataset = ds.dataset.map(...)
```

Further PRs will address following todos:
- make it work with our explore method
- implement a working cache mechanism for the instances
- Replace the `DataSource` class in the whole library