### PR TITLE
Remove DataSource from explore

### DIFF
--- a/tests/text/test_dataset.py
+++ b/tests/text/test_dataset.py
@@ -161,7 +161,7 @@ def test_explore():
         }
     )
 
-    explore.create(pipeline=pl, data_source=ds, batch_size=1, show_explore=False)
+    explore.create(pipeline=pl, dataset=ds, batch_size=1, show_explore=False)
 
 
 @pytest.mark.usefixtures("dataset")


### PR DESCRIPTION
This is the first in a series of PRs completely remove the `DataSource` class in our library (#404).

@ignacioct and I will take care of this providing alternately small PRs (changing at most 1 file) to make the review process easier and faster.