### PR TITLE
Introducing the transformers tutorial

### DIFF
--- a/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb
+++ b/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb
@@ -43,7 +43,8 @@
    "outputs": [],
    "source": [
     "!pip install -U pip\n",
-    "!pip install --use-feature=2020-resolver git+https://github.com/recognai/biome-text.git"
+    "!pip install git+https://github.com/recognai/biome-text.git\n",
+    "exit(0)  # Force restart of the runtime"
    ]
   },
   {
@@ -52,8 +53,6 @@
     "id": "NLS2EK3HCfT8"
    },
    "source": [
-    "Ignore warnings and don't forget to restart your runtime afterwards *(Runtime -> Restart runtime)* .\n",
-    "\n",
     "*If* you want to log your runs with [WandB](https://wandb.ai/home), don't forget to install its client and log in."
    ]
   },
@@ -128,7 +127,8 @@
     "from biome.text import Dataset, Pipeline\n",
     "from biome.text.configuration import VocabularyConfiguration, TrainerConfiguration\n",
     "from biome.text.hpo import TuneExperiment\n",
-    "from ray import tune"
+    "from ray import tune\n",
+    "import os"
    ]
   },
   {
@@ -380,7 +380,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "id": "26jk87DqvWxr"
    },
@@ -873,7 +873,7 @@
    },
    "outputs": [],
    "source": [
-    "analysis = tune.run(\n",
+    "analysis_frozen = tune.run(\n",
     "    tune_exp,\n",
     "    scheduler=tune.schedulers.ASHAScheduler(), \n",
     "    metric=\"validation_accuracy\",\n",
@@ -888,7 +888,11 @@
     "id": "LLrkJYC4A9Wr"
    },
    "source": [
-    "With the best configuration of our random search we should achieve an accuracy of about 0.64."
+    "The best configuration in our random search achieved an accuracy of about 0.63 with following parameters:\n",
+    "\n",
+    "- learning rate: 0.002541\n",
+    "- batch size: 16\n",
+    "- weight decay: 0.04194"
    ]
   },
   {
@@ -904,7 +908,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "id": "PvQNlVOQNu0a"
    },
@@ -929,7 +933,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "id": "_Dmk_ZwBaDRp"
    },
@@ -964,7 +968,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "id": "V47jYH9u0dBD"
    },
@@ -1002,7 +1006,7 @@
    },
    "outputs": [],
    "source": [
-    "analysis = tune.run(\n",
+    "analysis_finetuning = tune.run(\n",
     "    tune_exp,\n",
     "    scheduler=tune.schedulers.ASHAScheduler(),\n",
     "    metric=\"validation_accuracy\",\n",
@@ -1038,7 +1042,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "id": "XTjVMB4c7pgb"
    },
@@ -1094,7 +1098,63 @@
    "source": [
     "### Evaluating with a test set\n",
     "\n",
-    "TO BE DONE"
+    "Having optimized the training parameters of both models, we will now evaluate them on an independent test set.\n",
+    "\n",
+    "For the frozen-transformer configuration we can use the `analysis_frozen` object of the random search to directly access the best performing model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "best_model_path = os.path.join(analysis_frozen.get_best_logdir(), \"training\", \"model.tar.gz\")\n",
+    "\n",
+    "pl_frozen = Pipeline.from_pretrained(best_model_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With the best performing pipeline at hand we will call its evaluate method together with the test data set. By default the evaluation will be done with a batch size of 16 and on a CUDA device if one is available. You can also specify a `predictions_output_file` argument to save all the batch predictions made during evaluation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pl_frozen.evaluate(test_ds, predictions_output_file=\"predictions_from_evaluation.txt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "On the test set we achieve an accuracy of about 0.65, which is a bit better than the 0.63 on our validation set.\n",
+    "\n",
+    "Let us also quickly check the accuracy of our best fine-tuned model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pl_finetuned = Pipeline.from_pretrained(\"output/transformer_final_model/model.tar.gz\")\n",
+    "\n",
+    "pl_finetuned.evaluate(test_ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we achieve roughly the same accuracy of 0.67 as with the validation data set. So it seems both models generalized well during the random search and there is no strong bias towards the validation data set."
    ]
   },
   {
@@ -1118,27 +1178,7 @@
     "id": "0QpFfFcLQmlx"
    },
    "source": [
-    "With our best model at hand we will finally make a simple prediction. First we have to load the pipeline from our training output: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "id": "EYU8YrPQLSLV"
-   },
-   "outputs": [],
-   "source": [
-    "pl_trained = Pipeline.from_pretrained(\"output/transformer_final_model/model.tar.gz\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "B1FO8FTwq9Z3"
-   },
-   "source": [
-    "Then we can simply call the `predict` method that outputs a dictionary with a `labels` and `probabilities` key containing a list of labels and their corresponding probabilities, ordered from most to less likely."
+    "With our best model at hand we will finally make a simple prediction. We can call the `predict` method of our pipeline that outputs a dictionary with a labels and probabilities key containing a list of labels and their corresponding probabilities, ordered from most to less likely. "
    ]
   },
   {
@@ -1149,8 +1189,7 @@
    },
    "outputs": [],
    "source": [
-    "prediction_dict = pl_trained.predict(text=\"This is a title of a super intelligent Natural Language Processing system\")\n",
-    "prediction_dict"
+    "pl_finetuned.predict(text=\"This is a title of a super intelligent Natural Language Processing system\")"
    ]
   },
   {

--- a/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb
+++ b/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb
@@ -1,0 +1,1196 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "hHyH5XSkVosk"
+   },
+   "source": [
+    "# Using Transformers in biome.text\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "qgfpoXsuVoso"
+   },
+   "source": [
+    "<a target=\"_blank\" href=\"https://www.recogn.ai/biome-text/documentation/tutorials/4-Using_Transformers_in_biome_text.html\"><img class=\"icon\" src=\"https://www.recogn.ai/biome-text/assets/img/biome-isotype.svg\" width=24 /></a>\n",
+    "[View on recogn.ai](https://www.recogn.ai/biome-text/documentation/tutorials/4-Using_Transformers_in_biome_text.html)\n",
+    "    \n",
+    "<a target=\"_blank\" href=\"https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb\"><img class=\"icon\" src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" width=24 /></a>\n",
+    "[Run in Google Colab](https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb)\n",
+    "        \n",
+    "<a target=\"_blank\" href=\"https://github.com/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb\"><img class=\"icon\" src=\"https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png\" width=24 /></a>\n",
+    "[View source on GitHub](https://github.com/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ghPCC7JsCdRq"
+   },
+   "source": [
+    "When running this tutorial in Google Colab, make sure to install *biome.text* first:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "TYh_I8imVosu"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install -U pip\n",
+    "!pip install --use-feature=2020-resolver git+https://github.com/recognai/biome-text.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "NLS2EK3HCfT8"
+   },
+   "source": [
+    "Ignore warnings and don't forget to restart your runtime afterwards *(Runtime -> Restart runtime)* .\n",
+    "\n",
+    "*If* you want to log your runs with [WandB](https://wandb.ai/home), don't forget to install its client and log in."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "e2ux8k4keye_"
+   },
+   "outputs": [],
+   "source": [
+    "!pip install wandb\n",
+    "!wandb login"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "La2cKFlkBLpR"
+   },
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "In the last years we experienced a shift towards transfer learning as the standard approach to solve NLP problems. Before models were usually trained entirely from scratch, utilizing at most pretrained word embeddings. But nowadays it is very common to start with large pretrained language models as backbone of a system, and to set a task specific head on top of it. This new paradigm has made it easier to find state-of-the-art architectures for a great variety of NLP tasks.\n",
+    "\n",
+    "Almost all current language models are based on the transformer architecture. The awesome [Hugging Face Transformers](https://github.com/huggingface/transformers) library provides access to hundreds of such pretrained language models including state-of-the-art models such as infamous [BERT](https://github.com/google-research/bert), as well as community driven models often covering a specific language type or resource requirements.\n",
+    "\n",
+    "In this tutorial, we are going to classify [arXiv](https://arxiv.org/) papers into [categories](https://arxiv.org/category_taxonomy), analyzing the title of the paper and its abstract. We will use Hugging Face [distilled](https://medium.com/huggingface/distilbert-8cf3380435b5) implementation of [RoBERTa](https://ai.facebook.com/blog/roberta-an-optimized-method-for-pretraining-self-supervised-nlp-systems/) and explore ways how to easily include pretrained transformers in a *biome.text* pipeline."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "zbHC0ZczVosr"
+   },
+   "source": [
+    "### External links about transformers\n",
+    "If this is the first time you hear about \"Transformers\" not referring to giant robots, here is a small list of resources at which you might want to have a look first:\n",
+    "\n",
+    "* [Attention is all your need](https://arxiv.org/pdf/1706.03762.pdf): paper that introduced the architecture.\n",
+    "* [The Illustrated Transformer](https://jalammar.github.io/illustrated-transformer/): 20-30 minute article covering how they work.\n",
+    "* [Illustrated Guide to Transformer Neural Network: a step by step explanation](https://youtu.be/4Bdc55j80l8): 15 minute long video covering how they work.\n",
+    "* [An Introduction To Transfer Learning In NLP and HuggingFace](https://www.youtube.com/watch?v=8Hg2UtQg6G4): 1 hour talk by Thomas Wolf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "F0z7-Do9Voss"
+   },
+   "source": [
+    "### Imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8HQeEXeyVos0"
+   },
+   "source": [
+    "Let us first import all the stuff we need for this tutorial:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "id": "rj9KTpkFVos1"
+   },
+   "outputs": [],
+   "source": [
+    "from biome.text import Dataset, Pipeline\n",
+    "from biome.text.configuration import VocabularyConfiguration, TrainerConfiguration\n",
+    "from biome.text.hpo import TuneExperiment\n",
+    "from ray import tune"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LhxMQzw7Vos5"
+   },
+   "source": [
+    "## Exploring and preparing the data\n",
+    "\n",
+    "For this tutorial we are going to use the [arXiv dataset](https://www.kaggle.com/Cornell-University/arxiv) compiled by the Cornell University, which consists of metadata of scientific papers stored in [arXiv](https://arxiv.org/).\n",
+    "\n",
+    "We preprocessed the data in a separate [notebook](https://drive.google.com/file/d/1zUSz81x15RH5mL5GoN7i7xqiNGEqclU0/view?usp=sharing) producing three csv files (train, validate and test datasets) that contain the title, the abstract and the category of the corresponding paper. \n",
+    "\n",
+    "Our NLP task will be to classify the papers into the given categories based on the title and abstract. Below we download the preprocessed data and create our [Datasets](https://www.recogn.ai/biome-text/api/biome/text/dataset.html#dataset) with it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Pc9ldJ-uVos6"
+   },
+   "outputs": [],
+   "source": [
+    "# Downloading the datasets\n",
+    "!curl -O https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/transformers_arxiv-classifier/arxiv-dataset-train.json\n",
+    "!curl -O https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/transformers_arxiv-classifier/arxiv-dataset-validate.json\n",
+    "!curl -O https://biome-tutorials-data.s3-eu-west-1.amazonaws.com/transformers_arxiv-classifier/arxiv-dataset-test.json"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "C2IN6GeJ6n7Z"
+   },
+   "outputs": [],
+   "source": [
+    "# Loading from local\n",
+    "train_ds = Dataset.from_json(\"arxiv-dataset-train.json\")\n",
+    "valid_ds = Dataset.from_json(\"arxiv-dataset-validate.json\")\n",
+    "test_ds = Dataset.from_json(\"arxiv-dataset-test.json\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LdURuo_mVos-"
+   },
+   "source": [
+    "Let's have a look at the first 10 examples of the train dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "colab": {
+     "base_uri": "https://localhost:8080/",
+     "height": 363
+    },
+    "id": "ssccmk5MVos_",
+    "outputId": "2e246d26-7a81-4102-eacd-b77007d45ce5"
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>title</th>\n",
+       "      <th>categories</th>\n",
+       "      <th>abstract</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Coherent structures in the wake of a SAE squar...</td>\n",
+       "      <td>physics.flu-dyn</td>\n",
+       "      <td>The wake of a SAE squareback vehicle model i...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>On the interaction of precipitates and tensile...</td>\n",
+       "      <td>cond-mat.mtrl-sci</td>\n",
+       "      <td>Although magnesium alloys deform extensively...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>Multi-domain Spectral Collocation Method for V...</td>\n",
+       "      <td>math.NA</td>\n",
+       "      <td>Spectral and spectral element methods using ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>The min-max edge q-coloring problem</td>\n",
+       "      <td>cs.DS</td>\n",
+       "      <td>In this paper we introduce and study a new p...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>A Simple Model for a Dual Non-Abelian Monopole...</td>\n",
+       "      <td>hep-th</td>\n",
+       "      <td>We investigate the flux-tube joining two equ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>A second moment bound for critical points of p...</td>\n",
+       "      <td>math.PR</td>\n",
+       "      <td>We consider the number of critical points of...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>$\\Sigma^0$ production in proton nucleus collis...</td>\n",
+       "      <td>nucl-ex</td>\n",
+       "      <td>The production of $\\Sigma^{0}$ baryons in th...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>Zero-temperature glass transition in two dimen...</td>\n",
+       "      <td>cond-mat.stat-mech</td>\n",
+       "      <td>The nature of the glass transition is theore...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>Measurement of the $B^0_s\\to\\mu^+\\mu^-$ branch...</td>\n",
+       "      <td>hep-ex</td>\n",
+       "      <td>A search for the rare decays $B^0_s\\to\\mu^+\\...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>STAR inner tracking upgrade - A performance study</td>\n",
+       "      <td>nucl-ex</td>\n",
+       "      <td>Anisotropic flow measurements have demonstra...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                               title  ...                                           abstract\n",
+       "0  Coherent structures in the wake of a SAE squar...  ...    The wake of a SAE squareback vehicle model i...\n",
+       "1  On the interaction of precipitates and tensile...  ...    Although magnesium alloys deform extensively...\n",
+       "2  Multi-domain Spectral Collocation Method for V...  ...    Spectral and spectral element methods using ...\n",
+       "3                The min-max edge q-coloring problem  ...    In this paper we introduce and study a new p...\n",
+       "4  A Simple Model for a Dual Non-Abelian Monopole...  ...    We investigate the flux-tube joining two equ...\n",
+       "5  A second moment bound for critical points of p...  ...    We consider the number of critical points of...\n",
+       "6  $\\Sigma^0$ production in proton nucleus collis...  ...    The production of $\\Sigma^{0}$ baryons in th...\n",
+       "7  Zero-temperature glass transition in two dimen...  ...    The nature of the glass transition is theore...\n",
+       "8  Measurement of the $B^0_s\\to\\mu^+\\mu^-$ branch...  ...    A search for the rare decays $B^0_s\\to\\mu^+\\...\n",
+       "9  STAR inner tracking upgrade - A performance study  ...    Anisotropic flow measurements have demonstra...\n",
+       "\n",
+       "[10 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {
+      "tags": []
+     },
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "train_ds.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "-UlEwBj4C6Zj"
+   },
+   "source": [
+    "Our pipeline defined in the next section, or to be more precise the `TaskClassification` task [head](https://www.recogn.ai/biome-text/documentation/basics.html#head), will expect a *text* and *label* column to be present in our data.\n",
+    "Therefore, we need to map our input to these two columns:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Ew30e6IAuuZH"
+   },
+   "outputs": [],
+   "source": [
+    "# Renaming the 'categories' column into 'label'\n",
+    "train_ds.rename_column_(\"categories\", \"label\")\n",
+    "valid_ds.rename_column_(\"categories\", \"label\")\n",
+    "test_ds.rename_column_(\"categories\", \"label\")\n",
+    "\n",
+    "# Combining 'title' and 'abstract' into a 'text' column, and remove them afterwards\n",
+    "train_ds = train_ds.map(lambda x: {\"text\": x[\"title\"] + \" \" + x[\"abstract\"]}, remove_columns=[\"title\", \"abstract\"])\n",
+    "valid_ds = valid_ds.map(lambda x: {\"text\": x[\"title\"] + \" \" + x[\"abstract\"]}, remove_columns=[\"title\", \"abstract\"])\n",
+    "test_ds = test_ds.map(lambda x: {\"text\": x[\"title\"] + \" \" + x[\"abstract\"]}, remove_columns=[\"title\", \"abstract\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "G2wkHugwyXDn"
+   },
+   "source": [
+    "## Configuring and training the pipeline\n",
+    "\n",
+    "As we have seen in [previous tutorials](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html#explore-the-training-data), a *biome.text* [`Pipeline`](https://www.recogn.ai/biome-text/documentation/basics.html#pipeline) consists of tokenizing the input, extracting text features, applying a language encoding (optionally) and executing a task-specific head in the end. In *biome.text* the pre-trained transformers by Hugging Face are treated as a text feature, just like the *word* and *char* feature.\n",
+    "\n",
+    "In this section we will configure and train 3 different pipelines to showcase the usage of transformers in *biome.text*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "ETEfq79HEltM"
+   },
+   "source": [
+    "### Fine-tuning the transformer\n",
+    "\n",
+    "In our first pipeline we follow the common approach to use pretrained transformers in classification tasks. It consists of fine-tuning the transformer weights and using a special token as pooler in the end. In our configuration the former step means setting the `trainable` parameter in the *transformers* features to `True`. The downside of fine-tuning is that most of the pre-trained transformers are relatively big and require dedicated hardware to be fine-tuned. For example, in this tutorial we will use `distilroberta-base`, a [distilled version](https://github.com/huggingface/transformers/tree/master/examples/distillation) of RoBERTa with a total of ~80M parameters.\n",
+    "\n",
+    "We also need to specify the maximum number of input tokens `max_length` supported by the pretrained transformer. If you are sure that your input data does not exceed this limit, you can skip this parameter.\n",
+    "\n",
+    "With BERT like models, like RoBERTa, a special [CLS] token is added as first token to each input. It is pretrained to effectively represent the entire input and can be used as pooler in the head component. Many BERT like models pass this token through a non-linear tanh activation layer that is part of the pretraining. If you want to use these pretrained weights you have to use the `bert_pooler` together with the corresponding `pretrained_model`. We will fine-tune these weights as well (setting `require_grad` to `True`) and add a little dropout.\n",
+    "\n",
+    "::: tip Tip\n",
+    "\n",
+    "You can also use the [CLS] token directly without passing it through the non-linear layer by using the `cls_pooler`.\n",
+    "\n",
+    ":::\n",
+    "\n",
+    "The `TextClassification` head automatically applies a linear layer with an output dimension corresponding to the number of labels in the end.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "id": "26jk87DqvWxr"
+   },
+   "outputs": [],
+   "source": [
+    "pipeline_dict_finetuning = {\n",
+    "    \"name\": \"arxiv_categories_classification\",\n",
+    "    \"features\": {\n",
+    "        \"transformers\": {\n",
+    "            \"model_name\": \"distilroberta-base\",\n",
+    "            \"trainable\": True,  # freeze the weights of the transformer\n",
+    "            \"max_length\": 512,\n",
+    "        },\n",
+    "    },\n",
+    "    \"head\": {\n",
+    "        \"type\": \"TextClassification\",\n",
+    "        \"labels\": train_ds.unique(\"label\"),\n",
+    "        \"pooler\": {\n",
+    "            \"type\": \"bert_pooler\",\n",
+    "            \"pretrained_model\": \"distilroberta-base\",\n",
+    "            \"requires_grad\": True,\n",
+    "            \"dropout\": 0.1,\n",
+    "        },\n",
+    "        # If you do not want to use the pre-trained activation layer for the CLS token (see text) \n",
+    "        # \"pooler\": {\n",
+    "        #     \"type\": \"cls_pooler\",\n",
+    "        # }\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Dvs2Dd9KvqOD"
+   },
+   "outputs": [],
+   "source": [
+    "pl = Pipeline.from_config(pipeline_dict_finetuning)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6m-dlywoy-QJ"
+   },
+   "source": [
+    "In our trainer configuration we will use canonical values for the `batch_size` and `lr` taken from the Hugging Face transformers library. We also will apply a linearly decaying learning rate scheduler with 50 warm-up steps, which is recommended when fine-tuning a pretrained model. For now we will stick to two epochs to allow for a rapid iteration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Qe7KLWhjx-ci"
+   },
+   "outputs": [],
+   "source": [
+    "trainer = TrainerConfiguration(\n",
+    "    optimizer={\n",
+    "        \"type\": \"adamw\",\n",
+    "        \"lr\": 5e-5\n",
+    "    },\n",
+    "    learning_rate_scheduler={\n",
+    "        \"type\": \"linear_with_warmup\",\n",
+    "        \"num_epochs\": 2,\n",
+    "        \"num_steps_per_epoch\": 1250,\n",
+    "        \"warmup_steps\": 50\n",
+    "    },\n",
+    "    batch_size=8,\n",
+    "    num_epochs=2,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "SmUSfqrFz9x7"
+   },
+   "outputs": [],
+   "source": [
+    "pl.train(\n",
+    "    output=\"output/fine_tuning\",\n",
+    "    training=train_ds,\n",
+    "    validation=valid_ds,\n",
+    "    trainer=trainer,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "m_Nwn3Q2rZ_R"
+   },
+   "source": [
+    "After two epochs we achieve an accuracy of about 0.65, which is competetive looking at the corresponding [Kaggle notebooks](https://www.kaggle.com/Cornell-University/arxiv/notebooks). Keep in mind that we did not optimize any of the training parameters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "52u9ExRoBb_J"
+   },
+   "source": [
+    "### Training with a frozen transformer\n",
+    "\n",
+    "In our second pipeline we keep the weights of the transformer frozen by setting `trainable: False` and only train the pooler in the head component. In this setup the training will be significantly faster and does not necessarily require dedicated hardware.\n",
+    "\n",
+    "As pooler we will use a bidirectional [GRU](https://en.wikipedia.org/wiki/Gated_recurrent_unit) in the head."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "-QdJ8mhpEt0W"
+   },
+   "outputs": [],
+   "source": [
+    "pipeline_dict_frozen = {\n",
+    "    \"name\": \"arxiv_categories_classification\",\n",
+    "    \"features\": {\n",
+    "        \"transformers\": {\n",
+    "            \"model_name\": \"distilroberta-base\",\n",
+    "            \"trainable\": False,\n",
+    "            \"max_length\": 512,\n",
+    "        }\n",
+    "    },\n",
+    "    \"head\": {\n",
+    "        \"type\": \"TextClassification\",\n",
+    "        \"labels\": train_ds.unique(\"label\"),\n",
+    "        \"pooler\": {\n",
+    "            \"type\": \"gru\",\n",
+    "            \"num_layers\": 1,\n",
+    "            \"hidden_size\": 128,\n",
+    "            \"bidirectional\": True,\n",
+    "        },\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NLBsuB4dvJpU"
+   },
+   "outputs": [],
+   "source": [
+    "pl = Pipeline.from_config(pipeline_dict_frozen)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aR_zcLtDGzaF"
+   },
+   "source": [
+    "In our training configuration we will use the same `batch_size` as in the previous configuration but increase the learning rate to Pytorch's default value for the AdamW optimizer, in order to work well with the GRU. We also remove the learning rate scheduler with its warmup steps, since we do not modify the pretrained transformer weights."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "zKJm58fhw1-t"
+   },
+   "outputs": [],
+   "source": [
+    "trainer = TrainerConfiguration(\n",
+    "    optimizer={\n",
+    "        \"type\": \"adamw\",\n",
+    "        \"lr\": 0.002,\n",
+    "    },\n",
+    "    batch_size=8,\n",
+    "    num_epochs=2,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "89RlTqQ6GzaJ"
+   },
+   "outputs": [],
+   "source": [
+    "pl.train(\n",
+    "    output=\"output/frozen_transformer\",\n",
+    "    training=train_ds,\n",
+    "    validation=valid_ds,\n",
+    "    trainer=trainer,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "SHkc34Y0GzaN"
+   },
+   "source": [
+    "The training is about 4 times faster compared with fine-tuning the transformer, and after two epochs we reach a respectable accuracy of about 0.60. Keep in mind that we did not optimize any of the training parameters."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "JOx3BievET1v"
+   },
+   "source": [
+    "### Combining text features"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WmKTobUxDS-W"
+   },
+   "source": [
+    "As mentioned earlier, the pretrained transformers are treated as a text feature in *biome.text*. We can easily combine them with other features, such as the *char* feature for example, which encodes word tokens based on their characters.\n",
+    "\n",
+    "Keep in mind that the *char* feature provides a feature vector per word (spaCy) token, while the *transformers* feature provides a contextualized feature vector per word piece. Therefore, we simply sum up the word piece vectors of the transformers feature, to end up with concatenated feature vectors per word token. \n",
+    "\n",
+    "::: warning Note\n",
+    "\n",
+    "This also means that special transformer tokens, such as BERT's [CLS] token, are ignored when combining text features.\n",
+    "\n",
+    ":::\n",
+    "\n",
+    "As in the second configuration, we will pool the feature vectors with a *GRU* in the *head* component."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "wwj_GcJsEEns"
+   },
+   "outputs": [],
+   "source": [
+    "pipeline_dict_combining = {\n",
+    "    \"name\": \"arxiv_categories_classification\",\n",
+    "    \"tokenizer\": {},\n",
+    "    \"features\": {\n",
+    "        \"char\": {\n",
+    "            \"embedding_dim\": 32,\n",
+    "            \"lowercase_characters\": True,\n",
+    "            \"encoder\": {\n",
+    "                \"type\": \"gru\",\n",
+    "                \"num_layers\": 1,\n",
+    "                \"hidden_size\": 32,\n",
+    "                \"bidirectional\": True,\n",
+    "            },\n",
+    "            \"dropout\": 0.1,\n",
+    "        },\n",
+    "        \"transformers\": {\n",
+    "            \"model_name\": \"distilroberta-base\",\n",
+    "            \"trainable\": False,\n",
+    "            \"max_length\": 512,\n",
+    "        }\n",
+    "    },\n",
+    "    \"head\": {\n",
+    "        \"type\": \"TextClassification\",\n",
+    "        \"labels\": train_ds.unique(\"label\"),\n",
+    "        \"pooler\": {\n",
+    "            \"type\": \"gru\",\n",
+    "            \"num_layers\": 1,\n",
+    "            \"hidden_size\": 128,\n",
+    "            \"bidirectional\": True,\n",
+    "        },\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "SsLbHV1-seQU"
+   },
+   "outputs": [],
+   "source": [
+    "pl = Pipeline.from_config(pipeline_dict_combining)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yXoHVbFruR6M"
+   },
+   "source": [
+    "For the *char* feature we have to manually create the vocab before the training."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "0LlL_sWKstpy"
+   },
+   "outputs": [],
+   "source": [
+    "pl.create_vocabulary(VocabularyConfiguration(sources=[train_ds, valid_ds]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "aFKVplJEu7pU"
+   },
+   "source": [
+    "We will use the same training configuration as in the frozen transformer section."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "4bsw0Gb1uz1c"
+   },
+   "outputs": [],
+   "source": [
+    "trainer = TrainerConfiguration(\n",
+    "    optimizer={\n",
+    "        \"type\": \"adamw\",\n",
+    "        \"lr\": 0.001,\n",
+    "    },\n",
+    "    batch_size=8,\n",
+    "    num_epochs=2,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "4wsZVDQlu2WU"
+   },
+   "outputs": [],
+   "source": [
+    "pl.train(\n",
+    "    output=\"output/combined_features\",\n",
+    "    training=train_ds,\n",
+    "    validation=valid_ds,\n",
+    "    trainer=trainer,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yh_QfgDoBEgu"
+   },
+   "source": [
+    "With an accuracy of 0.55, combining features in this case seems to be counterproductive. The main reason is the exclusion of the special transformers tokens and the usage of feature vectors per word instead of word-pieces. Even when fine-tuning the transformer, those differences seem to significantly affect the performance as shown in our [WandB report](https://wandb.ai/ignacioct/biome/reports/Exploring-Ways-to-use-Pretrained-Transformers-in-biome-text--VmlldzoyNzk2MTM)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "U9VhCjKWHlnZ"
+   },
+   "source": [
+    "### Compare performances with TensorBoard (optional)\n",
+    "\n",
+    "In the output folder of the trainig we automatically log the results with [TensorBoard](https://www.tensorflow.org/tensorboard/). This helps us to conveniently compare the three training runs from above. Alternatively, if you installed and logged in to WandB, the runs should have been logged automatically to the *biome* project of your account. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Zu-59CTPa75a"
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext tensorboard\n",
+    "%tensorboard --logdir=output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "dEBUyp0OS-1j"
+   },
+   "source": [
+    "## Optimizing the trainer configuration\n",
+    "\n",
+    "As described in the [HPO tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.html#imports), *biome.text* relies on the [Ray Tune library](https://docs.ray.io/en/latest/tune.html#tune-index) to perform hyperparameter optimization. \n",
+    "We recommend to go through that tutorial first, as we will be skipping most of the implementation details here."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "2FAmS4r4jxIs"
+   },
+   "source": [
+    "### Frozen transformer\n",
+    "\n",
+    "In this section we will first try to improve the performance of the frozen-transformer configuration by conducting a random search for three training parameters:\n",
+    "- learning rate\n",
+    "- weight decay\n",
+    "- batch size\n",
+    "\n",
+    "We also set `num_serialized_models_to_keep` to 0 to reduce the disk storage footprint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "bF7BXByjGsPs"
+   },
+   "outputs": [],
+   "source": [
+    "trainer_dict = {\n",
+    "    \"optimizer\": {\n",
+    "        \"type\": \"adamw\",\n",
+    "        \"lr\": tune.loguniform(5e-3, 5e-4),\n",
+    "        \"weight_decay\": tune.loguniform(1e-3, 0.1)\n",
+    "    },\n",
+    "    \"batch_size\": tune.choice([4, 8, 16]),\n",
+    "    \"num_epochs\": 2,\n",
+    "    \"num_serialized_models_to_keep\": 0,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "kmtwUx5l3_f-"
+   },
+   "source": [
+    "Having defined the search space for our hyperparameters, we create a `TuneExperiment` where we specify the number of samples to be dranw from our search space, the `local_dir` for our HPO output and the computing resources we want Ray Tune to have access to."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "RJJ5aeZI3722"
+   },
+   "outputs": [],
+   "source": [
+    "tune_exp = TuneExperiment(\n",
+    "    pipeline_config=pipeline_dict_frozen, \n",
+    "    trainer_config=trainer_dict,\n",
+    "    train_dataset=train_ds,\n",
+    "    valid_dataset=valid_ds,\n",
+    "    name=\"frozen_transformer_sweep\",\n",
+    "    # parameters for tune.run\n",
+    "    num_samples=50,\n",
+    "    local_dir=\"tune_runs\",\n",
+    "    resources_per_trial={\"gpu\": 1, \"cpu\":2},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "mBsTEWbF3MSs"
+   },
+   "source": [
+    "With our TuneExperiment object at hand, we simply have to pass it on to the [`tune.run`](https://docs.ray.io/en/master/tune/api_docs/execution.html#tune-run) function to start our random search.\n",
+    "\n",
+    "To speed things up we will use the [ASHA](https://blog.ml.cmu.edu/2018/12/12/massively-parallel-hyperparameter-optimization/) trial scheduler that terminates low performing trials early. In our case we take the *validation_accuracy* as a meassure of the models performance.\n",
+    "\n",
+    "In Google Colab with a GPU backend this random search should not take more than about 1.5 hours and we recommend following the progress via WandB. Alternatively, you could follow the progress via [TensorBoard](https://www.tensorflow.org/tensorboard/) by launching a TensorBoard instance before starting the random search, and pointing it to the *local_dir* output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "2RZdb1MRRpfF"
+   },
+   "outputs": [],
+   "source": [
+    "%tensorboard --logdir=tune_runs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "uMYTfJEJ5D_5"
+   },
+   "outputs": [],
+   "source": [
+    "analysis = tune.run(\n",
+    "    tune_exp,\n",
+    "    scheduler=tune.schedulers.ASHAScheduler(), \n",
+    "    metric=\"validation_accuracy\",\n",
+    "    mode=\"max\",\n",
+    "    progress_reporter=tune.JupyterNotebookReporter(overwrite=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "LLrkJYC4A9Wr"
+   },
+   "source": [
+    "With the best configuration of our random search we should achieve an accuracy of about 0.64."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "006NKB3aLGNk"
+   },
+   "source": [
+    "### Fine-tuning the transformer\n",
+    "\n",
+    "We will also try to optimize the training parameters for a fine-tuning of the transformer. Since this is computationally much more expensive, we will take only a subset of our training data for the random search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "id": "PvQNlVOQNu0a"
+   },
+   "outputs": [],
+   "source": [
+    "train_1000 = train_ds.shuffle(seed=43).select(range(1000))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "yNjclQTnb7Jp"
+   },
+   "source": [
+    "The training parameters we are going to tune are the following:\n",
+    "\n",
+    "\n",
+    "*   learning rate\n",
+    "*   weight decay\n",
+    "*   warmup steps"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "id": "_Dmk_ZwBaDRp"
+   },
+   "outputs": [],
+   "source": [
+    "trainer_dict = {\n",
+    "    \"optimizer\": {\n",
+    "        \"type\": \"adamw\",\n",
+    "        \"lr\": tune.loguniform(1e-5, 1e-4),\n",
+    "        \"weight_decay\": tune.loguniform(1e-3, 0.1)\n",
+    "    },\n",
+    "    \"learning_rate_scheduler\": {\n",
+    "        \"type\": \"linear_with_warmup\",\n",
+    "        \"num_epochs\": 2,\n",
+    "        \"num_steps_per_epoch\": 125,\n",
+    "        \"warmup_steps\": tune.choice(list(range(101))),\n",
+    "    },\n",
+    "    \"batch_size\": 8,\n",
+    "    \"num_epochs\": 2,\n",
+    "    \"num_serialized_models_to_keep\": 0,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "g7emjI2A1wI9"
+   },
+   "source": [
+    "After having defined the search space, we create a `TuneExperiment` providing this time the subset of the training data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "id": "V47jYH9u0dBD"
+   },
+   "outputs": [],
+   "source": [
+    "tune_exp = TuneExperiment(\n",
+    "    pipeline_config=pipeline_dict_finetuning, \n",
+    "    trainer_config=trainer_dict,\n",
+    "    train_dataset=train_ds,\n",
+    "    valid_dataset=valid_ds,\n",
+    "    name=\"finetuning_sweep3\",\n",
+    "    # parameters for tune.run\n",
+    "    num_samples=50,\n",
+    "    local_dir=\"tune_runs\",\n",
+    "    resources_per_trial={\"gpu\": 1, \"cpu\":2},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WSQd6oaE3wGy"
+   },
+   "source": [
+    "Again, we will use the [ASHA](https://blog.ml.cmu.edu/2018/12/12/massively-parallel-hyperparameter-optimization/) trial scheduler and maximize the *validation_accuracy*.\n",
+    "\n",
+    "In Google Colab with a GPU backend, this random search should not take longer than 1.5 hours."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "MviYzLQuSOBV"
+   },
+   "outputs": [],
+   "source": [
+    "analysis = tune.run(\n",
+    "    tune_exp,\n",
+    "    scheduler=tune.schedulers.ASHAScheduler(),\n",
+    "    metric=\"validation_accuracy\",\n",
+    "    mode=\"max\",\n",
+    "    progress_reporter=tune.JupyterNotebookReporter(overwrite=True),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "t9G5ZmzkeQ0c"
+   },
+   "source": [
+    "We now take the configuration that yielded the best *validation accuracy* and train the pipeline on the full training set. In our random search the best configuration was following:\n",
+    "\n",
+    "*   learning rate: 0.0000453\n",
+    "*   warmup steps: 45\n",
+    "*   weight decay: 0.003197\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "feIOb4RdNObR"
+   },
+   "outputs": [],
+   "source": [
+    "pl = Pipeline.from_config(pipeline_dict_finetuning)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "id": "XTjVMB4c7pgb"
+   },
+   "outputs": [],
+   "source": [
+    "trainer = TrainerConfiguration(\n",
+    "    optimizer={\n",
+    "        \"type\": \"adamw\",\n",
+    "        \"lr\": 0.0000453,\n",
+    "        \"weight_decay\": 0.003197,\n",
+    "    },\n",
+    "    learning_rate_scheduler={\n",
+    "        \"type\": \"linear_with_warmup\",\n",
+    "        \"num_epochs\": 2,\n",
+    "        \"num_steps_per_epoch\": 1250,\n",
+    "        \"warmup_steps\": 45,\n",
+    "    },\n",
+    "    batch_size=8,\n",
+    "    num_epochs=2,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "qCZjdwib7zFu"
+   },
+   "outputs": [],
+   "source": [
+    "pl.train(\n",
+    "    output=\"output/transformer_final_model/\",\n",
+    "    training=train_ds,\n",
+    "    validation=valid_ds,\n",
+    "    trainer=trainer,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "IQy16a69jTzb"
+   },
+   "source": [
+    "With the optimized training parameters we achieve an accuracy of about 0.67."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DBZld5oOjoce"
+   },
+   "source": [
+    "### Evaluating with a test set\n",
+    "\n",
+    "TO BE DONE"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "8PFg7yMSfEt1"
+   },
+   "source": [
+    "## Making predictions\n",
+    "\n",
+    "Let's quickly recap what we have learnt so far:\n",
+    "\n",
+    "* Freezing the pretrained transformer and optimizing a GRU pooler in the head can be valid option if computing resources are limited;\n",
+    "* However, fine-tuning the transformer at word-piece level and using the CLS token as \"pooler\" works best;\n",
+    "* A quick HPO of the training parameters improved the accuracies by ~0.03.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "0QpFfFcLQmlx"
+   },
+   "source": [
+    "With our best model at hand we will finally make a simple prediction. First we have to load the pipeline from our training output: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "id": "EYU8YrPQLSLV"
+   },
+   "outputs": [],
+   "source": [
+    "pl_trained = Pipeline.from_pretrained(\"output/transformer_final_model/model.tar.gz\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "B1FO8FTwq9Z3"
+   },
+   "source": [
+    "Then we can simply call the `predict` method that outputs a dictionary with a `labels` and `probabilities` key containing a list of labels and their corresponding probabilities, ordered from most to less likely."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Pe0uM-Gdhfwg"
+   },
+   "outputs": [],
+   "source": [
+    "prediction_dict = pl_trained.predict(text=\"This is a title of a super intelligent Natural Language Processing system\")\n",
+    "prediction_dict"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "AjmdUT6DtJKL"
+   },
+   "source": [
+    "The most likely category predicted is the \"*cs.CL*\" category, which seems fitting according to this [list of arxiv categories and their meanings](https://arxiv.org/category_taxonomy)."
+   ]
+  }
+ ],
+ "metadata": {
+  "accelerator": "GPU",
+  "colab": {
+   "collapsed_sections": [
+    "zbHC0ZczVosr",
+    "DBZld5oOjoce"
+   ],
+   "name": "4_Using_Transformers_in_biome_text.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb
+++ b/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb
@@ -367,7 +367,7 @@
     "\n",
     "We also need to specify the maximum number of input tokens `max_length` supported by the pretrained transformer. If you are sure that your input data does not exceed this limit, you can skip this parameter.\n",
     "\n",
-    "With BERT like models, like RoBERTa, a special [CLS] token is added as first token to each input. It is pretrained to effectively represent the entire input and can be used as pooler in the head component. Many BERT like models pass this token through a non-linear tanh activation layer that is part of the pretraining. If you want to use these pretrained weights you have to use the `bert_pooler` together with the corresponding `pretrained_model`. We will fine-tune these weights as well (setting `require_grad` to `True`) and add a little dropout.\n",
+    "With BERT-like models, such as RoBERTa, a special [CLS] token is added as first token to each input. It is pretrained to effectively represent the entire input and can be used as pooler in the head component. Many BERT like models pass this token through a non-linear tanh activation layer that is part of the pretraining. If you want to use these pretrained weights you have to use the `bert_pooler` together with the corresponding `pretrained_model`. We will fine-tune these weights as well (setting `require_grad` to `True`) and add a little dropout.\n",
     "\n",
     "::: tip Tip\n",
     "\n",


### PR DESCRIPTION
This PR adds 4th tutorial about the *transformers* feature to our documentation.
The base of this tutorial was created in collaboration with @ignacioct , who also published this [very nice report](https://wandb.ai/ignacioct/biome/reports/Exploring-Ways-to-use-Pretrained-Transformers-in-biome-text--VmlldzoyNzk2MTM) on the WandB gallery as a direct result. You can find the tutorial here: https://github.com/recognai/biome-text/blob/feat/transformers_tutorial/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb

I am still not 100% happy, i think some minor things can be improved (for example, using `batches_per_epoch` instead of using a subset of the data for the HPO, or using some advanced search algorithm, since parallelizing the HPO in Google Colab is not possible due to the resources). There is also a TODO left: evaluation on a test set, i will add this once we have the new evaluate method. 
But In the near future i want to go over all the tutorials anyways, unifying them a bit and trying to improve things. So for now, i think this is a good first version.