### PR TITLE
fix(setup): upgrade required pip version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError as error:
 
 from pip import __version__ as pip_version
 
-PIP_VERSION_REQUIRED = "19.1.1"
+PIP_VERSION_REQUIRED = "20.2.0"
 
 
 def check_pip_version(required_version: str, version: str) -> bool:


### PR DESCRIPTION
This PR upgrade required pip version. Since we're using feature `--use-feature` in makefile directive and that feature is included since pip 20.2 version