### PR TITLE
fix(token-class): aligns raw text and tags tokenization

### DIFF
--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -313,9 +313,6 @@ def tags_from_offsets(
     -------
     tags (BIOUL or BIO)
     """
-    if offsets is None:
-        return []
-
     tags = spacy.gold.biluo_tags_from_offsets(
         doc, [(offset["start"], offset["end"], offset["label"]) for offset in offsets]
     )

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -7,6 +7,7 @@ from inspect import Parameter
 from typing import Any, Callable, Dict, Iterable, List, Tuple, Type, Optional
 
 import spacy
+import spacy.gold
 import yaml
 from allennlp.common import util
 from elasticsearch import Elasticsearch
@@ -312,6 +313,9 @@ def tags_from_offsets(
     -------
     tags (BIOUL or BIO)
     """
+    if offsets is None:
+        return []
+
     tags = spacy.gold.biluo_tags_from_offsets(
         doc, [(offset["start"], offset["end"], offset["label"]) for offset in offsets]
     )

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -143,7 +143,7 @@ class TokenClassification(TaskHead):
         if isinstance(text, str):
             doc = self.backbone.tokenizer.nlp(text)
             tokens = [token.text for token in doc]
-            tags = tags_from_offsets(doc, labels, self._label_encoding)
+            tags = tags_from_offsets(doc, labels, self._label_encoding) if labels is not None else []
             # discard misaligned examples for now
             if "-" in tags:
                 self.__LOGGER.warning(

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -57,6 +57,12 @@ def trainer_dict() -> Dict:
     return trainer_dict
 
 
+def test_tokenization_with_blank_tokens(pipeline_dict):
+    pipeline = Pipeline.from_config(pipeline_dict)
+    predictions = pipeline.predict(text="Test this text \n \n", labels=[])
+    assert len(predictions["tags"][0]) == 4
+
+
 def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
     pipeline = Pipeline.from_config(pipeline_dict)
 


### PR DESCRIPTION
This PR fixes misaligned tokenization for `TokenClassifier` between `raw_text` and `tags`, when original text contains spaces symbols like `\n`.