### PR TITLE
fix: default explain not working for token classification

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,5 +19,8 @@ prune docs/node_modules
 prune docs/api
 prune dist
 prune tests/**/htmlcov
+prune tests/mlruns
+prune tests/runs
+prune tests/output
 
 global-exclude *.pyc *.o

--- a/src/biome/text/modules/heads/task_head.py
+++ b/src/biome/text/modules/heads/task_head.py
@@ -141,7 +141,7 @@ class TaskHead(torch.nn.Module, Registrable):
         -------
             Prediction with explanation
         """
-        raise {**prediction, "explain": {}}
+        return {**prediction, "explain": {}}
 
 
 class TaskHeadConfiguration(ComponentConfiguration[TaskHead]):

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -57,6 +57,21 @@ def trainer_dict() -> Dict:
     return trainer_dict
 
 
+def test_default_explain(pipeline_dict):
+    pipeline = Pipeline.from_config(pipeline_dict)
+
+    prediction = pipeline.explain("This is a simple text")
+    assert prediction["explain"]
+    assert len(prediction["explain"]["text"]) == len(prediction["tags"][0])
+
+    prediction = pipeline.explain(text="This is a simple text", labels=[])
+    assert len(prediction["explain"]["labels"]) == len(prediction["explain"]["text"])
+
+    for label in prediction["explain"]["labels"]:
+        assert "label" in label
+        assert "token" in label
+
+
 def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
     pipeline = Pipeline.from_config(pipeline_dict)
 


### PR DESCRIPTION
This PR allow execute pipeline explain for token classification, processing `SequenceLabelField` and `MetadataField` fields types