### PR TITLE
Refactor/revise dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
         install_requires=[
             "allennlp~=1.2.0",
             "spacy~=2.3.0",
-            "gevent~=1.4.0",
+            "gevent~=20.9.0",
             "flask~=1.1.2",
             "flask-cors~=3.0.8",
             "click~=7.1.0",

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ if __name__ == "__main__":
             "uvicorn~=0.11.0",
             "distributed~=2.17.0",
             "cachey~=0.2.0",
-            "pyarrow~=0.17.0",
             "ujson~=2.0.0",
             "pandas~=1.1.0",
             "xlrd~=1.2.0",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ import sys
 from typing import Tuple
 
 try:
-    from setuptools import setup, find_namespace_packages
+    from setuptools import find_namespace_packages
+    from setuptools import setup
 except ImportError as error:
     raise ImportError("Make sure you have setuptools >= 40.1.0 installed!") from error
 
@@ -84,7 +85,6 @@ if __name__ == "__main__":
             "uvicorn~=0.11.0",
             "distributed~=2.17.0",
             "cachey~=0.2.0",
-            "ujson~=2.0.0",
             "pandas~=1.1.0",
             "xlrd~=1.2.0",
             "flatdict~=4.0.0",
@@ -95,7 +95,7 @@ if __name__ == "__main__":
             "elasticsearch>=6.8.0,<7.5.0",
             "ray[tune]~=1.0.0",
             "datasets~=1.1.2",
-            "tqdm>=4.49.0"
+            "tqdm>=4.49.0",
         ],
         extras_require={
             "testing": [

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -44,12 +44,6 @@ from .modules.heads import TaskHead
 from .modules.heads import TaskHeadConfiguration
 from .training_results import TrainingResults
 
-try:
-    import ujson as json
-except ModuleNotFoundError:
-    import json
-
-
 logging.getLogger("allennlp").setLevel(logging.ERROR)
 logging.getLogger("elasticsearch").setLevel(logging.ERROR)
 

--- a/tests/text/modules/heads/classification/test_record_pair_classification.py
+++ b/tests/text/modules/heads/classification/test_record_pair_classification.py
@@ -1,8 +1,11 @@
 from typing import Dict
 
-import pandas as pd
 import pytest
-from biome.text import TrainerConfiguration, VocabularyConfiguration, Dataset, Pipeline
+
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import TrainerConfiguration
+from biome.text import VocabularyConfiguration
 
 
 @pytest.fixture

--- a/tests/text/modules/heads/classification/test_relation_classifier.py
+++ b/tests/text/modules/heads/classification/test_relation_classifier.py
@@ -1,8 +1,11 @@
 from typing import Dict
 
-import pandas as pd
 import pytest
-from biome.text import TrainerConfiguration, VocabularyConfiguration, Dataset, Pipeline
+
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import TrainerConfiguration
+from biome.text import VocabularyConfiguration
 
 
 @pytest.fixture

--- a/tests/text/test_dataset.py
+++ b/tests/text/test_dataset.py
@@ -1,15 +1,18 @@
-import os
 import time
 from pathlib import Path
 
 import pandas as pd
 import pytest
-from allennlp.data import AllennlpDataset, AllennlpLazyDataset, Instance
-from elasticsearch import Elasticsearch
-
-from biome.text import Dataset, Pipeline, explore
+from allennlp.data import AllennlpDataset
+from allennlp.data import AllennlpLazyDataset
+from allennlp.data import Instance
 from datasets.features import Features
 from datasets.features import Value
+from elasticsearch import Elasticsearch
+
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import explore
 
 
 @pytest.fixture(scope="class")

--- a/tests/text/test_pipeline_datasets.py
+++ b/tests/text/test_pipeline_datasets.py
@@ -1,23 +1,15 @@
 import logging
 import os
 
-import pandas as pd
 import pytest
-
-# fmt: off
 import torch
 
-from biome.text import (
-    Pipeline,
-    Dataset,
-    PipelineConfiguration,
-    TrainerConfiguration,
-    VocabularyConfiguration,
-)
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import PipelineConfiguration
+from biome.text import TrainerConfiguration
+from biome.text import VocabularyConfiguration
 from biome.text.modules.heads import TextClassificationConfiguration
-
-from allennlp.data import AllennlpDataset, Instance, AllennlpLazyDataset
-# fmt: on
 from tests.text.test_pipeline_model import TestHead
 
 
@@ -98,9 +90,7 @@ def test_training_from_pretrained_with_head_replace(
     assert copied.backbone.featurizer.tokenizer.config.max_nr_of_sentences == 3
 
 
-def test_training_with_logging(
-    pipeline: Pipeline, dataset: Dataset, tmp_path: str
-):
+def test_training_with_logging(pipeline: Pipeline, dataset: Dataset, tmp_path: str):
     training = dataset.to_instances(pipeline)
     pipeline.create_vocabulary(VocabularyConfiguration(sources=[training]))
 


### PR DESCRIPTION
This PR revises a bit the dependencies:
- pyarrow not needed anymore, comes with *datasets*
- ujson not used in our library, and makes trouble in windows
- an up to date version of gevent solves a RunTimeError for greenlet and also solves the Segmentation Fault when launching the UI via `explore.show` or `biome.text.ui.launch_ui`

It also includes a small import cleanup.