### PR TITLE
refactor:token classification prediction revision

### DIFF
--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -346,6 +346,11 @@ def offsets_from_tags(
         A list of dicts with start and end character/token index with respect to the doc and the span label:
         `{"start": int, "end": int, "start_token": int, "end_token", "label": str}`
     """
+    # spacy.gold.offsets_from_biluo_tags surprisingly does not check this ...
+    if len(doc) != len(tags):
+        raise ValueError(f"Number of tokens and tags must be the same, "
+                         f"but 'len({list(doc)}) != len({tags})")
+
     if label_encoding == "BIO":
         tags = bioul_tags_to_bio_tags(tags)
 

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -359,7 +359,7 @@ def offsets_from_tags(
         span = doc.char_span(start, end)
         data = {
             "start_token": span.start,
-            "end_token": span.end - 1 if span.end < len(doc) else span.end,
+            "end_token": span.end,
             "label": label,
         }
         if not only_token_spans:

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -322,7 +322,10 @@ def tags_from_offsets(
 
 
 def offsets_from_tags(
-    doc: Doc, tags: List[str], label_encoding: Optional[str] = "BIOUL"
+    doc: Doc,
+    tags: List[str],
+    label_encoding: Optional[str] = "BIOUL",
+    only_token_spans: bool = False,
 ) -> List[Dict]:
     """Converts BIOUL or BIO tags to offsets
 
@@ -334,20 +337,29 @@ def offsets_from_tags(
         A list of BIOUL or BIO tags
     label_encoding
         The label encoding to be used: BIOUL or BIO
+    only_token_spans
+        If True, offsets contains only token index references. Default is False
 
     Returns
     -------
     offsets
-        A list of dicts with start and end character index with respect to the doc and the span label:
-        `{"start": int, "end": int, "label": str}`
+        A list of dicts with start and end character/token index with respect to the doc and the span label:
+        `{"start": int, "end": int, "start_token": int, "end_token", "label": str}`
     """
     if label_encoding == "BIO":
         tags = bioul_tags_to_bio_tags(tags)
-    offsets = [
-        {"start": offset[0], "end": offset[1], "label": offset[2]}
-        for offset in spacy.gold.offsets_from_biluo_tags(doc, tags)
-    ]
 
+    offsets = []
+    for start, end, label in spacy.gold.offsets_from_biluo_tags(doc, tags):
+        span = doc.char_span(start, end)
+        data = {
+            "start_token": span.start,
+            "end_token": span.end - 1 if span.end < len(doc) else span.end,
+            "label": label,
+        }
+        if not only_token_spans:
+            data.update({"start": start, "end": end})
+        offsets.append(data)
     return offsets
 
 

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -240,7 +240,8 @@ class TokenClassification(TaskHead):
         tokens: List[List[str]] = []
         # See self.featurize for tokenization structure
         for (doc, pre_tokenized), k_tags in zip(output.tokenization, output.tags):
-            tokens.append([token.text for token in doc])
+            if not pre_tokenized:
+                tokens.append([token.text for token in doc])
             entities.append(
                 [
                     offsets_from_tags(
@@ -249,8 +250,8 @@ class TokenClassification(TaskHead):
                     for tags in k_tags
                 ]
             )
-
-        output.tokens = tokens
+        if tokens:
+            output.tokens = tokens
         output.entities = entities
 
         del output.logits

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -262,15 +262,10 @@ class TokenClassification(TaskHead):
             self._decode_tags(k_tags) for k_tags in output.viterbi_paths
         ]
 
-        # fmt: off
-        output.entities, output.tokens = zip(*[
-            (
-                [self._decode_entities(doc, tags, pre_tokenized) for tags in k_tags],
-                self._decode_tokens(doc) if not pre_tokenized else None
-            )
-            for doc, pre_tokenized, k_tags in zip(*output.tokenization, output.tags)
-        ])
-        # fmt: on
+        output.entities, output.tokens = [], []
+        for doc, pre_tokenized, k_tags in zip(*output.tokenization, output.tags):
+            output.entities.append([self._decode_entities(doc, tags, pre_tokenized) for tags in k_tags])
+            output.tokens.append(self._decode_tokens(doc) if not pre_tokenized else None)
 
         output.tokens = [tokens for tokens in output.tokens if tokens]
         if len(output.tokens) < 1:  # drop tokens field if no data

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -86,6 +86,8 @@ def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
     predictions = pipeline.predict(["test", "this", "pretokenized", "text"])
     assert "entities" in predictions
     assert "tags" in predictions
+    assert "tokens" not in predictions
+
     for entity in predictions["entities"][0]:
         assert "start_token" in entity
         assert "end_token" in entity
@@ -98,13 +100,13 @@ def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
     )
     assert "entities" in predictions[0]
     assert "tags" in predictions[0]
+    assert "tokens" in predictions[0]
 
     for entity in predictions[0]["entities"][0]:
         assert "start" in entity
         assert "end" in entity
 
     pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_dataset]))
-
 
     pipeline.train(
         output=str(tmp_path / "ner_experiment"),
@@ -113,7 +115,10 @@ def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
     )
 
 
-def test_that_fails(pipeline_dict, training_dataset, trainer_dict, tmp_path):
+def test_preserve_pretokenization(
+    pipeline_dict, training_dataset, trainer_dict, tmp_path
+):
     pipeline = Pipeline.from_config(pipeline_dict)
-    predictions = pipeline.predict(["test", "this", "pre-tokenized", "text"])
-    print(predictions)
+    tokens = ["test", "this", "pre tokenized", "text"]
+    prediction = pipeline.predict(tokens)
+    assert len(prediction["tags"][0]) == len(tokens)

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -111,3 +111,9 @@ def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
         trainer=TrainerConfiguration(**trainer_dict),
         training=training_dataset,
     )
+
+
+def test_that_fails(pipeline_dict, training_dataset, trainer_dict, tmp_path):
+    pipeline = Pipeline.from_config(pipeline_dict)
+    predictions = pipeline.predict(["test", "this", "pre-tokenized", "text"])
+    print(predictions)

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -89,14 +89,24 @@ def test_train(pipeline_dict, training_data_source, trainer_dict, tmp_path):
     assert pipeline.head.labels == ["B-NER", "I-NER", "U-NER", "L-NER", "O"]
 
     predictions = pipeline.predict(["test", "this", "pretokenized", "text"])
-    assert "entities" not in predictions
+    assert "entities" in predictions
     assert "tags" in predictions
+    for entity in predictions["entities"][0]:
+        assert "start_token" in entity
+        assert "end_token" in entity
+        assert "label" in entity
+        assert "start" not in entity
+        assert "end" not in entity
 
     predictions = pipeline.predict_batch(
         [{"text": "Test this NER system"}, {"text": "and this"}]
     )
     assert "entities" in predictions[0]
     assert "tags" in predictions[0]
+
+    for entity in predictions[0]["entities"][0]:
+        assert "start" in entity
+        assert "end" in entity
 
     pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_data_source]))
 


### PR DESCRIPTION
This PR normalizes prediction data for token classification.

* All predictions contains `entities` and `tags` keys
* Non pre-tokenized predictions contains also `tokens` info
* `start` and `end` fields are dropped for pretokenized predictions

Also make `explore` works with multi-output heads