### PR TITLE
refactor: using exclusive or outputs features for Token classifier

### DIFF
--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -74,7 +74,7 @@ class PipelineModel(allennlp.models.Model):
         self._inputs = self._head.inputs() or [p.name for p in required]
         self._output = (
             [p.name for p in optional if p.name not in self._inputs] or [None]
-        )[0]
+        )
 
     @classmethod
     def from_params(
@@ -176,8 +176,8 @@ class PipelineModel(allennlp.models.Model):
         return self._inputs
 
     @property
-    def output(self) -> Optional[str]:
-        """The model output (not prediction): Corresponding to head.featurize optional argument names. Should be one"""
+    def output(self) -> List[str]:
+        """The model outputs (not prediction): Corresponding to head.featurize optional argument names."""
         return self._output
 
     def init_prediction_logger(

--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -276,7 +276,7 @@ class Dataset:
         """
         self._LOGGER.info("Creating instances ...")
 
-        input_columns = [col for col in pipeline.inputs + [pipeline.output] if col]
+        input_columns = [col for col in pipeline.inputs + pipeline.output if col]
         dataset_with_pickled_instances = self.dataset.map(
             self._create_and_pickle_instances,
             fn_kwargs={
@@ -312,7 +312,7 @@ class Dataset:
     @staticmethod
     def _create_and_pickle_instances(row, input_columns, featurize, instances_col_name):
         """Helper function to be used together with the `datasets.Dataset.map` method"""
-        instance = featurize(**{key: row[key] for key in input_columns})
+        instance = featurize(**{key: row.get(key) for key in input_columns})
 
         return {instances_col_name: pickle.dumps(instance)}
 

--- a/src/biome/text/explore.py
+++ b/src/biome/text/explore.py
@@ -363,7 +363,7 @@ def _explore(
         pipeline_name=pipeline.name,
         pipeline_type=pipeline.type_name,
         pipeline_inputs=pipeline.inputs,
-        pipeline_outputs=[pipeline.output],
+        pipeline_outputs=pipeline.output,
         pipeline_labels=pipeline.head.labels,  # TODO(dvilasuero,dcfidalgo): Only for text classification ??????
         task_name=pipeline.head.task_name().as_string(),
         use_prediction=True,
@@ -411,7 +411,7 @@ def _explore_a_dataset(
         return {"prediction": sanitize(predictions)}
 
     # Here we include the pipeline.output so we do not use it for the metadata later on, see metadata below
-    input_columns = [col for col in pipeline.inputs + [pipeline.output] if col]
+    input_columns = [col for col in pipeline.inputs + pipeline.output if col]
     meta_columns = [
         col_name for col_name in dataset.column_names if col_name not in input_columns
     ]
@@ -437,7 +437,7 @@ def _explore_a_dataset(
         pipeline_name=pipeline.name,
         pipeline_type=pipeline.type_name,
         pipeline_inputs=pipeline.inputs,
-        pipeline_outputs=[pipeline.output],
+        pipeline_outputs=pipeline.output,
         pipeline_labels=pipeline.head.labels,  # TODO(dvilasuero,dcfidalgo): Only for text classification ??????
         task_name=pipeline.head.task_name().as_string(),
         use_prediction=True,

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -146,13 +146,14 @@ class TokenClassification(TaskHead):
         if isinstance(text, str):
             doc = self.backbone.tokenizer.nlp(text)
             tokens = [token.text for token in doc]
-            tags = tags_from_offsets(doc, labels, self._label_encoding) if labels is not None else []
+            entitiy_tags = tags_from_offsets(doc, entities, self._label_encoding) if entities is not None else []
             # discard misaligned examples for now
-            if "-" in tags:
+            if "-" in entitiy_tags:
                 self.__LOGGER.warning(
-                    f"Could not align spans with tokens for following example: '{text}' {labels}"
+                    f"Could not align spans with tokens for following example: '{text}' {entities}"
                 )
                 return None
+            tags = entitiy_tags
         else:
             tokens = text
             tags = labels
@@ -163,7 +164,7 @@ class TokenClassification(TaskHead):
         instance.add_field(field_name="raw_text", field=MetadataField(text))
 
         if self.training:
-            assert tags, f"No tags found when training. Data {text, labels}"
+            assert tags, f"No tags found when training. Data {text, tags, entities}"
             instance.add_field(
                 "labels",
                 SequenceLabelField(

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -124,7 +124,7 @@ class TokenClassification(TaskHead):
         self,
         text: Union[str, List[str]],
         entities: Optional[List[dict]] = None,
-        labels: Optional[Union[List[str], List[int]]] = None,
+        tags: Optional[Union[List[str], List[int]]] = None,
     ) -> Optional[Instance]:
         """
         Parameters
@@ -142,8 +142,8 @@ class TokenClassification(TaskHead):
             'label': str, label of the span
 
             They are used with the `spacy.gold.biluo_tags_from_offsets` method.
-        labels
-            A list of tag labels in the BIOUL or BIO format.
+        tags
+            A list of tags in the BIOUL or BIO format.
         """
         instance = self.backbone.featurizer(
             text, to_field="text", tokenize=isinstance(text, str), aggregate=True
@@ -162,16 +162,15 @@ class TokenClassification(TaskHead):
             # discard misaligned examples for now
             if "-" in tags:
                 self.__LOGGER.warning(
-                    f"Could not align spans with tokens for following example: '{text}' {labels}"
+                    f"Could not align spans with tokens for following example: '{text}' {tags}"
                 )
                 return None
-            labels = tags
 
-        if labels is not None:
+        if tags is not None:
             instance.add_field(
                 "labels",
                 SequenceLabelField(
-                    labels,
+                    tags,
                     sequence_field=cast(TextField, instance["text"]),
                     label_namespace=vocabulary.LABELS_NAMESPACE,
                 ),

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -12,12 +12,7 @@ import numpy
 import torch
 from allennlp.commands.find_learning_rate import search_learning_rate
 from allennlp.common import Params
-from allennlp.data import (
-    AllennlpDataset,
-    AllennlpLazyDataset,
-    Instance,
-    Vocabulary,
-)
+from allennlp.data import AllennlpDataset, AllennlpLazyDataset, Instance, Vocabulary
 from allennlp.models import load_archive
 from allennlp.models.archival import Archive
 from dask.dataframe import DataFrame
@@ -469,7 +464,12 @@ class Pipeline:
     def _update_ds_mapping_with_pipeline_input_output(
         self, datasource: DataSource
     ) -> Dict:
-        mapping = {k: k for k in self.inputs + [self.output] if k}
+        output_keys = [
+            output_key
+            for output_key in self._model.output
+            if output_key in datasource.to_dataframe().columns
+        ]
+        mapping = {k: k for k in self.inputs + output_keys if k}
         mapping.update(datasource.mapping)
 
         return mapping
@@ -600,7 +600,7 @@ class Pipeline:
         return self._model.inputs
 
     @property
-    def output(self) -> str:
+    def output(self) -> List[str]:
         """Gets the pipeline output field names"""
         return self._model.output
 

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -16,7 +16,7 @@ def training_data_source(tmp_path) -> DataSource:
                 "This is a simple NER test with misaligned spans",
                 "No NER here",
             ],
-            "labels": [
+            "entities": [
                 [{"start": 17, "end": 20, "label": "NER"}],
                 [{"start": 17, "end": 22, "label": "NER"}],
                 [],
@@ -59,6 +59,8 @@ def trainer_dict() -> Dict:
 
 def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
     pipeline = Pipeline.from_config(pipeline_dict)
+
+    assert pipeline.output == ["entities", "labels"]
 
     assert pipeline.head.span_labels == ["NER"]
     assert pipeline.head.labels == ["B-NER", "I-NER", "U-NER", "L-NER", "O"]

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -60,7 +60,7 @@ def trainer_dict() -> Dict:
 def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
     pipeline = Pipeline.from_config(pipeline_dict)
 
-    assert pipeline.output == ["entities", "labels"]
+    assert pipeline.output == ["entities", "tags"]
 
     assert pipeline.head.span_labels == ["NER"]
     assert pipeline.head.labels == ["B-NER", "I-NER", "U-NER", "L-NER", "O"]

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -57,25 +57,25 @@ def trainer_dict() -> Dict:
     return trainer_dict
 
 
-
 def test_tokenization_with_blank_tokens(pipeline_dict):
     pipeline = Pipeline.from_config(pipeline_dict)
-    predictions = pipeline.predict(text="Test this text \n \n", labels=[])
+    predictions = pipeline.predict(text="Test this text \n \n", entities=[])
     assert len(predictions["tags"][0]) == 4
 
-    
-    
+
 def test_default_explain(pipeline_dict):
     pipeline = Pipeline.from_config(pipeline_dict)
 
     prediction = pipeline.explain("This is a simple text")
     assert prediction["explain"]
     assert len(prediction["explain"]["text"]) == len(prediction["tags"][0])
+    # enable training mode for generate instances with tags
+    pipeline.head.train()
 
-    prediction = pipeline.explain(text="This is a simple text", labels=[])
-    assert len(prediction["explain"]["labels"]) == len(prediction["explain"]["text"])
+    prediction = pipeline.explain(text="This is a simple text", entities=[])
+    assert len(prediction["explain"]["tags"]) == len(prediction["explain"]["text"])
 
-    for label in prediction["explain"]["labels"]:
+    for label in prediction["explain"]["tags"]:
         assert "label" in label
         assert "token" in label
 

--- a/tests/text/test_dataset.py
+++ b/tests/text/test_dataset.py
@@ -64,9 +64,6 @@ def test_training_with_dataset():
     ds = Dataset.from_json(
         paths=os.path.join(RESOURCES_PATH, "data", "dataset_sequence.jsonl")
     )
-    ds.dataset.rename_column_("hypothesis", "text")
-    # or to keep the 'hypothesis' column and add the new 'text' column:
-    # ds.dataset = ds.dataset.map(lambda x: {"text": x["hypothesis"]})
 
     labels = list(set(ds["label"]))
 
@@ -74,9 +71,18 @@ def test_training_with_dataset():
         {
             "name": "datasets_test",
             "features": {"word": {"embedding_dim": 2},},
-            "head": {"type": "TextClassification", "labels": labels,},
+            "head": {"type": "TextClassification", "labels": labels},
         }
     )
+
+    with pytest.raises(Exception):
+        ds.to_instances(pl)
+
+    ds.dataset.rename_column_("hypothesis", "text")
+    # or to keep the 'hypothesis' column and add the new 'text' column:
+    # ds.dataset = ds.dataset.map(lambda x: {"text": x["hypothesis"]})
+    instances = ds.to_instances(pl, lazy=False)
+    assert len(instances) == 4
 
     vocab_config = VocabularyConfiguration(sources=[ds])
     pl.create_vocabulary(vocab_config)

--- a/tests/text/test_pipeline_with_optional_inputs.py
+++ b/tests/text/test_pipeline_with_optional_inputs.py
@@ -48,4 +48,4 @@ def test_check_pipeline_inputs_and_output():
     pipeline = Pipeline.from_config(config)
 
     assert pipeline.inputs == ["text", "second_text"]
-    assert pipeline.output == "label"
+    assert pipeline.output == ["label"]


### PR DESCRIPTION
This PR splits  `labels` field in `TokenClassification` head in `labels` (tag labels)  and `entities` (span labels). Consequently, multiple output can be defined in pipelines, returning a list of names, instead of a single string.

