### PR TITLE
Add a `Pipeline.evaluate` method

### DIFF
--- a/src/biome/text/cli/cli.py
+++ b/src/biome/text/cli/cli.py
@@ -4,10 +4,11 @@ import sys
 import click
 from click import Group
 
+from .evaluate import evaluate
 from .serve import serve
 from .train import train
 
-SUPPORTED_COMMANDS = [serve, train]
+SUPPORTED_COMMANDS = [train, evaluate, serve]
 
 
 def main():

--- a/src/biome/text/cli/evaluate.py
+++ b/src/biome/text/cli/evaluate.py
@@ -1,0 +1,72 @@
+from typing import Optional
+
+import click
+
+from biome.text import Pipeline
+from biome.text.cli.train import dataset_from_path
+
+
+@click.command()
+@click.argument(
+    "pipeline_path",
+    type=click.Path(exists=True),
+)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    required=True,
+    help="Path to write the evaluation metrics to.",
+)
+@click.option(
+    "--dataset",
+    "-ds",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to the dataset",
+)
+@click.option(
+    "--batch_size",
+    "-bs",
+    type=int,
+    default=16,
+    show_default=True,
+    help="Batch size during evaluation.",
+)
+@click.option(
+    "--lazy",
+    "-l",
+    type=bool,
+    default=False,
+    show_default=True,
+    help="If true, data is lazily loaded from disk, otherwise it is loaded into memory.",
+)
+@click.option(
+    "--prediction_output",
+    "-po",
+    type=click.Path(),
+    default=None,
+    help="Write batch predictions to this file.",
+)
+def evaluate(
+    pipeline_path: str,
+    output: str,
+    dataset: str,
+    batch_size: int = 16,
+    lazy: bool = False,
+    prediction_output: Optional[str] = None,
+) -> None:
+    """Evaluate a pipeline on a given dataset.
+
+    PIPELINE_PATH is the path to a pretrained pipeline (model.tar.gz file).
+    """
+    pipeline = Pipeline.from_pretrained(pipeline_path)
+    dataset = dataset_from_path(dataset)
+
+    pipeline.evaluate(
+        dataset,
+        batch_size=batch_size,
+        lazy=lazy,
+        predictions_output_file=prediction_output,
+        metrics_output_file=output,
+    )

--- a/src/biome/text/cli/serve.py
+++ b/src/biome/text/cli/serve.py
@@ -4,18 +4,28 @@ from click import Path
 from biome.text import Pipeline
 
 
-@click.command("serve", help="Serves pipeline as rest api service")
+@click.command()
 @click.argument("pipeline_path", type=Path(exists=True))
-@click.option("-p", "--port", "port", type=int, default=8888, show_default=True)
 @click.option(
-    "--predictions-dir",
-    "predictions_dir",
-    type=str,
-    default=None,
+    "--port",
+    "-p",
+    type=int,
+    default=8888,
     show_default=True,
+    help="Port on which to serve the REST API.",
+)
+@click.option(
+    "--predictions_dir",
+    "-pd",
+    type=click.Path(),
+    default=None,
     help="Path to log raw predictions from the service.",
 )
 def serve(pipeline_path: str, port: int, predictions_dir: str) -> None:
+    """Serves the pipeline predictions as a REST API
+
+    PIPELINE_PATH is the path to a pretrained pipeline (model.tar.gz file).
+    """
     pipeline = Pipeline.from_pretrained(pipeline_path)
 
     if predictions_dir:

--- a/src/biome/text/cli/train.py
+++ b/src/biome/text/cli/train.py
@@ -5,19 +5,50 @@ from typing import Optional
 import click
 from elasticsearch import Elasticsearch
 
-from biome.text import Pipeline, Dataset, TrainerConfiguration, VocabularyConfiguration
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import TrainerConfiguration
+from biome.text import VocabularyConfiguration
 from biome.text.helpers import yaml_to_dict
 
 
-@click.command("train", help="Train a pipeline")
-@click.argument("pipeline_path", type=click.Path(exists=True))
-@click.option("-o", "--output", "output", type=click.Path(), required=True)
-@click.option("--trainer", "trainer", type=click.Path(exists=True), required=True)
-@click.option("--training", "training", type=click.Path(exists=True), required=True)
-@click.option(
-    "--validation", "validation", type=click.Path(exists=True), required=False
+@click.command()
+@click.argument(
+    "pipeline_path",
+    type=click.Path(exists=True),
+    required=True,
 )
-@click.option("--test", "test", type=click.Path(exists=True), required=False)
+@click.option(
+    "--output",
+    "-o",
+    type=click.Path(),
+    required=True,
+    help="Path of the training output.",
+)
+@click.option(
+    "--trainer",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to the trainer configuration YAML file.",
+)
+@click.option(
+    "--training",
+    type=click.Path(exists=True),
+    required=True,
+    help="Path to the training data.",
+)
+@click.option(
+    "--validation",
+    type=click.Path(exists=True),
+    required=False,
+    help="Path to the validation data.",
+)
+@click.option(
+    "--test",
+    type=click.Path(exists=True),
+    required=False,
+    help="Path to the test data.",
+)
 def train(
     pipeline_path: str,
     output: str,
@@ -26,6 +57,11 @@ def train(
     validation: Optional[str] = None,
     test: Optional[str] = None,
 ) -> None:
+    """Train a pipeline.
+
+    PIPELINE_PATH is either the path to a pretrained pipeline (model.tar.gz file),
+    or the path to a pipeline configuration (YAML file).
+    """
     _, extension = os.path.splitext(pipeline_path)
     extension = extension[1:].lower()
     pipeline = (

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -520,7 +520,8 @@ class Pipeline:
         batch_size: int = 16,
         lazy: bool = False,
         predictions_output_file: Optional[str] = None,
-    ):
+        metrics_output_file: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Evaluates the pipeline on a given dataset
 
         Parameters
@@ -533,6 +534,8 @@ class Pipeline:
             If true, instances from the dataset are lazily loaded from disk, otherwise they are loaded into memory.
         predictions_output_file
             Optional path to write the predictions to.
+        metrics_output_file
+            Optional path to write the final metrics to.
 
         Returns
         -------
@@ -559,6 +562,7 @@ class Pipeline:
             data_loader,
             cuda_device=model_device,
             predictions_output_file=predictions_output_file,
+            output_file=metrics_output_file,
         )
 
     def save_vocabulary(self, directory: str) -> None:

--- a/tests/text/test_pipeline_evaluate.py
+++ b/tests/text/test_pipeline_evaluate.py
@@ -1,0 +1,50 @@
+import json
+
+import pytest
+
+from biome.text import Dataset
+from biome.text import Pipeline
+
+
+@pytest.fixture
+def dataset() -> Dataset:
+    data = {
+        "text": ["test", "this", "shaight", "good"],
+        "label": ["good", "good", "bad", "good"],
+    }
+    return Dataset.from_dict(data)
+
+
+@pytest.fixture
+def pipeline(dataset):
+    labels = dataset.unique("label")
+    return Pipeline.from_config(
+        {
+            "name": "test_pipeline_evaluate",
+            "head": {
+                "type": "TextClassification",
+                "labels": labels,
+            },
+        }
+    )
+
+
+def test_pipeline_evaluate(pipeline, dataset, tmp_path):
+    prediction_output_file = tmp_path / "prediction_output_file.json"
+    metrics = pipeline.evaluate(
+        dataset, predictions_output_file=str(prediction_output_file), batch_size=1
+    )
+
+    assert "loss" in metrics
+
+    predictions = []
+    with prediction_output_file.open() as file:
+        for line in file.readlines():
+            predictions.append(json.loads(line))
+
+    assert len(predictions) == 4
+    assert all(["loss" in prediction for prediction in predictions])
+
+    dataset.remove_columns_("label")
+    with pytest.raises(ValueError):
+        pipeline.evaluate(dataset)


### PR DESCRIPTION
This PR adds a `evaluate` method to our `Pipeline` reusing basically AllenNLP's evaluate function.

I am not sure anymore if we should use an evaluate method in our `explore` command, therefore i refrained from a more complex custom implementation.

For our UI we need several things that an "evaluation" does not necessarily provide:
- loss per instance (basically means batch_size = 1)
- attributes (from our `explain`)

On the other side, the metrics we get out of an evaluation are also not really interesting for the UI, since we calculate the metrics there on-the-fly applying the respective filters.

Additionally, now we use a "prediction cache" in the explore method that is not really compatible with an evaluate method.. 

@frascuchon Maybe we need another technical discussion about the explore functionality. For now, if we want to have the loss per instance, we can simply use the `predict` instead of the `predict_batch` method inside the explore, which includes a loss key when providing the label as well.