### PR TITLE
Add 'use_amp' option to the TrainerConfiguration

### DIFF
--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -463,6 +463,9 @@ class TrainerConfiguration:
     random_seed
         Seed for the underlying random number generator.
         If None, we take the random seeds provided by AllenNLP's `prepare_environment` method.
+
+    use_amp
+        If `True`, we'll train using [Automatic Mixed Precision](https://pytorch.org/docs/stable/amp.html).
     """
 
     optimizer: Dict[str, Any] = dataclasses.field(
@@ -477,6 +480,7 @@ class TrainerConfiguration:
     learning_rate_scheduler: Optional[Dict[str, Any]] = None
     momentum_scheduler: Optional[Dict[str, Any]] = None
     moving_average: Optional[Dict[str, Any]] = None
+    use_amp: bool = False
     # Data loader parameters
     batch_size: Optional[int] = 16
     data_bucketing: bool = False

--- a/tests/text/test_trainer.py
+++ b/tests/text/test_trainer.py
@@ -1,0 +1,47 @@
+import pytest
+from biome.text import Dataset, Pipeline, TrainerConfiguration, VocabularyConfiguration
+
+
+@pytest.fixture(scope="module")
+def dataset() -> Dataset:
+    data = {
+        "text": ["Test", "this", "shaight", "!"],
+        "label": ["0", "1", "0", "0"]
+    }
+
+    return Dataset.from_dict(data)
+
+
+@pytest.fixture(scope="module")
+def pipeline(dataset) -> Pipeline:
+    config = {
+        "name": "test_trainer",
+        "features": {
+            "word": {"embedding_dim": 2}
+        },
+        "head": {
+            "type": "TextClassification",
+            "labels": list(set(dataset["label"]))
+        }
+    }
+    pl = Pipeline.from_config(config)
+    pl.create_vocabulary(VocabularyConfiguration(sources=[dataset]))
+
+    return pl
+
+
+def test_use_amp(dataset, pipeline, tmp_path, capsys):
+    trainer_config = TrainerConfiguration(
+        num_epochs=1,
+        batch_size=2,
+        use_amp=True,
+    )
+
+    pipeline.train(
+        output=str(tmp_path / "test_use_amp_output"),
+        training=dataset,
+        trainer=trainer_config
+    )
+
+    captured = capsys.readouterr()
+    assert "use_amp = True" in captured.err

--- a/tests/text/test_trainer.py
+++ b/tests/text/test_trainer.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 from biome.text import Dataset, Pipeline, TrainerConfiguration, VocabularyConfiguration
 
 
@@ -30,6 +31,7 @@ def pipeline(dataset) -> Pipeline:
     return pl
 
 
+@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Using AMP requires a cuda device")
 def test_use_amp(dataset, pipeline, tmp_path, capsys):
     trainer_config = TrainerConfiguration(
         num_epochs=1,


### PR DESCRIPTION
This PR adds the `use_amp` option to our `TrainerConfiguration` as requested in #356.