### PR TITLE
refactor(token_classifier): config only accepts span labels

### DIFF
--- a/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb
+++ b/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,154 +80,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>text</th>\n",
-       "      <th>labels</th>\n",
-       "      <th>intent</th>\n",
-       "      <th>path</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>[Find, the, schedule, for, Across, the, Line, ...</td>\n",
-       "      <td>[O, O, B-object_type, O, B-movie_name, I-movie...</td>\n",
-       "      <td>SearchScreeningEvent</td>\n",
-       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>[play, Party, Ben, on, Slacker]</td>\n",
-       "      <td>[O, B-artist, I-artist, O, B-service]</td>\n",
-       "      <td>PlayMusic</td>\n",
-       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>[play, a, 1988, soundtrack]</td>\n",
-       "      <td>[O, O, B-year, B-music_item]</td>\n",
-       "      <td>PlayMusic</td>\n",
-       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>[Can, you, play, The, Change, Is, Made, on, Ne...</td>\n",
-       "      <td>[O, O, O, B-track, I-track, I-track, I-track, ...</td>\n",
-       "      <td>PlayMusic</td>\n",
-       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>[what, is, the, forecast, for, colder, in, Ans...</td>\n",
-       "      <td>[O, O, O, O, O, B-condition_temperature, O, B-...</td>\n",
-       "      <td>GetWeather</td>\n",
-       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>[What's, the, weather, in, Totowa, WY, one, mi...</td>\n",
-       "      <td>[O, O, O, O, B-city, B-state, B-timeRange, I-t...</td>\n",
-       "      <td>GetWeather</td>\n",
-       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>[Play, a, tune, from, Space, Mandino, .]</td>\n",
-       "      <td>[O, O, B-music_item, O, B-artist, I-artist, O]</td>\n",
-       "      <td>PlayMusic</td>\n",
-       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
-       "      <td>[give, five, out, of, 6, stars, to, current, e...</td>\n",
-       "      <td>[O, B-rating_value, O, O, B-best_rating, B-rat...</td>\n",
-       "      <td>RateBook</td>\n",
-       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>8</th>\n",
-       "      <td>[Play, some, chanson, style, music.]</td>\n",
-       "      <td>[O, O, B-genre, O, O]</td>\n",
-       "      <td>PlayMusic</td>\n",
-       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>9</th>\n",
-       "      <td>[I, would, give, French, Poets, and, Novelists...</td>\n",
-       "      <td>[O, O, O, B-object_name, I-object_name, I-obje...</td>\n",
-       "      <td>RateBook</td>\n",
-       "      <td>https://biome-tutorials-data.s3-eu-west-1.amaz...</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                                                text  \\\n",
-       "0  [Find, the, schedule, for, Across, the, Line, ...   \n",
-       "1                    [play, Party, Ben, on, Slacker]   \n",
-       "2                        [play, a, 1988, soundtrack]   \n",
-       "3  [Can, you, play, The, Change, Is, Made, on, Ne...   \n",
-       "4  [what, is, the, forecast, for, colder, in, Ans...   \n",
-       "5  [What's, the, weather, in, Totowa, WY, one, mi...   \n",
-       "6           [Play, a, tune, from, Space, Mandino, .]   \n",
-       "7  [give, five, out, of, 6, stars, to, current, e...   \n",
-       "8               [Play, some, chanson, style, music.]   \n",
-       "9  [I, would, give, French, Poets, and, Novelists...   \n",
-       "\n",
-       "                                              labels                 intent  \\\n",
-       "0  [O, O, B-object_type, O, B-movie_name, I-movie...   SearchScreeningEvent   \n",
-       "1              [O, B-artist, I-artist, O, B-service]              PlayMusic   \n",
-       "2                       [O, O, B-year, B-music_item]              PlayMusic   \n",
-       "3  [O, O, O, B-track, I-track, I-track, I-track, ...              PlayMusic   \n",
-       "4  [O, O, O, O, O, B-condition_temperature, O, B-...             GetWeather   \n",
-       "5  [O, O, O, O, B-city, B-state, B-timeRange, I-t...             GetWeather   \n",
-       "6     [O, O, B-music_item, O, B-artist, I-artist, O]              PlayMusic   \n",
-       "7  [O, B-rating_value, O, O, B-best_rating, B-rat...               RateBook   \n",
-       "8                              [O, O, B-genre, O, O]              PlayMusic   \n",
-       "9  [O, O, O, B-object_name, I-object_name, I-obje...               RateBook   \n",
-       "\n",
-       "                                                path  \n",
-       "0  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
-       "1  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
-       "2  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
-       "3  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
-       "4  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
-       "5  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
-       "6  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
-       "7  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
-       "8  https://biome-tutorials-data.s3-eu-west-1.amaz...  \n",
-       "9  https://biome-tutorials-data.s3-eu-west-1.amaz...  "
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "train_ds = DataSource(source=\"https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/token_classifier/train.json\")\n",
     "train_ds.head()"
@@ -252,20 +107,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "13084"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "len(train_ds.to_dataframe())"
    ]
@@ -279,20 +123,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "72"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = train_ds.to_dataframe().compute()\n",
     "labels_total = df.labels.sum()\n",
@@ -308,7 +141,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "nbreg": {
      "diff_ignore": [
@@ -316,29 +149,7 @@
      ]
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "O                               59610\n",
-       "I-object_name                    7400\n",
-       "I-playlist                       3230\n",
-       "B-object_type                    3023\n",
-       "B-object_name                    2778\n",
-       "                                ...  \n",
-       "I-cuisine                          28\n",
-       "I-facility                         14\n",
-       "I-object_part_of_series_type        3\n",
-       "I-object_select                     3\n",
-       "I-playlist_owner                    1\n",
-       "Length: 72, dtype: int64"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "pd.Series(labels_total).value_counts()"
@@ -417,7 +228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,14 +312,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "from biome.text.modules.heads import TokenClassificationConfiguration\n",
     "\n",
+    "labels = list(set([label[2:] for label in labels_total if label != 'O']))\n",
+    "\n",
     "head_config = TokenClassificationConfiguration(\n",
-    "    labels=list(set(labels_total)),\n",
+    "    labels=labels,\n",
     "    label_encoding=\"BIO\",\n",
     "    feedforward={\n",
     "        \"num_layers\": 1,\n",
@@ -535,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,7 +364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +406,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +445,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "nbreg": {
      "diff_ignore": [
@@ -640,50 +453,7 @@
      ]
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9c800176bdeb421086035a1f62ec9072",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(FloatProgress(value=1.0, bar_style='info', max=1.0), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "8344e270710c48338180d511f772a157",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(FloatProgress(value=0.0, max=999994.0), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "pl.create_vocabulary(vocab_config)"
    ]
@@ -697,20 +467,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1989112"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pl.num_trainable_parameters"
    ]
@@ -741,7 +500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -816,7 +575,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "nbreg": {
      "diff_ignore": [
@@ -824,27 +583,7 @@
      ]
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[('can', 'O'),\n",
-       " ('you', 'O'),\n",
-       " ('play', 'O'),\n",
-       " ('biome', 'B-track'),\n",
-       " ('text', 'I-track'),\n",
-       " ('by', 'O'),\n",
-       " ('backstreet', 'B-artist'),\n",
-       " ('recognais', 'I-artist'),\n",
-       " ('on', 'O'),\n",
-       " ('Spotify', 'B-service')]"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "text = \"can you play biome text by backstreet recognais on Spotify\".split()\n",
     "prediction = pl_trained.predict(text)\n",

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -34,7 +34,7 @@ def training_data_source(tmp_path) -> DataSource:
 def pipeline_dict() -> Dict:
     pipeline_dict = {
         "name": "biome-bimpm",
-        "features": {"word": {"embedding_dim": 2,},},
+        "features": {"word": {"embedding_dim": 2}},
         "head": {
             "type": "TokenClassification",
             "labels": ["NER"],
@@ -59,11 +59,17 @@ def trainer_dict() -> Dict:
 
 def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
     pipeline = Pipeline.from_config(pipeline_dict)
+
+    assert pipeline.head.span_labels == ["NER"]
+    assert pipeline.head.labels == ["B-NER", "I-NER", "U-NER", "L-NER", "O"]
+
     predictions = pipeline.predict(["test", "this", "pretokenized", "text"])
     assert "entities" not in predictions
     assert "tags" in predictions
 
-    predictions = pipeline.predict_batch([{"text": "Test this NER system"}, {"text": "and this"}])
+    predictions = pipeline.predict_batch(
+        [{"text": "Test this NER system"}, {"text": "and this"}]
+    )
     assert "entities" in predictions[0]
     assert "tags" in predictions[0]
 


### PR DESCRIPTION
This PR simplifies token classifiers configuration. Only accepts labels values a span values, and internally converts into configured labels encoding.
 