### PR TITLE
No objects in instance meta

### DIFF
--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -269,7 +269,7 @@ class Dataset:
         return self.dataset.num_rows
 
     def to_instances(
-        self, pipeline: "Pipeline", lazy=True, num_proc: Optional[int] = None
+        self, pipeline: "Pipeline", lazy=True, num_proc: int = 1
     ) -> InstancesDataset:
         """Convert input to instances for the pipeline
 
@@ -280,7 +280,7 @@ class Dataset:
         lazy
             If true, instances are lazily read from disk, otherwise they are kept in memory.
         num_proc
-            Number of processes to be spawn. If None, we try to figure out a decent default.
+            Number of processes to be spawn.
         """
         self._LOGGER.info("Creating instances ...")
 
@@ -294,14 +294,7 @@ class Dataset:
                 "featurize": pipeline.head.featurize,
                 "instances_col_name": self._PICKLED_INSTANCES_COL_NAME,
             },
-            # trying to be smart about multiprocessing,
-            # at least 1000 examples per process to avoid overhead,
-            # but 1000 is a pretty random number, can surely be optimized
-            num_proc=num_proc
-            or min(
-                max(1, int(len(self.dataset) / 1000)),
-                int(multiprocessing.cpu_count() / 2),
-            ),
+            num_proc=num_proc,
             new_fingerprint=self._create_fingerprint_for_instance_dataset(pipeline),
         )
 

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -344,7 +344,7 @@ def offsets_from_tags(
     -------
     offsets
         A list of dicts with start and end character/token index with respect to the doc and the span label:
-        `{"start": int, "end": int, "start_token": int, "end_token", "label": str}`
+        `{"start": int, "end": int, "start_token": int, "end_token": int, "label": str}`
     """
     # spacy.gold.offsets_from_biluo_tags surprisingly does not check this ...
     if len(doc) != len(tags):


### PR DESCRIPTION
This PR resolves a bug encountered by Dani and reported on slack (see https://colab.research.google.com/drive/1GHvOdjC4cesmWuZJgU3b_lGlOsT5m14Z?usp=sharing)

With the new `Dataset` class we serialize the instances via pickle in order to cache them **and** to allow for lazy loading. In the `TokenClassification` head we were putting `MetadataField`s with spacy `Doc` objects into the instances, and pickling/unpickling those instances took quite some time plus the cached instancese were >15GB big coming from a training set of ~1MB ... 

I refactored a bit the `TokenClassification` to avoid passing on a spacy Doc via the `Instance` itself.
The down side of the approach presented here is that for predictions of untokenized text, we create two times the same spacy Doc object:
- 1. For tokenizing the input text when creating the instance
- 2. For obtaining the offsets when decoding the model output
Not sure if this can be avoided.

I also removed the automatic computation of a default value for the `num_proc` argument in `Dataset.to_instances()`, it was too sketchy ... i could expose it in the `Pipeline.train()` method, but at the moment you can already use it like this for example:
```python
pipeline.train(training=train_ds.to_instances(pipeline, num_proc=8))
```