### PR TITLE
Improve instance creation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,8 @@ if __name__ == "__main__":
             "mlflow~=1.9.0",
             "elasticsearch>=6.8.0,<7.5.0",
             "ray[tune]~=1.0.0",
-            "datasets~=1.1.2"
+            "datasets~=1.1.2",
+            "tqdm>=4.49.0"
         ],
         extras_require={
             "testing": [

--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -465,8 +465,8 @@ class Dataset:
                 / f"{fingerprint}.{self._CACHED_INSTANCE_LIST_EXTENSION}"
             )
             with cache_path.open("wb") as file:
+                self._LOGGER.info(f"Caching instances to {cache_path})")
                 pickle.dump(instance_list, file)
-            self._LOGGER.info(f"Cached instances to {cache_path})")
         except (IndexError, KeyError, FileNotFoundError):
             pass
 

--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -435,7 +435,6 @@ class Dataset:
         instance_list
             Returns None, if no cached instances are found
         """
-        self._LOGGER.info("Looking for cached instances")
         try:
             cache_path = (
                 Path(self.dataset.cache_files[0]["filename"]).parent

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -234,7 +234,7 @@ class Pipeline:
         test: Optional[Union[Dataset, InstancesDataset]] = None,
         extend_vocab: Optional[VocabularyConfiguration] = None,
         loggers: List[BaseTrainLogger] = None,
-        lazy: bool = True,
+        lazy: bool = False,
         restore: bool = False,
         quiet: bool = False,
     ) -> TrainingResults:
@@ -258,7 +258,7 @@ class Pipeline:
             A list of loggers that execute a callback before the training, after each epoch,
             and at the end of the training (see `biome.text.logger.MlflowLogger`, for example)
         lazy
-            If true, load the data lazily from disk, otherwise load them in memory.
+            If true, dataset instances are lazily loaded from disk, otherwise they are loaded and kept in memory.
         restore
             If enabled, tries to read previous training status from the `output` folder and
             continues the training process


### PR DESCRIPTION
This PR is a follow-up PR of #442 

I found an intermediate solution for caching the instances. Instead of caching each Instance by itself, we can pickle the whole list of instances. Pickle is smart enough to deal with references to class instances, so the indexers are not a problem anymore.

The default behavior of `Dataset.to_instances` is now:
- Create and keep instances in memory + cache the whole list of instances on disk.
- Subsequent calls to `Dataset.to_instance` will reuse those cached instances and load them into memory. You can turn off this behavior by specifying `use_cache=False`.
- If `lazy=True`, lazily load data from disk and create instances on-the-fly

For now we loose the ability to multiprocess the instance creation (since we do not use the `Dataset.map` method anymore), i will try to implement it again using directly the `multiprocessing` library, let's see if i manage.