### PR TITLE
Adding a new HPO component, making is compatible with Datasets

### DIFF
--- a/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
+++ b/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
@@ -93,7 +93,7 @@
     "from biome.text import Pipeline, Dataset\n",
     "from biome.text.configuration import VocabularyConfiguration, WordFeatures, TrainerConfiguration\n",
     "from biome.text.loggers import BaseTrainLogger\n",
-    "from biome.text.hpo import RayTuneTrainable\n",
+    "from biome.text.hpo import TuneExperiment\n",
     "from ray import tune"
    ]
   },
@@ -108,7 +108,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As a first step we will download the training and validation data to our local machine, and create our dataset. "
+    "As a first step we will download the training and validation data to our local machine, and create our datasets. "
    ]
   },
   {
@@ -135,128 +135,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Creating the pipeline and vocabulary"
+    "## Defining the pipeline and the search space"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In order to be more efficient and speed things up, we will create the vocabulary beforehand and reuse it in every trial.\n",
-    "For this we have to define a `Pipeline` first and create the vocabulary from our datasets.\n",
+    "As mentioned in the introduction we will use the same pipeline configuration as used in the [base tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html)).\n",
     "\n",
-    "Let's start with defining the configuration of our pipeline (for details see the [base tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html)):"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "labels = list(set(train_ds[\"label\"]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pipeline_config = {\n",
-    "    \"name\": \"german_business_names\",\n",
-    "    \"tokenizer\": {\n",
-    "        \"text_cleaning\": {\n",
-    "            \"rules\": [\"strip_spaces\"]\n",
-    "        }\n",
-    "    },\n",
-    "    \"features\": {\n",
-    "        \"word\": {\n",
-    "            \"embedding_dim\": 64,\n",
-    "            \"lowercase_tokens\": True,\n",
-    "        },\n",
-    "        \"char\": {\n",
-    "            \"embedding_dim\": 32,\n",
-    "            \"lowercase_characters\": True,\n",
-    "            \"encoder\": {\n",
-    "                \"type\": \"gru\",\n",
-    "                \"num_layers\": 1,\n",
-    "                \"hidden_size\": 32,\n",
-    "                \"bidirectional\": True,\n",
-    "            },\n",
-    "            \"dropout\": 0.1,\n",
-    "        },\n",
-    "    },\n",
-    "    \"head\": {\n",
-    "        \"type\": \"TextClassification\",\n",
-    "        \"labels\": labels,\n",
-    "        \"pooler\": {\n",
-    "            \"type\": \"gru\",\n",
-    "            \"num_layers\": 1,\n",
-    "            \"hidden_size\": 32,\n",
-    "            \"bidirectional\": True,\n",
-    "        },\n",
-    "        \"feedforward\": {\n",
-    "            \"num_layers\": 1,\n",
-    "            \"hidden_dims\": [32],\n",
-    "            \"activations\": [\"relu\"],\n",
-    "            \"dropout\": [0.0],\n",
-    "        },\n",
-    "    },       \n",
-    "}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We will use this configuration dictionary to create our pipeline:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pl = Pipeline.from_config(pipeline_config)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Next, we have to define the vocabulary configuration and create our vocabulary.\n",
-    "\n",
-    "\n",
-    "::: tip Note\n",
-    "\n",
-    "If you want to optimize the vocabulary configuration in the hyperparameter search (for example, the `min_count` argument), you have to move the vocabulary creation to the `trainable` function below. That is, in each trial the vocabulary will be created anew.\n",
-    "\n",
-    ":::"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vocab_config = VocabularyConfiguration(sources=[train_ds], min_count={WordFeatures.namespace: 20})\n",
-    "pl.create_vocabulary(vocab_config)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Defining the search space"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "To perform a random hyperparameter search (as well as a grid search) we simply have to replace the parameters we want to optimize with methods from the [Random Distributions API](https://docs.ray.io/en/latest/tune/api_docs/search_space.html#random-distributions-api) or the [Grid Search API](https://docs.ray.io/en/latest/tune/api_docs/search_space.html#grid-search-api) in our configuration dictionaries.\n",
     "For a complete description of both APIs and how they interplay with each other, see the corresponding section in the [Ray Tune docs](https://docs.ray.io/en/latest/tune/api_docs/search_space.html). \n",
     "\n",
@@ -315,7 +202,7 @@
     "    },\n",
     "    \"head\": {\n",
     "        \"type\": \"TextClassification\",\n",
-    "        \"labels\": labels,\n",
+    "        \"labels\": list(set(train_ds[\"label\"])),\n",
     "        \"pooler\": {\n",
     "            \"type\": tune.choice([\"gru\", \"lstm\"]),\n",
     "            \"num_layers\": tune.choice([1, 2]),\n",
@@ -364,38 +251,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we have everything ready to start our random hyperparameter search.\n",
-    "The `tune.run` method requires a trainable function that takes as argument a configuration.\n",
-    "*biome.text* provides both elements via the `RayTuneTrainable` class, which we instantiate with our configuration dictionaries, our datasets and a vocabulary to be shared among the trials for efficiency reasons, but this is optional.\n",
-    "We also provide a name that will mainly be used as project and experiment name for the integrated WandB and MLFlow logger, respectively."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "trainable = RayTuneTrainable(\n",
-    "    pipeline_config=pipeline_config,\n",
-    "    trainer_config=trainer_config,\n",
-    "    train_dataset=train_ds,\n",
-    "    valid_dataset=valid_ds,\n",
-    "    vocab=pl.backbone.vocab,\n",
-    "    name=\"My first HPO experiment\"\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The number of trials our search will go through depends on the `num_samples` parameter of the `tune.run` method.\n",
+    "Before starting our random hyperparameter search we first have to create a `TuneExperiment` instance with our configurations dicts and our datasets.\n",
+    "We also set a name that will mainly be used as project and experiment name for the integrated WandB and MLFlow logger, respectively.\n",
+    "\n",
+    "Furthermore, we can pass on all the parameters available for the underlying [`tune.Experiment`](https://docs.ray.io/en/master/tune/api_docs/execution.html#tune-experiment) class:\n",
+    "\n",
+    "- The number of trials our search will go through depends on the `num_samples` parameter.\n",
     "In our case, a random search, it equals the number of trials, whereas in the case of a grid search the total number of trials is `num_samples` times the grid configurations (see the [Tune docs](https://docs.ray.io/en/latest/tune/api_docs/search_space.html#overview) for illustrative examples).\n",
     "\n",
-    "The `local_dir` parameter defines the output directory of the HPO results and will also contain the training results of each trial (that is the model weights and metrics).\n",
+    "- The `local_dir` parameter defines the output directory of the HPO results and will also contain the training results of each trial (that is the model weights and metrics).\n",
     "\n",
-    "The number of parallel running trials depends on your `resources_per_trial` configuration and your local resources.\n",
+    "- The number of parallel running trials depends on your `resources_per_trial` configuration and your local resources.\n",
     "The default value is `{\"cpu\": 1, \"gpu\": 0}` and results, for example, in 8 parallel running trials on a machine with 8 CPUs.\n",
     "You can also use fractional values. To share a GPU between 2 trials, for example, pass on `{\"gpu\": 0.5}`. \n",
     "\n",
@@ -405,12 +271,41 @@
     "If you do not want to use a GPU, just set the value to 0 `{\"cpu\": 1, \"gpu\": 0}`.\n",
     "\n",
     ":::\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "my_random_search = TuneExperiment(\n",
+    "    pipeline_config=pipeline_config,\n",
+    "    trainer_config=trainer_config,\n",
+    "    train_dataset=train_ds,\n",
+    "    valid_dataset=valid_ds,\n",
+    "    name=\"My first random search\",\n",
+    "    # `tune.Experiment` kwargs:\n",
+    "    num_samples=50,\n",
+    "    local_dir=\"tune_runs\",\n",
+    "    resources_per_trial={\"cpu\": 1, \"gpu\": 0.5},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With our `TuneExperiment` object at hand, we simply have to pass it on to the [`tune.run`](https://docs.ray.io/en/master/tune/api_docs/execution.html#tune-run) function to start our random search.\n",
     "\n",
     "In this tutorial we will perform a random search together with the [Asynchronous Successive Halving Algorithm (ASHA)](https://blog.ml.cmu.edu/2018/12/12/massively-parallel-hyperparameter-optimization/) to schedule our trials.\n",
     "The Ray Tune developers advocate this `scheduler` as a good starting point for its aggressive termination of low-performing trials.\n",
     "You can look up the available configurations in the [ASHAScheduler docs](https://docs.ray.io/en/latest/tune/api_docs/schedulers.html#asha-tune-schedulers-ashascheduler), here we will just use the default parameters.\n",
     "\n",
-    "We also have to specify on what `metric` to optimize and its `mode` (should the metric be *minimized* (`min`) or *maximized* (`max`) )."
+    "We also have to specify on what `metric` to optimize and its `mode` (should the metric be *minimized* (`min`) or *maximized* (`max`) ).\n",
+    "\n",
+    "The `progress_reporter` is a nice feature to keep track of the progress inside a Jupyter Notebook, for example."
    ]
   },
   {
@@ -420,14 +315,10 @@
    "outputs": [],
    "source": [
     "analysis = tune.run(\n",
-    "    trainable.func,\n",
-    "    config=trainable.config,\n",
+    "    my_random_search,\n",
     "    scheduler=tune.schedulers.ASHAScheduler(), \n",
     "    metric=\"validation_loss\", \n",
     "    mode=\"min\",\n",
-    "    num_samples=50,\n",
-    "    local_dir=\"tune_runs\",\n",
-    "    resources_per_trial={\"cpu\": 1, \"gpu\": 0.5},\n",
     "    progress_reporter=tune.JupyterNotebookReporter(overwrite=True)\n",
     ")"
    ]
@@ -436,7 +327,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Following the progress with tensorboard (optional)"
+    "### Following the progress with tensorboard (optional)"
    ]
   },
   {
@@ -797,7 +688,10 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.7.7"
-  }
+  },
+  "toc-autonumbering": false,
+  "toc-showcode": false,
+  "toc-showmarkdowntxt": false
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
+++ b/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
@@ -357,33 +357,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Defining a trial scheduler"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In this tutorial we will perform a random search together with the [Asynchronous Successive Halving Algorithm (ASHA)](https://blog.ml.cmu.edu/2018/12/12/massively-parallel-hyperparameter-optimization/) to schedule our trials.\n",
-    "The Ray Tune developers advocate this scheduler as a good starting point for its aggressive termination of low-performing trials.\n",
-    "\n",
-    "To create an instance of the `ASHAScheduler` we have to specify the decisive metric for terminating low-performing trials and the mode of this metric (is the objective to *minimize* the metric, `min`, or to *maximize* it, `max`).\n",
-    "For a complete description of the configurations, see the [ASHAScheduler docs](https://docs.ray.io/en/latest/tune/api_docs/schedulers.html#asha-tune-schedulers-ashascheduler)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "asha = tune.schedulers.ASHAScheduler(metric=\"validation_loss\", mode=\"min\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Starting the random search"
    ]
   },
@@ -393,7 +366,7 @@
    "source": [
     "Now we have everything ready to start our random hyperparameter search.\n",
     "The `tune.run` method requires a trainable function that takes as argument a configuration.\n",
-    "*biome.text* provides both elements via the `RayTuneTrainable` class which we instantiate with our configuration dictionaries, our datasets and a vocabulary (to be shared among the trials for efficiency reasons, but this is optional).\n",
+    "*biome.text* provides both elements via the `RayTuneTrainable` class, which we instantiate with our configuration dictionaries, our datasets and a vocabulary to be shared among the trials for efficiency reasons, but this is optional.\n",
     "We also provide a name that will mainly be used as project and experiment name for the integrated WandB and MLFlow logger, respectively."
    ]
   },
@@ -433,7 +406,11 @@
     "\n",
     ":::\n",
     "\n",
-    "We also tell it to share the vocab among the trials by setting `shared_vocab` to true, and to sample 50 times from the hyperparameter space by setting `num_samples` to 50."
+    "In this tutorial we will perform a random search together with the [Asynchronous Successive Halving Algorithm (ASHA)](https://blog.ml.cmu.edu/2018/12/12/massively-parallel-hyperparameter-optimization/) to schedule our trials.\n",
+    "The Ray Tune developers advocate this `scheduler` as a good starting point for its aggressive termination of low-performing trials.\n",
+    "You can look up the available configurations in the [ASHAScheduler docs](https://docs.ray.io/en/latest/tune/api_docs/schedulers.html#asha-tune-schedulers-ashascheduler), here we will just use the default parameters.\n",
+    "\n",
+    "We also have to specify on what `metric` to optimize and its `mode` (should the metric be *minimized* (`min`) or *maximized* (`max`) )."
    ]
   },
   {
@@ -445,7 +422,9 @@
     "analysis = tune.run(\n",
     "    trainable.func,\n",
     "    config=trainable.config,\n",
-    "    scheduler=asha, \n",
+    "    scheduler=tune.schedulers.ASHAScheduler(), \n",
+    "    metric=\"validation_loss\", \n",
+    "    mode=\"min\",\n",
     "    num_samples=50,\n",
     "    local_dir=\"tune_runs\",\n",
     "    resources_per_trial={\"cpu\": 1, \"gpu\": 0.5},\n",
@@ -563,8 +542,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_config = analysis.get_best_config(metric=\"validation_loss\", mode=\"min\")\n",
-    "best_logdir = analysis.get_best_logdir(metric=\"validation_loss\", mode=\"min\")"
+    "analysis.get_best_config()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_config = analysis.get_best_config()\n",
+    "best_logdir = analysis.get_best_logdir()"
    ]
   },
   {
@@ -580,7 +568,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "best_model = os.path.join(best_logdir, \"output\", \"model.tar.gz\")\n",
+    "best_model = os.path.join(best_logdir, \"training\", \"model.tar.gz\")\n",
     "pl_trained = Pipeline.from_pretrained(best_model)"
    ]
   },

--- a/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
+++ b/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
@@ -90,11 +90,10 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from biome.text.data import DataSource\n",
-    "from biome.text import Pipeline\n",
+    "from biome.text import Pipeline, Dataset\n",
     "from biome.text.configuration import VocabularyConfiguration, WordFeatures, TrainerConfiguration\n",
     "from biome.text.loggers import BaseTrainLogger\n",
-    "from biome.text.hpo import HpoParams, HpoExperiment\n",
+    "from biome.text.hpo import RayTuneTrainable\n",
     "from ray import tune"
    ]
   },
@@ -102,15 +101,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Download the data"
+    "## Creating the datasets"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As a first step we will download the training and validation data to our local machine. \n",
-    "This will save us some time in the long run, since we will perform the hyperparameter search on our local machine and access the data frequently."
+    "As a first step we will download the training and validation data to our local machine, and create our dataset. "
    ]
   },
   {
@@ -119,40 +117,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!curl -O https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/text_classifier/business.cat.train.csv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "!curl -O https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/text_classifier/business.cat.train.csv\n",
     "!curl -O https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/text_classifier/business.cat.valid.csv"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We will store the absolute path of the data to use them later on when creating our `DataSource`s."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_path = os.path.abspath(\"business.cat.train.csv\")\n",
-    "valid_path = os.path.abspath(\"business.cat.valid.csv\")"
+    "train_ds = Dataset.from_csv(\"business.cat.train.csv\")\n",
+    "valid_ds = Dataset.from_csv(\"business.cat.valid.csv\")"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Create the pipeline and vocabulary"
+    "## Creating the pipeline and vocabulary"
    ]
   },
   {
@@ -160,7 +143,7 @@
    "metadata": {},
    "source": [
     "In order to be more efficient and speed things up, we will create the vocabulary beforehand and reuse it in every trial.\n",
-    "For this we have to define a `Pipeline` first and create the vocabulary from our `DataSource`.\n",
+    "For this we have to define a `Pipeline` first and create the vocabulary from our datasets.\n",
     "\n",
     "Let's start with defining the configuration of our pipeline (for details see the [base tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html)):"
    ]
@@ -171,7 +154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "labels = DataSource(train_path).to_dataframe().label.compute()"
+    "labels = list(set(train_ds[\"label\"]))"
    ]
   },
   {
@@ -180,7 +163,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipeline_dict = {\n",
+    "pipeline_config = {\n",
     "    \"name\": \"german_business_names\",\n",
     "    \"tokenizer\": {\n",
     "        \"text_cleaning\": {\n",
@@ -206,7 +189,7 @@
     "    },\n",
     "    \"head\": {\n",
     "        \"type\": \"TextClassification\",\n",
-    "        \"labels\": list(labels.value_counts().index),\n",
+    "        \"labels\": labels,\n",
     "        \"pooler\": {\n",
     "            \"type\": \"gru\",\n",
     "            \"num_layers\": 1,\n",
@@ -236,7 +219,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pl = Pipeline.from_config(pipeline_dict)"
+    "pl = Pipeline.from_config(pipeline_config)"
    ]
   },
   {
@@ -259,15 +242,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vocab_config = VocabularyConfiguration(sources=[DataSource(train_path)], min_count={WordFeatures.namespace: 20})"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "vocab_config = VocabularyConfiguration(sources=[train_ds], min_count={WordFeatures.namespace: 20})\n",
     "pl.create_vocabulary(vocab_config)"
    ]
   },
@@ -275,15 +250,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Random search with a trial scheduler"
+    "## Defining the search space"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To perform a random hyperparameter search (as well as a grid search) we simply have to replace the parameters we want to optimize with methods from the [Random Distributions API](https://docs.ray.io/en/latest/tune/api_docs/grid_random.html#random-distributions-api) and the [Grid Search API](https://docs.ray.io/en/latest/tune/api_docs/grid_random.html#grid-search-api), respectively.\n",
-    "For a complete description of both APIs and how they interplay with each other, see the corresponding section in the [Ray Tune docs](https://docs.ray.io/en/latest/tune/api_docs/grid_random.html). \n",
+    "To perform a random hyperparameter search (as well as a grid search) we simply have to replace the parameters we want to optimize with methods from the [Random Distributions API](https://docs.ray.io/en/latest/tune/api_docs/search_space.html#random-distributions-api) or the [Grid Search API](https://docs.ray.io/en/latest/tune/api_docs/search_space.html#grid-search-api) in our configuration dictionaries.\n",
+    "For a complete description of both APIs and how they interplay with each other, see the corresponding section in the [Ray Tune docs](https://docs.ray.io/en/latest/tune/api_docs/search_space.html). \n",
     "\n",
     "In our case we will tune 9 parameters:\n",
     "- the output dimensions of our `word` and `char` features\n",
@@ -304,7 +279,7 @@
     "\n",
     ":::\n",
     "\n",
-    "We will use the `HpoParams` class to define our tunable parameters and to configure our trainer: "
+    "In the following configuration dictionaries we replaced the relevant parameters with tune's search spaces."
    ]
   },
   {
@@ -313,39 +288,57 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hpo_params = HpoParams(\n",
-    "    pipeline={\n",
-    "        \"features\": {\n",
-    "            \"word\": {\n",
-    "                \"embedding_dim\": tune.choice([32, 64])\n",
-    "            },\n",
-    "            \"char\": {\n",
-    "                \"encoder\": {\n",
-    "                    \"hidden_size\": tune.choice([32, 64])\n",
-    "                },\n",
-    "                \"dropout\": tune.uniform(0, 0.5)\n",
-    "            }\n",
-    "        },\n",
-    "        \"head\": {\n",
-    "            \"pooler\": {\n",
-    "                \"type\": tune.choice([\"gru\", \"lstm\"]),\n",
-    "                \"num_layers\": tune.choice([1, 2]),\n",
-    "                \"hidden_size\": tune.choice([32, 64]),\n",
-    "                \"bidirectional\": tune.choice([True, False])\n",
-    "            },\n",
-    "            \"feedforward\": {\n",
-    "                \"hidden_dims\": [tune.choice([32, 64])],\n",
-    "            }\n",
+    "# defining the search spaces in our pipeline config\n",
+    "pipeline_config = {\n",
+    "    \"name\": \"german_business_names\",\n",
+    "    \"tokenizer\": {\n",
+    "        \"text_cleaning\": {\n",
+    "            \"rules\": [\"strip_spaces\"]\n",
     "        }\n",
     "    },\n",
-    "    trainer={\n",
-    "        \"optimizer\": {\n",
-    "            \"type\": \"adam\",\n",
-    "            \"lr\": tune.loguniform(0.001, 0.01),\n",
+    "    \"features\": {\n",
+    "        \"word\": {\n",
+    "            \"embedding_dim\": tune.choice([32, 64]),\n",
+    "            \"lowercase_tokens\": True,\n",
     "        },\n",
-    "        \"num_epochs\": 3,\n",
-    "    }\n",
-    ")"
+    "        \"char\": {\n",
+    "            \"embedding_dim\": 32,\n",
+    "            \"lowercase_characters\": True,\n",
+    "            \"encoder\": {\n",
+    "                \"type\": \"gru\",\n",
+    "                \"num_layers\": 1,\n",
+    "                \"hidden_size\": tune.choice([32, 64]),\n",
+    "                \"bidirectional\": True,\n",
+    "            },\n",
+    "            \"dropout\": tune.uniform(0, 0.5),\n",
+    "        },\n",
+    "    },\n",
+    "    \"head\": {\n",
+    "        \"type\": \"TextClassification\",\n",
+    "        \"labels\": labels,\n",
+    "        \"pooler\": {\n",
+    "            \"type\": tune.choice([\"gru\", \"lstm\"]),\n",
+    "            \"num_layers\": tune.choice([1, 2]),\n",
+    "            \"hidden_size\": tune.choice([32, 64]),\n",
+    "            \"bidirectional\": tune.choice([True, False]),\n",
+    "        },\n",
+    "        \"feedforward\": {\n",
+    "            \"num_layers\": 1,\n",
+    "            \"hidden_dims\": tune.choice([32, 64]),\n",
+    "            \"activations\": [\"relu\"],\n",
+    "            \"dropout\": [0.0],\n",
+    "        },\n",
+    "    },       \n",
+    "}\n",
+    "\n",
+    "# defining the search spaces in our trainer config\n",
+    "trainer_config = {\n",
+    "    \"optimizer\": {\n",
+    "        \"type\": \"adam\",\n",
+    "        \"lr\": tune.loguniform(0.001, 0.01)\n",
+    "    },\n",
+    "    \"num_epochs\": 3\n",
+    "}"
    ]
   },
   {
@@ -355,29 +348,16 @@
     "::: tip Note\n",
     "\n",
     "By default we will use a GPU if available.\n",
-    "If you do not want to use your GPU, just specify `\"cuda_device\": -1` in the trainer section of the dictionary above.\n",
+    "If you do not want to use your GPU, just specify `\"cuda_device\": -1` in your `trainer_config` above.\n",
     "\n",
-    ":::\n",
-    "\n",
-    "We then create an `HpoExperiment` with a name that will mainly be used as project name for the MLFlow and WandB logger.\n",
-    "We also tell it to share the vocab among the trials by setting `shared_vocab` to true, and to sample 50 times from the hyperparameter space by setting `num_samples` to 50."
+    ":::"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "hpo_experiment = HpoExperiment(\n",
-    "    name=\"my_first_hpo_experiment\",\n",
-    "    pipeline=pl,\n",
-    "    train=train_path,\n",
-    "    validation=valid_path,\n",
-    "    hpo_params=hpo_params,\n",
-    "    shared_vocab=True,\n",
-    "    num_samples=50\n",
-    ")"
+    "## Defining a trial scheduler"
    ]
   },
   {
@@ -404,6 +384,79 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Starting the random search"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we have everything ready to start our random hyperparameter search.\n",
+    "The `tune.run` method requires a trainable function that takes as argument a configuration.\n",
+    "*biome.text* provides both elements via the `RayTuneTrainable` class which we instantiate with our configuration dictionaries, our datasets and a vocabulary (to be shared among the trials for efficiency reasons, but this is optional).\n",
+    "We also provide a name that will mainly be used as project and experiment name for the integrated WandB and MLFlow logger, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainable = RayTuneTrainable(\n",
+    "    pipeline_config=pipeline_config,\n",
+    "    trainer_config=trainer_config,\n",
+    "    train_dataset=train_ds,\n",
+    "    valid_dataset=valid_ds,\n",
+    "    vocab=pl.backbone.vocab,\n",
+    "    name=\"My first HPO experiment\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The number of trials our search will go through depends on the `num_samples` parameter of the `tune.run` method.\n",
+    "In our case, a random search, it equals the number of trials, whereas in the case of a grid search the total number of trials is `num_samples` times the grid configurations (see the [Tune docs](https://docs.ray.io/en/latest/tune/api_docs/search_space.html#overview) for illustrative examples).\n",
+    "\n",
+    "The `local_dir` parameter defines the output directory of the HPO results and will also contain the training results of each trial (that is the model weights and metrics).\n",
+    "\n",
+    "The number of parallel running trials depends on your `resources_per_trial` configuration and your local resources.\n",
+    "The default value is `{\"cpu\": 1, \"gpu\": 0}` and results, for example, in 8 parallel running trials on a machine with 8 CPUs.\n",
+    "You can also use fractional values. To share a GPU between 2 trials, for example, pass on `{\"gpu\": 0.5}`. \n",
+    "\n",
+    "::: tip Note\n",
+    "\n",
+    "Keep in mind: to run your HPO on GPUs, you have to specify them in the `resources_per_trial` parameter when calling `tune.run()`.\n",
+    "If you do not want to use a GPU, just set the value to 0 `{\"cpu\": 1, \"gpu\": 0}`.\n",
+    "\n",
+    ":::\n",
+    "\n",
+    "We also tell it to share the vocab among the trials by setting `shared_vocab` to true, and to sample 50 times from the hyperparameter space by setting `num_samples` to 50."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "analysis = tune.run(\n",
+    "    trainable.func,\n",
+    "    config=trainable.config,\n",
+    "    scheduler=asha, \n",
+    "    num_samples=50,\n",
+    "    local_dir=\"tune_runs\",\n",
+    "    resources_per_trial={\"cpu\": 1, \"gpu\": 0.5},\n",
+    "    progress_reporter=tune.JupyterNotebookReporter(overwrite=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Following the progress with tensorboard (optional)"
    ]
   },
@@ -412,7 +465,8 @@
    "metadata": {},
    "source": [
     "Ray Tune automatically logs its results with [TensorBoard](https://www.tensorflow.org/tensorboard/).\n",
-    "We can take advantage of this and launch a TensorBoard instance before starting the hyperparameter search to follow its progress."
+    "We can take advantage of this and launch a TensorBoard instance before starting the hyperparameter search to follow its progress.\n",
+    "The `RayTuneTrainable` class will also log the metrics to MLFlow and WandB, if you prefer those platforms."
    ]
   },
   {
@@ -445,50 +499,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Start the hyperparameter search"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now we have everything ready to start our hyperparameter search with the `tune.run()` method.\n",
-    "\n",
-    "The number of trials our search will go through depends on the `num_samples` parameter.\n",
-    "In our case, a random search, it equals the number of trials, whereas in the case of a grid search the total number of trials is `num_samples` times the grid configurations (see the [Tune docs](https://docs.ray.io/en/latest/tune/api_docs/grid_random.html) for illustrative examples).\n",
-    "\n",
-    "The number of parallel running trials depends on your `resources_per_trial` configuration and your local resources.\n",
-    "The default value is `{\"cpu\": 1, \"gpu\": 0}` and results, for example, in 8 parallel running trials on a machine with 8 CPUs.\n",
-    "You can also use fractional values. To share a GPU between 2 trials, for example, pass on `{\"gpu\": 0.5}`. \n",
-    "\n",
-    "The `local_dir` parameter defines the output directory of the HPO results and will also contain the training results of each trial (that is the model weights and metrics).\n",
-    "\n",
-    "::: tip Note\n",
-    "\n",
-    "Keep in mind: to run your HPO on GPUs, you have to specify them in the `TrainerConfiguration` in the `trainable` function, as well as in the `resources_per_trial` parameter when calling `tune.run()`.\n",
-    "If you do not want to use a GPU, just set the value to 0 `{\"cpu\": 1, \"gpu\": 0}`.\n",
-    "\n",
-    ":::"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "analysis = tune.run(\n",
-    "    hpo_experiment.as_tune_experiment(),  \n",
-    "    scheduler=asha, \n",
-    "    resources_per_trial={\"cpu\": 1, \"gpu\": 0.5},\n",
-    "    progress_reporter=tune.JupyterNotebookReporter(overwrite=True)\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Checking the results"
    ]
   },
@@ -496,7 +506,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The *analysis* object returned by `tune.run()` can be accessed through a *pandas DataFrame*."
+    "The *analysis* object returned by `tune.run` can be accessed through a *pandas DataFrame*."
    ]
   },
   {
@@ -537,7 +547,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Evaluate the best performing model"
+    "### Evaluating the best performing model"
    ]
   },
   {
@@ -605,7 +615,7 @@
    "source": [
     "from biome.text import explore\n",
     "\n",
-    "explore.create(pl_trained, DataSource(valid_path), explain=True)"
+    "explore.create(pl_trained, valid_ds, explain=True)"
    ]
   },
   {

--- a/src/biome/text/hpo.py
+++ b/src/biome/text/hpo.py
@@ -196,7 +196,7 @@ class RayTuneTrainable:
     """This class provides a trainable function and a config to conduct an HPO with `ray.tune.run`
 
     Minimal usage:
-    >>> my_trainable = RayTuneTrainable(pipeline_config, trainer_config, train_ds, valid_dataset)
+    >>> my_trainable = RayTuneTrainable(pipeline_config, trainer_config, train_dataset, valid_dataset)
     >>> tune.run(my_trainable.func, config=my_trainable.config)
 
     Parameters

--- a/src/biome/text/hpo.py
+++ b/src/biome/text/hpo.py
@@ -3,15 +3,26 @@ This module includes all components related to a HPO experiment execution.
 It tries to allow for a simple integration with HPO libraries like Ray Tune.
 """
 import os
+import tempfile
 from dataclasses import asdict, dataclass, field
-from typing import Any, Callable, Dict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Callable, Dict, Union, List, Optional
 
 import mlflow
+from allennlp.data import Vocabulary
 from ray import tune
 
 from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration, helpers
 from biome.text.data import DataSource
-from biome.text.loggers import BaseTrainLogger, MlflowLogger, WandBLogger, is_wandb_installed_and_logged_in
+from biome.text.dataset import Dataset
+from biome.text.errors import ValidationError
+from biome.text.loggers import (
+    BaseTrainLogger,
+    MlflowLogger,
+    WandBLogger,
+    is_wandb_installed_and_logged_in,
+)
 
 
 class TuneMetricsLogger(BaseTrainLogger):
@@ -142,7 +153,6 @@ class HpoExperiment:
         Number of times to sample from the hyperparameter space.
         If `grid_search` is provided as an argument in the hpo_params, the grid will be repeated `num_samples` of times.
         Default: 1
-
     """
 
     name: str
@@ -180,3 +190,182 @@ class HpoExperiment:
             local_dir=os.path.abspath("runs/tune"),
             num_samples=self.num_samples,
         )
+
+
+class RayTuneTrainable:
+    """This class provides a trainable function and a config to conduct an HPO with `ray.tune.run`
+
+    Minimal usage:
+    >>> my_trainable = RayTuneTrainable(pipeline_config, trainer_config, train_ds, valid_dataset)
+    >>> tune.run(my_trainable.func, config=my_trainable.config)
+
+    Parameters
+    ----------
+    pipeline_config
+        The pipeline configuration with its hyperparemter search spaces:
+        https://docs.ray.io/en/master/tune/key-concepts.html#search-spaces
+    trainer_config
+        The trainer configuration with its hyperparameter search spaces
+    train_dataset
+        Training dataset
+    valid_dataset
+        Validation dataset
+    vocab
+        If you want to share the same vocabulary between the trials you can provide it here
+    name
+        Used as the project name in the WandB logger and as experiment name in the MLFlow logger.
+        By default we construct following string: 'HPO on %date (%time)'
+    """
+
+    def __init__(
+        self,
+        pipeline_config: dict,
+        trainer_config: dict,
+        train_dataset: Dataset,
+        valid_dataset: Dataset,
+        vocab: Optional[Vocabulary] = None,
+        name: Optional[str] = None
+    ):
+        # save created tmp dirs in this list to clean them up when object gets destroyed
+        self._created_tmp_dirs: List[tempfile.TemporaryDirectory] = []
+
+        self._train_dataset_path = self._save_dataset_to_disk(train_dataset)
+        self._valid_dataset_path = self._save_dataset_to_disk(valid_dataset)
+
+        self._pipeline_config = pipeline_config
+        self._trainer_config = trainer_config or {}
+        self._vocab_path = (
+            self._save_vocab_to_disk(vocab) if vocab is not None else None
+        )
+        self._name = name or f"HPO on {datetime.now().strftime('%Y-%m-%d (%I-%M)')}"
+
+    def _save_dataset_to_disk(self, dataset: Dataset) -> str:
+        """Saves the dataset to disk if not saved already
+
+        Parameters
+        ----------
+        dataset
+            Dataset to save to disk
+
+        Returns
+        -------
+        dataset_path
+            Path to the saved dataset, that is a directory
+        """
+        try:
+            filename = Path(dataset.dataset.cache_files[0]["filename"])
+        except (IndexError, KeyError):
+            filename = Path()
+
+        if filename.name != "dataset.arrow":
+            tmp_dir = tempfile.TemporaryDirectory()
+            self._created_tmp_dirs.append(tmp_dir)
+            dataset_path = tmp_dir.name
+            dataset.save_to_disk(dataset_path)
+        else:
+            dataset_path = str(filename.absolute())
+
+        # Make sure that we can load the dataset successfully
+        try:
+            Dataset.load_from_disk(dataset_path)
+        except Exception as exception:
+            raise ValidationError(
+                f"Could not load dataset saved in '{dataset_path}'"
+            ) from exception
+
+        return dataset_path
+
+    def _save_vocab_to_disk(self, vocab: Vocabulary) -> str:
+        """Saves the vocab to disk to reuse it between the trials
+
+        Parameters
+        ----------
+        vocab
+            Vocabulary to be saved to disk
+
+        Returns
+        -------
+        vocab_path
+            Path to the vocabulary, that is a directory
+        """
+        tmp_dir = tempfile.TemporaryDirectory()
+        self._created_tmp_dirs.append(tmp_dir)
+        vocab_path = tmp_dir.name
+        vocab.save_to_files(vocab_path)
+
+        # Make sure that we can load the vocab successfully
+        try:
+            Vocabulary.from_files(vocab_path)
+        except Exception as exception:
+            raise ValidationError(
+                f"Could not load vocab saved in '{vocab_path}'"
+            ) from exception
+
+        return vocab_path
+
+    @property
+    def config(self) -> dict:
+        """The config dictionary used by the `RayTuneTrainable.func` function"""
+        return {
+            "pipeline_config": self._pipeline_config,
+            "trainer_config": self._trainer_config,
+            "train_dataset_path": self._train_dataset_path,
+            "valid_dataset_path": self._valid_dataset_path,
+            "mlflow_tracking_uri": mlflow.get_tracking_uri(),
+            "vocab_path": self._vocab_path,
+            "name": self._name,
+        }
+
+    @staticmethod
+    def func(config, reporter):
+        """The trainable function passed on to `ray.tune.run`
+
+        It performs the most straight forward training loop with the provided `config`:
+        - Create the pipeline (optionally with a provided vocab)
+        - Set up a MLFlow and WandB logger
+        - Set up a TuneMetrics logger that reports all metrics back to ray tune after each epoch
+        - Create the vocab if necessary
+        - Execute the training
+        """
+        pipeline = Pipeline.from_config(
+            config["pipeline_config"], vocab_path=config["vocab_path"]
+        )
+
+        trainer_config = TrainerConfiguration(
+            **helpers.sanitize_for_params(config["trainer_config"])
+        )
+
+        mlflow_tracking_uri = config["mlflow_tracking_uri"]
+        mlflow.set_tracking_uri(mlflow_tracking_uri)
+
+        train_ds = Dataset.load_from_disk(config["train_dataset_path"])
+        valid_ds = Dataset.load_from_disk(config["valid_dataset_path"])
+
+        train_loggers = [
+            MlflowLogger(
+                experiment_name=config["name"],
+                run_name=reporter.trial_name,
+                ray_trial_id=reporter.trial_id,
+                ray_logdir=reporter.logdir,
+            ),
+            TuneMetricsLogger(),
+        ]
+        if is_wandb_installed_and_logged_in():
+            train_loggers = [WandBLogger(project_name=config["name"])] + train_loggers
+
+        if pipeline.has_empty_vocab():
+            vocab_config = VocabularyConfiguration(sources=[train_ds, valid_ds])
+            pipeline.create_vocabulary(vocab_config)
+
+        pipeline.train(
+            output="training",
+            training=train_ds,
+            validation=valid_ds,
+            trainer=trainer_config,
+            loggers=train_loggers,
+        )
+
+    def __del__(self):
+        """Cleans up the created tmp dirs with the datasets"""
+        for tmp_dir in self._created_tmp_dirs:
+            tmp_dir.cleanup()

--- a/tests/text/test_hpo.py
+++ b/tests/text/test_hpo.py
@@ -100,7 +100,7 @@ def pipeline_config():
 
 
 @pytest.fixture
-def trainer_config():
+def trainer_config() -> dict:
     return {
         "optimizer": {"type": "adam", "lr": 0.01},
         "num_epochs": 1,
@@ -124,13 +124,16 @@ def test_ray_tune_trainable(dataset, pipeline_config, trainer_config, monkeypatc
         train_dataset=dataset,
         valid_dataset=dataset,
         vocab=pl.backbone.vocab,
+        num_samples=1,
     )
 
     assert trainable._name.startswith("HPO on")
     assert trainable._vocab_path is not None
 
-    analysis = tune.run(trainable.func, config=trainable.config, num_samples=1)
-    assert len(analysis.trials) == 1
+    # analysis = tune.run(trainable.func, config=trainable.config, num_samples=1)
+    analysis = tune.run_experiments(trainable)
+    print(analysis[0])
+    assert len(analysis[0].trials) == 1
 
     mlflow.set_tracking_uri(mlflow.get_tracking_uri())
     assert mlflow.get_experiment_by_name(trainable._name)


### PR DESCRIPTION
This PR introduces a new HPO class (`RayTuneTrainable`) that is compatible with Datasets and is intended to replace the `HpoParams` and `HpoExperiment` classes.

Personally i find it confusing that you can define the same parameters in the `tune.Experiment` and in `tune.run`, but the latter will be ignored if they were specified in the former. So the new implementation does not make use of the `tune.Experiment` and relies more on the parameters provided directly to `tune.run`. Also working with @ignacioct we noticed that it is more intuitive and faster to just copy the configs of your pipeline or trainer, and replace the parameters with the search spaces, than to write a new dict with only the search spaces. So the merging capabilities of the `HpoParams` are not really needed.

A minimal usage example of the new class would be:
```python
my_trainable = RayTuneTrainable(pipeline_config, trainer_config, train_dataset, valid_dataset)
tune.run(my_trainable.func, config=my_trainable.config)
```
For a more detailed usage you can have a look at the updated tutorial.
I think it's a bit more elegant than the three step flow we have right now:
```
HpoParams -> HpoExperiment -> ray.tune(HpoExperiment.as_tune_experiment())
```

@frascuchon If you are OK with this proposal i would go ahead and remove the old HPO components in a follow-up PR.