### PR TITLE
Avoid copy of pipeline when running a learning rate search

### DIFF
--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -286,7 +286,7 @@ def create_dataloader(
 
 
 def create_trainer_for_finding_lr(
-    pipeline: Pipeline,
+    model: PipelineModel,
     trainer_config: TrainerConfiguration,
     training_data: InstancesDataset,
 ) -> GradientDescentTrainer:
@@ -294,16 +294,14 @@ def create_trainer_for_finding_lr(
 
     Parameters
     ----------
-    pipeline
-        The pipeline with the model
+    model
+        The underlying model
     trainer_config
         A trainer configuration
     training_data
         The training data
     """
     prepare_environment(Params({}))
-
-    training_data.index_with(pipeline.backbone.vocab)
 
     trainer_params = Params(
         helpers.sanitize_for_params(trainer_config.to_allennlp_trainer())
@@ -314,7 +312,7 @@ def create_trainer_for_finding_lr(
     )
 
     return cast("GradientDescentTrainer", Trainer.from_params(
-        model=pipeline._model,
+        model=model,
         data_loader=training_data_loader,
         params=trainer_params,
         serialization_dir=None,

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -196,9 +196,10 @@ class Pipeline:
             training_data = self.create_dataset(training_data)
         elif isinstance(training_data, Dataset):
             training_data: AllennlpLazyDataset = training_data.to_instances(pipeline=self)
+        training_data.index_with(self._model.vocab)
 
         trainer = create_trainer_for_finding_lr(
-            pipeline=self,
+            model=self._model,
             trainer_config=trainer_config,
             training_data=training_data,
         )

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -3,21 +3,23 @@ import inspect
 import logging
 import os
 import shutil
+import tempfile
 from inspect import Parameter
+from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Type, Union, cast
 
 import numpy
+import torch
+from allennlp.commands.find_learning_rate import search_learning_rate
 from allennlp.common import Params
 from allennlp.data import (
     AllennlpDataset,
     AllennlpLazyDataset,
     Instance,
     Vocabulary,
-    Token,
 )
 from allennlp.models import load_archive
 from allennlp.models.archival import Archive
-from allennlp.commands.find_learning_rate import search_learning_rate
 from dask.dataframe import DataFrame
 
 from biome.text import vocabulary
@@ -27,8 +29,8 @@ from biome.text.configuration import (
     VocabularyConfiguration,
     FindLRConfiguration,
 )
-from biome.text.dataset import Dataset
 from biome.text.data import DataSource, InstancesDataset
+from biome.text.dataset import Dataset
 from biome.text.errors import ActionNotSupportedError, EmptyVocabError
 from biome.text.features import TransformersFeatures
 from biome.text.helpers import update_method_signature
@@ -182,11 +184,8 @@ class Pipeline:
         """
         from biome.text._helpers import create_trainer_for_finding_lr
 
-        # The original pipeline keeps unchanged
-        find_lr_pipeline = self._make_copy()
-
         if vocabulary.is_empty(
-            find_lr_pipeline.backbone.vocab, self.config.features.keys
+            self._model.vocab, self.config.features.keys
         ):
             raise EmptyVocabError(
                 "Found an empty vocabulary. "
@@ -194,24 +193,30 @@ class Pipeline:
             )
 
         if isinstance(training_data, DataSource):
-            training_data = find_lr_pipeline.create_dataset(training_data)
+            training_data = self.create_dataset(training_data)
         elif isinstance(training_data, Dataset):
             training_data: AllennlpLazyDataset = training_data.to_instances(pipeline=self)
 
         trainer = create_trainer_for_finding_lr(
-            pipeline=find_lr_pipeline,
+            pipeline=self,
             trainer_config=trainer_config,
             training_data=training_data,
         )
 
-        learning_rates, losses = search_learning_rate(
-            trainer=trainer,
-            start_lr=find_lr_config.start_lr,
-            end_lr=find_lr_config.end_lr,
-            num_batches=find_lr_config.num_batches,
-            linear_steps=find_lr_config.linear_steps,
-            stopping_factor=find_lr_config.stopping_factor,
-        )
+        # restore the state after the lr search is done
+        tmp_state_path = Path(tempfile.gettempdir()) / f"model_state_before_findlr_{id(self)}.pth"
+        torch.save(self._model.state_dict(), tmp_state_path)
+        try:
+            learning_rates, losses = search_learning_rate(
+                trainer=trainer,
+                start_lr=find_lr_config.start_lr,
+                end_lr=find_lr_config.end_lr,
+                num_batches=find_lr_config.num_batches,
+                linear_steps=find_lr_config.linear_steps,
+                stopping_factor=find_lr_config.stopping_factor,
+            )
+        finally:
+            self._model.load_state_dict(torch.load(tmp_state_path))
 
         return learning_rates, losses
 

--- a/tests/text/test_pipeline_find_lr.py
+++ b/tests/text/test_pipeline_find_lr.py
@@ -86,6 +86,7 @@ def test_find_lr(train_data_source, pipeline_dict, trainer_config, find_lr_confi
     vocab_config = VocabularyConfiguration(sources=[train_data_source])
 
     pl.create_vocabulary(vocab_config)
+    prev_prediction = pl.predict("test")
 
     learning_rates, losses = pl.find_lr(
         trainer_config=trainer_config,
@@ -94,3 +95,7 @@ def test_find_lr(train_data_source, pipeline_dict, trainer_config, find_lr_confi
     )
 
     assert len(learning_rates) == len(losses) == 12
+    assert all(
+        a == pytest.approx(b, rel=0.0001)
+        for a, b in zip(prev_prediction["logits"], pl.predict("test")["logits"])
+    )


### PR DESCRIPTION
This PR improves a bit the `Pipeline.find_lr` method. Instead of copying the whole pipeline, it saves the model state before the learning rate scan and restores it afterwards.