### PR TITLE
Only return an Instance if the head did succeed in creating an Instance

### DIFF
--- a/src/biome/text/explore.py
+++ b/src/biome/text/explore.py
@@ -416,16 +416,15 @@ def _explore_a_dataset(
         col_name for col_name in dataset.column_names if col_name not in input_columns
     ]
 
-    dataset = (dataset
-        .map(
-            lambda x: {"metadata": {col_name: x[col_name] for col_name in meta_columns}},
-            remove_columns=meta_columns)
-        .map(add_predictions,
-            fn_kwargs={"columns": input_columns},
-            batched=True,
-            batch_size=options.batch_size,
-            num_proc=options.num_proc,
-        )
+    dataset = dataset.map(
+        lambda x: {"metadata": {col_name: x[col_name] for col_name in meta_columns}},
+        remove_columns=meta_columns,
+    ).map(
+        add_predictions,
+        fn_kwargs={"columns": input_columns},
+        batched=True,
+        batch_size=options.batch_size,
+        num_proc=options.num_proc,
     )
 
     data_exploration = DataExploration(

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -1,14 +1,12 @@
 from typing import Dict
 
 import pytest
-from biome.text import Pipeline, VocabularyConfiguration, TrainerConfiguration
-from biome.text.data import DataSource
+from biome.text import Pipeline, VocabularyConfiguration, TrainerConfiguration, Dataset
 import pandas as pd
 
 
 @pytest.fixture
-def training_data_source(tmp_path) -> DataSource:
-    data_file = tmp_path / "train.json"
+def training_dataset() -> Dataset:
     df = pd.DataFrame(
         {
             "text": [
@@ -23,11 +21,8 @@ def training_data_source(tmp_path) -> DataSource:
             ],
         }
     )
-    df.to_json(data_file, lines=True, orient="records")
 
-    return DataSource(
-        source=str(data_file), flatten=False, lines=True, orient="records"
-    )
+    return Dataset.from_pandas(df)
 
 
 @pytest.fixture
@@ -72,7 +67,7 @@ def test_default_explain(pipeline_dict):
         assert "token" in label
 
 
-def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
+def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
     pipeline = Pipeline.from_config(pipeline_dict)
 
     assert pipeline.head.span_labels == ["NER"]
@@ -88,11 +83,10 @@ def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
     assert "entities" in predictions[0]
     assert "tags" in predictions[0]
 
-    pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_data_source]))
+    pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_dataset]))
 
     pipeline.train(
         output=str(tmp_path / "ner_experiment"),
         trainer=TrainerConfiguration(**trainer_dict),
-        training=training_data_source,
-        validation=training_data_source,
+        training=training_dataset,
     )


### PR DESCRIPTION
This PR closes #415 

The `TokenClassification.featurize` will return None as instance if the spans cannot be aligned with the tokens. This lead to issues when these "instances" were passed on to the building of the vocab of the training.

We now skip those examples in `Dataset.to_instances` via the instance generator. We leave it to the head to make a meaningful logging of these examples. Maybe we could do the same for empty Instances, that is the head is responsible for checking that the instances that it returns make sense, otherwise it returns `None`. 