### PR TITLE
Expose 'num_serialized_models_to_keep' argument in TrainerConfiguration

### DIFF
--- a/tests/text/test_loggers.py
+++ b/tests/text/test_loggers.py
@@ -53,6 +53,7 @@ def test_mlflow_logger():
         "trainer.optimizer.type": "adam",
         "trainer.patience": "2",
         "trainer.num_epochs": "20",
+        "trainer.num_serialized_models_to_keep": "1",
         "pipeline.tokenizer.remove_space_tokens": "True",
     }
     assert expected_parmams == run.data.params


### PR DESCRIPTION
Title says it all ... setting `num_serialized_models_to_keep: 0` in the `TrainerConfiguration` helps to reduce the disk footprint during the training, most notable in HPO experiment.

I also removed the `no_grad` argument that is used nowhere at the moment, and simplified a bit the `to_allennlp_trainer` logic.