### PR TITLE
Introducing the mutable pipeline

### DIFF
--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -4,26 +4,16 @@ import logging
 import os
 import shutil
 import tempfile
-from biome.text import vocabulary
-from biome.text.configuration import FindLRConfiguration
-from biome.text.configuration import PipelineConfiguration
-from biome.text.configuration import TrainerConfiguration
-from biome.text.configuration import VocabularyConfiguration
-from biome.text.dataset import InstancesDataset
-from biome.text.dataset import Dataset
-from biome.text.errors import EmptyVocabError
-from biome.text.features import TransformersFeatures
-from biome.text.helpers import update_method_signature
 from inspect import Parameter
 from pathlib import Path
 from typing import Any
-from typing import cast
 from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Type
 from typing import Union
+from typing import cast
 
 import numpy
 import torch
@@ -34,10 +24,21 @@ from allennlp.data import Vocabulary
 from allennlp.models import load_archive
 from allennlp.models.archival import Archive
 
+from biome.text import vocabulary
+from biome.text.configuration import FindLRConfiguration
+from biome.text.configuration import PipelineConfiguration
+from biome.text.configuration import TrainerConfiguration
+from biome.text.configuration import VocabularyConfiguration
+from biome.text.dataset import Dataset
+from biome.text.dataset import InstancesDataset
+from biome.text.errors import EmptyVocabError
+from biome.text.features import TransformersFeatures
+from biome.text.helpers import update_method_signature
+
 from ._model import PipelineModel
 from .backbone import ModelBackbone
-from .loggers import add_default_wandb_logger_if_needed
 from .loggers import BaseTrainLogger
+from .loggers import add_default_wandb_logger_if_needed
 from .modules.heads import TaskHead
 from .modules.heads import TaskHeadConfiguration
 from .training_results import TrainingResults

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -9,7 +9,7 @@ from biome.text.configuration import FindLRConfiguration
 from biome.text.configuration import PipelineConfiguration
 from biome.text.configuration import TrainerConfiguration
 from biome.text.configuration import VocabularyConfiguration
-from biome.text.data import InstancesDataset
+from biome.text.dataset import InstancesDataset
 from biome.text.dataset import Dataset
 from biome.text.errors import EmptyVocabError
 from biome.text.features import TransformersFeatures

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -4,26 +4,6 @@ import logging
 import os
 import shutil
 import tempfile
-from inspect import Parameter
-from pathlib import Path
-from typing import Any
-from typing import Dict
-from typing import Iterable
-from typing import List
-from typing import Optional
-from typing import Type
-from typing import Union
-from typing import cast
-
-import numpy
-import torch
-from allennlp.commands.find_learning_rate import search_learning_rate
-from allennlp.common import Params
-from allennlp.data import AllennlpLazyDataset
-from allennlp.data import Vocabulary
-from allennlp.models import load_archive
-from allennlp.models.archival import Archive
-
 from biome.text import vocabulary
 from biome.text.configuration import FindLRConfiguration
 from biome.text.configuration import PipelineConfiguration
@@ -34,10 +14,30 @@ from biome.text.dataset import Dataset
 from biome.text.errors import EmptyVocabError
 from biome.text.features import TransformersFeatures
 from biome.text.helpers import update_method_signature
+from inspect import Parameter
+from pathlib import Path
+from typing import Any
+from typing import cast
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Type
+from typing import Union
+
+import numpy
+import torch
+from allennlp.commands.find_learning_rate import search_learning_rate
+from allennlp.common import Params
+from allennlp.data import AllennlpLazyDataset
+from allennlp.data import Vocabulary
+from allennlp.models import load_archive
+from allennlp.models.archival import Archive
+
 from ._model import PipelineModel
 from .backbone import ModelBackbone
-from .loggers import BaseTrainLogger
 from .loggers import add_default_wandb_logger_if_needed
+from .loggers import BaseTrainLogger
 from .modules.heads import TaskHead
 from .modules.heads import TaskHeadConfiguration
 from .training_results import TrainingResults

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -4,43 +4,40 @@ import logging
 import os
 import shutil
 import tempfile
-from biome.text import vocabulary
-from biome.text.configuration import FindLRConfiguration
-from biome.text.configuration import PipelineConfiguration
-from biome.text.configuration import TrainerConfiguration
-from biome.text.configuration import VocabularyConfiguration
-from biome.text.dataset import InstancesDataset
-from biome.text.dataset import Dataset
-from biome.text.errors import ActionNotSupportedError
-from biome.text.errors import EmptyVocabError
-from biome.text.features import TransformersFeatures
-from biome.text.helpers import update_method_signature
 from inspect import Parameter
 from pathlib import Path
 from typing import Any
-from typing import cast
 from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Type
 from typing import Union
+from typing import cast
 
 import numpy
 import torch
 from allennlp.commands.find_learning_rate import search_learning_rate
 from allennlp.common import Params
 from allennlp.data import AllennlpLazyDataset
-from allennlp.data import Instance
 from allennlp.data import Vocabulary
 from allennlp.models import load_archive
 from allennlp.models.archival import Archive
-from dask.dataframe import DataFrame
 
+from biome.text import vocabulary
+from biome.text.configuration import FindLRConfiguration
+from biome.text.configuration import PipelineConfiguration
+from biome.text.configuration import TrainerConfiguration
+from biome.text.configuration import VocabularyConfiguration
+from biome.text.data import InstancesDataset
+from biome.text.dataset import Dataset
+from biome.text.errors import EmptyVocabError
+from biome.text.features import TransformersFeatures
+from biome.text.helpers import update_method_signature
 from ._model import PipelineModel
 from .backbone import ModelBackbone
-from .loggers import add_default_wandb_logger_if_needed
 from .loggers import BaseTrainLogger
+from .loggers import add_default_wandb_logger_if_needed
 from .modules.heads import TaskHead
 from .modules.heads import TaskHeadConfiguration
 from .training_results import TrainingResults
@@ -58,14 +55,19 @@ logging.getLogger("elasticsearch").setLevel(logging.ERROR)
 class Pipeline:
     """Manages NLP models configuration and actions.
 
-    Use `Pipeline` for creating new models from a configuration or loading a pre-trained model.
+    Use `Pipeline` for creating new models from a configuration or loading a pretrained model.
 
     Use instantiated Pipelines for training from scratch, fine-tuning, predicting, serving, or exploring predictions.
     """
 
     __LOGGER = logging.getLogger(__name__)
-    _model: PipelineModel = None
-    _config: PipelineConfiguration = None
+
+    def __init__(self, model: PipelineModel, config: PipelineConfiguration, model_path: str = None):
+        self._model = model
+        self._config = config
+        self._model_path = model_path
+
+        self._update_prediction_signatures()
 
     @classmethod
     def from_yaml(cls, path: str, vocab_path: Optional[str] = None) -> "Pipeline":
@@ -92,7 +94,7 @@ class Pipeline:
         cls,
         config: Union[PipelineConfiguration, dict],
         vocab_path: Optional[str] = None,
-    ) -> "_BlankPipeline":
+    ) -> "Pipeline":
         """Creates a pipeline from a `PipelineConfiguration` object or a configuration dictionary
 
         Parameters
@@ -109,25 +111,42 @@ class Pipeline:
         """
         if isinstance(config, dict):
             config = PipelineConfiguration.from_dict(config)
-        return _BlankPipeline(
-            config=config, vocab=vocabulary.load_vocabulary(vocab_path)
-        )
+        model = cls._model_from_config(config, vocab=vocabulary.load_vocabulary(vocab_path))
+
+        if not isinstance(model, PipelineModel):
+            raise TypeError(f"Cannot load model. Wrong format of {model}")
+
+        cls._add_transformers_vocab_if_needed(model)
+
+        return cls(model, config)
 
     @classmethod
-    def from_pretrained(cls, path: str, **kwargs) -> "_PreTrainedPipeline":
-        """Loads a pipeline from a pre-trained pipeline providing a *model.tar.gz* file path
+    def from_pretrained(cls, path: str) -> "Pipeline":
+        """Loads a pretrained pipeline providing a *model.tar.gz* file path
 
         Parameters
         ----------
         path: `str`
-            The path to the *model.tar.gz* file of a pre-trained `Pipeline`
+            The path to the *model.tar.gz* file of a pretrained `Pipeline`
 
         Returns
         -------
         pipeline: `Pipeline`
-            A configured pipeline
+            A pretrained pipeline
         """
-        return _PreTrainedPipeline(pretrained_path=path, **kwargs)
+        archive = load_archive(
+            path,
+            # Necessary for AllenNLP>=1.2.0 that requires a dataset_reader config key
+            # We choose the "interleaving" type since it is the most light weight one.
+            overrides={"dataset_reader": {"type": "interleaving", "readers": {}}}
+        )
+        model = cls._model_from_archive(archive)
+        config = cls._config_from_archive(archive)
+
+        if not isinstance(model, PipelineModel):
+            raise TypeError(f"Cannot load model. Wrong format of {model}")
+
+        return cls(model, config, path)
 
     def init_prediction_logger(self, output_dir: str, max_logging_size: int = 100):
         """Initializes the prediction logging.
@@ -271,11 +290,6 @@ class Pipeline:
         training_results
             Training results including the generated model path and the related metrics
         """
-        if extend_vocab is not None and isinstance(self, _BlankPipeline):
-            raise ActionNotSupportedError(
-                "If you want to customize pipeline vocab, please use the `create_vocabulary()` method instead"
-            )
-
         trainer = trainer or TrainerConfiguration()
         try:
             if not restore and os.path.isdir(output):
@@ -283,20 +297,17 @@ class Pipeline:
 
             self.__configure_training_logging(output, quiet)
 
-            # The original pipeline keeps unchanged
-            train_pipeline = self._make_copy()
             vocab = None
-
             if restore:
                 vocab = vocabulary.load_vocabulary(os.path.join(output, "vocabulary"))
             if extend_vocab is not None and not vocab:
-                vocab = train_pipeline._extend_vocabulary(
-                    train_pipeline.backbone.vocab, vocab_config=extend_vocab
+                vocab = self._extend_vocabulary(
+                    self.backbone.vocab, vocab_config=extend_vocab
                 )
             if vocab:
-                train_pipeline._set_vocab(vocab)
+                self._set_vocab(vocab)
 
-            if train_pipeline.has_empty_vocab():
+            if self.has_empty_vocab():
                 raise EmptyVocabError(
                     "Found an empty vocabulary. "
                     "You probably forgot to create a vocabulary with '.create_vocabulary()'."
@@ -308,14 +319,14 @@ class Pipeline:
             for name, dataset in datasets.items():
                 if isinstance(dataset, Dataset):
                     datasets[name] = dataset.to_instances(
-                        pipeline=train_pipeline, lazy=lazy
+                        pipeline=self, lazy=lazy
                     )
 
             loggers = loggers or []
             loggers = add_default_wandb_logger_if_needed(loggers)
 
             pipeline_trainer = PipelineTrainer(
-                train_pipeline,
+                self,
                 trainer_config=trainer,
                 output_dir=output,
                 epoch_callbacks=loggers,
@@ -325,7 +336,7 @@ class Pipeline:
             for logger in loggers:
                 try:
                     logger.init_train(
-                        pipeline=train_pipeline,
+                        pipeline=self,
                         trainer_configuration=trainer,
                         **datasets,
                     )
@@ -334,8 +345,8 @@ class Pipeline:
                         "Logger %s failed on init_train: %s", logger, e
                     )
 
-            model_path, metrics = pipeline_trainer.train()
-            train_results = TrainingResults(model_path, metrics)
+            self._model_path, metrics = pipeline_trainer.train()
+            train_results = TrainingResults(self._model_path, metrics)
 
             for logger in loggers:
                 try:
@@ -362,11 +373,17 @@ class Pipeline:
         """
         self._model.set_vocab(vocab)
 
-    def _make_copy(self) -> "Pipeline":
-        """
-        Creates a copy of current pipeline instance
-        """
-        return _PipelineCopy(self)
+    def copy(self) -> "Pipeline":
+        """Returns a copy of the pipeline"""
+        model = self._model_from_config(
+            self._config, vocab=self.backbone.vocab
+        )
+        config = copy.deepcopy(self._config)
+
+        pipeline_copy = Pipeline(model, config, self._model_path)
+        pipeline_copy._model.load_state_dict(self._model.state_dict())
+
+        return pipeline_copy
 
     @staticmethod
     def __restore_training_logging():
@@ -598,6 +615,11 @@ class Pipeline:
         """Returns the names of the trainable parameters in the pipeline"""
         return [name for name, p in self._model.named_parameters() if p.requires_grad]
 
+    @property
+    def model_path(self) -> str:
+        """Returns the binary file path of the last trained model"""
+        return self._model_path
+
     def _update_prediction_signatures(self):
         """Fixes the `self.predict` signature to match the model inputs for interactive work-flows"""
         new_signature = inspect.Signature(
@@ -681,32 +703,40 @@ class Pipeline:
         """Determines if a pipeline has an empty vocab under configured features"""
         return vocabulary.is_empty(self.backbone.vocab, self.config.features.keys)
 
+    @staticmethod
+    def _add_transformers_vocab_if_needed(model: PipelineModel):
+        """Adds the transformers vocabulary to the `vocab`
 
-class _BlankPipeline(Pipeline):
-    """A blank pipeline initialized via a configuration
+        Parameters
+        ----------
+        vocab
+            The transformers vocabulary will be added to this vocab
+        """
+        # The AllenNLP`s PretrainedTransformerIndexer adds its specific vocabulary to the Model's vocab
+        # when the first `tokens_to_index()` is called via the private _add_encoding_to_vocabulary_if_needed method.
+        # We trigger this here manually in a super ugly way ...
+        # Actually i am not sure why they add it to their vocab in the first place ...
+        transformers_indexer = model.head.backbone.featurizer.indexer.get(
+            TransformersFeatures.namespace
+        )
+        if transformers_indexer is not None:
+            try:
+                transformers_indexer._add_encoding_to_vocabulary_if_needed(model.vocab)
+            except AttributeError:
+                transformers_indexer._matched_indexer._add_encoding_to_vocabulary_if_needed(
+                    model.vocab
+                )
 
-    Parameters
-    ----------
-    config: `Optional[PipelineConfiguration]`
-        A `PipelineConfiguration` object defining the configuration of the fresh `Pipeline`.
-    vocab
-        The vocabulary for the pipeline
-    """
+    @staticmethod
+    def _model_from_archive(archive: Archive) -> PipelineModel:
+        if not isinstance(archive.model, PipelineModel):
+            raise ValueError(f"Wrong pipeline model: {archive.model}")
+        return cast(PipelineModel, archive.model)
 
-    def __init__(
-        self,
-        config: PipelineConfiguration,
-        vocab: Optional[Vocabulary] = None,
-        **extra_args,
-    ):
-        self._config = config
-        self._model = self._model_from_config(self._config, vocab=vocab, **extra_args)
-
-        if not isinstance(self._model, PipelineModel):
-            raise TypeError(f"Cannot load model. Wrong format of {self._model}")
-
-        self._add_transformers_vocab_if_necessary(self._model.vocab)
-        self._update_prediction_signatures()
+    @staticmethod
+    def _config_from_archive(archive: Archive) -> PipelineConfiguration:
+        config = archive.config["model"]["config"]
+        return PipelineConfiguration.from_params(config)
 
     def create_vocabulary(self, config: VocabularyConfiguration) -> None:
         """Creates the vocabulary for the pipeline from scratch
@@ -720,83 +750,4 @@ class _BlankPipeline(Pipeline):
         # TODO (dcfidalgo): This can maybe optimized, do we really need to create a new PipelineModel
         #  and add again the transformers vocab?
         self._model = self._model_from_config(self.config, vocab=vocab)
-        self._add_transformers_vocab_if_necessary(self._model.vocab)
-
-    def _add_transformers_vocab_if_necessary(self, vocab):
-        """Adds the transformers vocabulary to the `vocab`
-
-        Parameters
-        ----------
-        vocab
-            The transformers vocabulary will be added to this vocab
-        """
-        # The AllenNLP`s PretrainedTransformerIndexer adds its specific vocabulary to the Model's vocab
-        # when the first `tokens_to_index()` is called via the private _add_encoding_to_vocabulary_if_needed method.
-        # We trigger this here manually in a super ugly way ...
-        # Actually i am not sure why they add it to their vocab in the first place ...
-        transformers_indexer = self.backbone.featurizer.indexer.get(
-            TransformersFeatures.namespace
-        )
-        if transformers_indexer is not None:
-            try:
-                transformers_indexer._add_encoding_to_vocabulary_if_needed(vocab)
-            except AttributeError:
-                transformers_indexer._matched_indexer._add_encoding_to_vocabulary_if_needed(
-                    vocab
-                )
-
-
-class _PreTrainedPipeline(Pipeline):
-    """
-
-    Arguments
-    ---------
-    pretrained_path: `Optional[str]`
-        The path to the model.tar.gz of a pre-trained `Pipeline`
-
-    """
-
-    def __init__(self, pretrained_path: str, **extra_args):
-        self._binary = pretrained_path
-        archive = load_archive(
-            self._binary,
-            # Necessary for AllenNLP>=1.2.0 that requires a dataset_reader config key
-            # We choose the "interleaving" type since it is the most light weight one.
-            overrides={"dataset_reader": {"type": "interleaving", "readers": {}}},
-            **extra_args,
-        )
-        self._model = self.__model_from_archive(archive)
-        self._config = self.__config_from_archive(archive)
-
-        if not isinstance(self._model, PipelineModel):
-            raise TypeError(f"Cannot load model. Wrong format of {self._model}")
-        self._update_prediction_signatures()
-
-    @staticmethod
-    def __model_from_archive(archive: Archive) -> PipelineModel:
-        if not isinstance(archive.model, PipelineModel):
-            raise ValueError(f"Wrong pipeline model: {archive.model}")
-        return cast(PipelineModel, archive.model)
-
-    @staticmethod
-    def __config_from_archive(archive: Archive) -> PipelineConfiguration:
-        config = archive.config["model"]["config"]
-        return PipelineConfiguration.from_params(config)
-
-    @property
-    def trained_path(self) -> str:
-        """Gets the path to the pretrained binary file"""
-        return self._binary
-
-
-class _PipelineCopy(Pipeline):
-    """A copy of a pipeline ready for training."""
-
-    def __init__(self, from_pipeline: Pipeline):
-        self._model = self._model_from_config(
-            from_pipeline.config, vocab=from_pipeline.backbone.vocab
-        )
-        if isinstance(from_pipeline, _PreTrainedPipeline):
-            self._model.load_state_dict(from_pipeline._model.state_dict())
-
-        self._config = copy.deepcopy(from_pipeline.config)
+        self._add_transformers_vocab_if_needed(self._model)

--- a/tests/text/modules/heads/test_relation_classifier.py
+++ b/tests/text/modules/heads/test_relation_classifier.py
@@ -94,11 +94,5 @@ def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
         validation=training_dataset,
     )
 
-    pl_trained = Pipeline.from_pretrained(str(tmp_path / "relation_classifier"))
-    pl_trained.predict(
-        text="The most common audits were about waste and recycling",
-        entities=[
-            {"start": 34, "end": 39, "label": "OBJECT", "text": "waste"},
-            {"start": 16, "end": 22, "label": "SUBJECT", "text": "audits"},
-        ],
-    )
+    # test loading
+    Pipeline.from_pretrained(str(tmp_path / "relation_classifier"))

--- a/tests/text/test_hpo.py
+++ b/tests/text/test_hpo.py
@@ -85,7 +85,7 @@ def test_tune_exp_save_dataset_and_vocab(
 
 
 def test_tune_exp_custom_trainable(
-    dataset, pipeline_config, trainer_config, monkeypatch
+    dataset, pipeline_config, trainer_config,
 ):
     def my_trainable(config):
         pass

--- a/tests/text/test_pipeline_copy.py
+++ b/tests/text/test_pipeline_copy.py
@@ -1,0 +1,47 @@
+from biome.text import Pipeline, Dataset, TrainerConfiguration, VocabularyConfiguration
+import pytest
+from numpy.testing import assert_allclose
+
+
+@pytest.fixture
+def pipeline():
+    return Pipeline.from_config(
+        {
+            "name": "test_pipeline_copy",
+            "head": {
+                "type": "TextClassification",
+                "labels": ["a", "b"],
+            },
+        }
+    )
+
+
+@pytest.fixture
+def dataset():
+    return Dataset.from_dict(
+        {
+            "text": ["this is", "a test"],
+            "label": ["a", "b"],
+        }
+    )
+
+
+def test_copy(pipeline):
+    prediction = pipeline.predict("check this")
+    pipeline_copy = pipeline.copy()
+    prediction_copy = pipeline_copy.predict("check this")
+
+    assert_allclose(prediction["probs"], prediction_copy["probs"])
+
+
+def test_train_from_pretrained(pipeline, dataset, tmp_path):
+    output_path = tmp_path / "test_train_from_pretrained_output"
+    trainer_config = TrainerConfiguration(num_epochs=1, batch_size=2, cuda_device=-1)
+    pipeline.create_vocabulary(VocabularyConfiguration(sources=[dataset]))
+    pipeline.train(output=str(output_path), training=dataset, trainer=trainer_config)
+
+    prediction = pipeline.predict("a test")
+    pipeline_loaded = Pipeline.from_pretrained(str(output_path))
+    prediction_loaded = pipeline_loaded.predict("a test")
+
+    assert_allclose(prediction["probs"], prediction_loaded["probs"])

--- a/tests/text/test_pipeline_datasets.py
+++ b/tests/text/test_pipeline_datasets.py
@@ -87,7 +87,7 @@ def test_training_from_pretrained_with_head_replace(
     trained = Pipeline.from_pretrained(results.model_path)
     trained.set_head(TestHead)
     trained.config.tokenizer_config.max_nr_of_sentences = 3
-    copied = trained._make_copy()
+    copied = trained.copy()
     assert isinstance(copied.head, TestHead)
     assert copied.num_parameters == trained.num_parameters
     assert copied.num_trainable_parameters == trained.num_trainable_parameters

--- a/tests/text_classification_integration_test.py
+++ b/tests/text_classification_integration_test.py
@@ -134,7 +134,7 @@ def test_text_classification(
         metrics = json.load(file)
 
     # It may fail in some systems
-    assert metrics["training_loss"] == pytest.approx(0.705, abs=0.003)
+    assert metrics["training_loss"] == pytest.approx(0.665, abs=0.003)
 
     # Test vocab from a pretrained file
     pl = Pipeline.from_pretrained(str(output / "model.tar.gz"))


### PR DESCRIPTION
This PR switches to a "mutable" pipeline, that is training the pipeline modifies directly its weights instead the ones of a copy of the pipeline. It is a follow-up on the discussion here #410  .

I did some minor bench marking about memory consumption, and especially for big pretrained transformers this approach saves some memory depending on the size of the transformer (it was ~400 MB in case of the distilroberta_base). 

Since a mutable pipeline means that `_BlankPipeline` can be a `_PreTrainedPipeline` and `_PipelineCopy` is not needed anymore, i switched to only one `Pipeline` class. And one remark about `Pipeline.create_vocabulary`: i would like to get rid of this and make the vocab creation for a training as automatic as possible. If one wants some fancy vocab creation (most of the times you don't and when using pretrained transformers you can't) you can pass on a VocabConfiguration directly to the train method. I have some draft ready, will present this soon.

