### PR TITLE
Automatic vocab creation

### DIFF
--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -52,7 +52,7 @@ class PipelineModel(allennlp.models.Model):
     This class represents pipeline model implementation for connect biome.text concepts with
     allennlp implementation details
 
-    This class manage the head + backbone encoder, keeping the allennlnlp Model lifecycle. This class
+    This class manages the head + backbone encoder, keeping the allennlnlp Model lifecycle. This class
     should be hidden to api users.
 
     Parameters
@@ -68,6 +68,8 @@ class PipelineModel(allennlp.models.Model):
         Name of the pipeline model
     head: TaskHead
         TaskHead of the pipeline model
+    vocab: Vocabulary
+        The vocabulary of the model
     file_path: Optional[str]
         File path to a serialized version of this pipeline model
     inputs: List[str]
@@ -79,7 +81,7 @@ class PipelineModel(allennlp.models.Model):
     PREDICTION_FILE_NAME = "predictions.json"
 
     def __init__(self, name: str, head: TaskHead):
-        allennlp.models.Model.__init__(self, head.backbone.vocab)
+        super().__init__(head.backbone.vocab)
 
         self.name = name
         self._head = None

--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -218,11 +218,11 @@ class PipelineModel(allennlp.models.Model):
         vocab
             The model's vocabulary will be extended with this one.
         """
+        # self.vocab and self._head.backbone.vocab point to the same vocab!
         self.vocab.extend_from_vocab(vocab)
-        self._head.backbone.vocab = self.vocab
 
         # updates the embedding matrices
-        self._head.backbone.on_vocab_update()
+        self.extend_embedder_vocab()
         # updates head specific things
         self._head.on_vocab_update()
 

--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -7,23 +7,39 @@ import warnings
 from functools import lru_cache
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union, cast
+from typing import Any
+from typing import Dict
+from typing import Iterable
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Type
+from typing import Union
+from typing import cast
 
 import allennlp
 import numpy
 import torch
 from allennlp.common import Params
 from allennlp.common.util import sanitize
-from allennlp.data import Field, Instance, Token, Vocabulary
-from allennlp.data.fields import ListField, MetadataField, SequenceLabelField, TextField
+from allennlp.data import Field
+from allennlp.data import Instance
+from allennlp.data import Token
+from allennlp.data import Vocabulary
+from allennlp.data.fields import ListField
+from allennlp.data.fields import MetadataField
+from allennlp.data.fields import SequenceLabelField
+from allennlp.data.fields import TextField
 from allennlp.models.archival import CONFIG_NAME
 
 from . import vocabulary
 from .backbone import ModelBackbone
 from .configuration import PipelineConfiguration
-from .errors import MissingArgumentError, WrongValueError
+from .errors import MissingArgumentError
+from .errors import WrongValueError
 from .helpers import split_signature_params_by_predicate
-from .modules.heads import TaskHead, TaskOutput
+from .modules.heads import TaskHead
+from .modules.heads import TaskOutput
 
 
 class _HashDict(dict):
@@ -95,9 +111,9 @@ class PipelineModel(allennlp.models.Model):
             self._head.featurize, lambda p: p.default == inspect.Parameter.empty
         )
         self._inputs = self._head.inputs() or [p.name for p in required]
-        self._output = (
-            [p.name for p in optional if p.name not in self._inputs] or [None]
-        )
+        self._output = [p.name for p in optional if p.name not in self._inputs] or [
+            None
+        ]
 
     @classmethod
     def from_params(
@@ -110,6 +126,19 @@ class PipelineModel(allennlp.models.Model):
         Load the model implementation from params. We build manually each component from config sections.
 
         The param keys matches exactly with keys in yaml configuration files
+
+        Parameters
+        ----------
+        params
+            The config key in these params is used to build the model components
+        vocab
+            The vocabulary for the model
+        **extras
+            Necessary for AllenNLP from_params machinery
+
+        Returns
+        -------
+        pipeline_model
         """
 
         config = params.pop("config")
@@ -457,7 +486,9 @@ class PipelineModel(allennlp.models.Model):
             if isinstance(field, SequenceLabelField):
                 return [
                     {"label": label, "token": token["token"]}
-                    for label, token in zip(field.labels, extract_field_tokens(field.sequence_field))
+                    for label, token in zip(
+                        field.labels, extract_field_tokens(field.sequence_field)
+                    )
                 ]
             if isinstance(field, MetadataField):
                 return []

--- a/src/biome/text/backbone.py
+++ b/src/biome/text/backbone.py
@@ -1,7 +1,8 @@
 from typing import Optional
 
 import torch
-from allennlp.data import TextFieldTensors, Vocabulary
+from allennlp.data import TextFieldTensors
+from allennlp.data import Vocabulary
 from allennlp.modules import TextFieldEmbedder
 from allennlp.modules.seq2seq_encoders import PassThroughEncoder
 
@@ -71,10 +72,3 @@ class ModelBackbone(torch.nn.Module):
         """
         embeddings = self.embedder(text, num_wrapping_dims=num_wrapping_dims)
         return self.encoder(embeddings, mask=mask)
-
-    def on_vocab_update(self):
-        """This method is called when a base model updates the vocabulary"""
-        # This loop applies only for embedding layer.
-        for model_path, module in self.named_modules():
-            if hasattr(module, "extend_vocab"):
-                module.extend_vocab(self.vocab)

--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -24,7 +24,8 @@ from elasticsearch.helpers import scan
 from spacy import __version__ as spacy__version__
 from tqdm.auto import tqdm
 
-from biome.text import __version__ as biome__version__, helpers
+from biome.text import __version__ as biome__version__
+from biome.text import helpers
 from biome.text.helpers import copy_sign_and_docs
 
 if TYPE_CHECKING:
@@ -430,11 +431,8 @@ class Dataset:
         hasher = Hasher()
         hasher.update(self.dataset._fingerprint)  # necessary evil ...
         hasher.update(vars(pipeline.backbone.tokenizer.config))
-        feature_config = pipeline.config.features
-        for feature_key in feature_config.keys:
-            feature: Features = getattr(feature_config, feature_key)
-            if feature:
-                hasher.update(feature.config["indexer"])
+        for feature in pipeline.config.features:
+            hasher.update(feature.config["indexer"])
         hasher.update(biome__version__)
         hasher.update(allennlp__version__)
         hasher.update(spacy__version__)

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -1,11 +1,15 @@
-from typing import Any, Dict, Optional
-from abc import ABC, abstractmethod
+from abc import ABC
+from abc import abstractmethod
+from typing import Any
+from typing import Dict
+from typing import Optional
 
 from biome.text.modules.configuration import Seq2VecEncoderConfiguration
 
 
 class Features(ABC):
     """All features used in the pipeline configuration inherit from this abstract class."""
+
     @property
     @abstractmethod
     def config(self):
@@ -66,7 +70,7 @@ class WordFeatures(Features):
                 "embedding_dim": self.embedding_dim,
                 "vocab_namespace": self.namespace,
                 "trainable": self.trainable,
-                **({"pretrained_file": self.weights_file} if self.weights_file else {}),
+                "pretrained_file": self.weights_file,
             },
         }
 

--- a/src/biome/text/hpo.py
+++ b/src/biome/text/hpo.py
@@ -241,16 +241,13 @@ class TuneExperiment(tune.Experiment):
         if is_wandb_installed_and_logged_in():
             train_loggers = [WandBLogger(project_name=config["name"])] + train_loggers
 
-        if pipeline.has_empty_vocab():
-            vocab_config = VocabularyConfiguration(sources=[train_ds, valid_ds])
-            pipeline.create_vocabulary(vocab_config)
-
         pipeline.train(
             output="training",
             training=train_ds,
             validation=valid_ds,
             trainer=trainer_config,
             loggers=train_loggers,
+            vocab_config=None if config["vocab_path"] else "default",
         )
 
     def __del__(self):

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -31,8 +31,8 @@ from biome.text.configuration import PipelineConfiguration
 from biome.text.configuration import TrainerConfiguration
 from biome.text.configuration import VocabularyConfiguration
 from biome.text.dataset import Dataset
-from biome.text.errors import EmptyVocabError
 from biome.text.dataset import InstancesDataset
+from biome.text.errors import EmptyVocabError
 from biome.text.features import TransformersFeatures
 from biome.text.helpers import update_method_signature
 
@@ -107,7 +107,10 @@ class Pipeline:
         if isinstance(config, dict):
             config = PipelineConfiguration.from_dict(config)
         model = cls._model_from_config(
-            config, vocab=vocabulary.load_vocabulary(vocab_path)
+            config,
+            vocab=vocabulary.load_vocabulary(vocab_path)
+            if vocab_path is not None
+            else None,
         )
 
         if not isinstance(model, PipelineModel):

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -19,6 +19,7 @@ import numpy
 import torch
 from allennlp.commands.find_learning_rate import search_learning_rate
 from allennlp.common import Params
+from allennlp.common.file_utils import is_url_or_existing_file
 from allennlp.data import AllennlpLazyDataset
 from allennlp.data import Vocabulary
 from allennlp.models import load_archive
@@ -34,6 +35,7 @@ from biome.text.dataset import Dataset
 from biome.text.dataset import InstancesDataset
 from biome.text.errors import EmptyVocabError
 from biome.text.features import TransformersFeatures
+from biome.text.features import WordFeatures
 from biome.text.helpers import update_method_signature
 
 from ._model import PipelineModel
@@ -106,13 +108,11 @@ class Pipeline:
         """
         if isinstance(config, dict):
             config = PipelineConfiguration.from_dict(config)
-        model = cls._model_from_config(
-            config,
-            vocab=vocabulary.load_vocabulary(vocab_path)
-            if vocab_path is not None
-            else None,
-        )
 
+        model = PipelineModel.from_params(
+            Params({"config": config}),
+            vocab=Vocabulary.from_files(vocab_path) if vocab_path is not None else None,
+        )
         if not isinstance(model, PipelineModel):
             raise TypeError(f"Cannot load model. Wrong format of {model}")
 
@@ -184,6 +184,7 @@ class Pipeline:
         find_lr_config: FindLRConfiguration,
         training_data: Union[Dataset, InstancesDataset],
         vocab_config: Optional[Union[VocabularyConfiguration, str]] = "default",
+        lazy: bool = False,
     ):
         """Returns a learning rate scan on the model.
 
@@ -200,10 +201,12 @@ class Pipeline:
         training_data
             The training data
         vocab_config
-            A `VocabularyConfiguration` to create/extend the pipeline's vocabulary for the the learning rate scan.
-            If 'default', we will use the default configuration
-            `VocabularyConfiguration(sources=[training, validation])`.
+            A `VocabularyConfiguration` to create/extend the pipeline's vocabulary if necessary.
+            If 'default' (str), we will use the default configuration
+            `VocabularyConfiguration(datasets=[training_data])`.
             If None, we will leave the pipeline's vocabulary untouched.
+        lazy
+            If true, dataset instances are lazily loaded from disk, otherwise they are loaded and kept in memory.
 
         Returns
         -------
@@ -213,30 +216,14 @@ class Pipeline:
         """
         from biome.text._helpers import create_trainer_for_finding_lr
 
-        # Creating/Setting the vocabulary
-        vocab = None
-        if vocab_config == "default":
-            vocab = self._extend_vocabulary(
-                self.backbone.vocab,
-                vocab_config=VocabularyConfiguration(sources=[training_data]),
-            )
-        elif isinstance(vocab_config, VocabularyConfiguration):
-            vocab = self._extend_vocabulary(
-                self.backbone.vocab, vocab_config=vocab_config
-            )
-
-        if vocab is not None:
-            self._set_vocab(vocab)
-
-        if vocabulary.is_empty(self._model.vocab, self.config.features.keys):
-            raise EmptyVocabError(
-                "You need a non-empty vocabulary for the learning rate scan!"
-            )
+        self._prepare_vocab(
+            vocab_config=vocab_config, training_data=training_data, lazy=lazy
+        )
 
         if isinstance(training_data, Dataset):
             training_data: AllennlpLazyDataset = training_data.to_instances(
                 pipeline=self,
-                lazy=True,
+                lazy=lazy,
             )
         training_data.index_with(self._model.vocab)
 
@@ -293,9 +280,8 @@ class Pipeline:
         test
             The test Dataset (optional)
         vocab_config
-            A `VocabularyConfiguration` to create/extend the pipeline's vocabulary for the training.
-            If 'default', we will use the default configuration
-            `VocabularyConfiguration(sources=[training, validation])`.
+            A `VocabularyConfiguration` to create/extend the pipeline's vocabulary if necessary.
+            If 'default' (str), we will use the default configuration `VocabularyConfiguration(sources=[training])`.
             If None, we will leave the pipeline's vocabulary untouched.
         loggers
             A list of loggers that execute a callback before the training, after each epoch,
@@ -321,32 +307,14 @@ class Pipeline:
 
             self.__configure_training_logging(output, quiet)
 
-            # Creating/Setting the vocabulary
-            vocab = None
-            if restore:
-                vocab = vocabulary.load_vocabulary(os.path.join(output, "vocabulary"))
-                if vocab_config is not None:
-                    self.__LOGGER.warning(
-                        "When restoring a training the 'vocab' argument is ignored!"
-                    )
-            elif vocab_config == "default":
-                sources = [training] + ([validation] if validation else [])
-                vocab = self._extend_vocabulary(
-                    self.backbone.vocab,
-                    vocab_config=VocabularyConfiguration(sources=sources),
-                )
-            elif isinstance(vocab_config, VocabularyConfiguration):
-                vocab = self._extend_vocabulary(
-                    self.backbone.vocab, vocab_config=vocab_config
-                )
-
-            if vocab is not None:
-                self._set_vocab(vocab)
-
-            if self.has_empty_vocab():
-                raise EmptyVocabError(
-                    "You need a non-empty vocabulary for the training!"
-                )
+            self._prepare_vocab(
+                vocabulary_folder=os.path.join(output, "vocabulary")
+                if restore
+                else None,
+                vocab_config=vocab_config,
+                training_data=training,
+                lazy=lazy,
+            )
 
             from ._helpers import PipelineTrainer
 
@@ -394,21 +362,72 @@ class Pipeline:
         finally:
             self.__restore_training_logging()
 
-    def _set_vocab(self, vocab: Vocabulary):
-        """
-        Updates pipeline vocabulary with passed one. This method will overwrite the current vocab.
+    def _prepare_vocab(
+        self,
+        vocabulary_folder: Optional[str] = None,
+        vocab_config: Optional[Union[str, VocabularyConfiguration]] = "default",
+        training_data: Optional[Dataset] = None,
+        lazy: bool = False,
+    ):
+        """Prepare and set the vocab for a training or learning rate scan.
 
         Parameters
         ----------
-        vocab:
-            The vocabulary to set
-
+        vocabulary_folder
+            If specified, load the vocab from this folder
+        vocab_config
+            A `VocabularyConfiguration` to create/extend the pipeline's vocabulary if necessary.
+            If 'default' (str), we will use the default configuration
+            `VocabularyConfiguration(sources=[training_data])`.
+            If None, we will leave the pipeline's vocabulary untouched.
+        training_data
+            The training data in case we need to construct the default config
+        lazy
+            If true, dataset instances are lazily loaded from disk, otherwise they are loaded and kept in memory.
         """
-        self._model.set_vocab(vocab)
+        # The transformers feature comes with its own vocab, no need to prepare anything if it is the only feature
+        if self.config.features.configured_namespaces == [
+            TransformersFeatures.namespace
+        ]:
+            return
+
+        # If the vocab is empty, we assume this is an untrained pipeline
+        # and we want to raise an error if the weights file is not found.
+        # Extending the vocab with a non-existent weights file only throws a warning.
+        try:
+            assert is_url_or_existing_file(Path(self.config.features.word.weights_file))
+        except AssertionError:
+            if vocabulary.is_empty(self.vocab, [WordFeatures.namespace]):
+                raise FileNotFoundError(
+                    f"Cannot find the weights file {self.config.features.word.weights_file}"
+                )
+        # no word feature, or weights_file is None
+        except (AttributeError, TypeError):
+            pass
+
+        if vocabulary_folder is not None:
+            self._model.extend_vocabulary(Vocabulary.from_files(vocabulary_folder))
+            vocab_config = None
+
+        vocab_config = (
+            VocabularyConfiguration(datasets=[training_data])
+            if vocab_config == "default"
+            else vocab_config
+        )
+        if vocab_config is not None:
+            vocab = vocab_config.build_vocab(pipeline=self, lazy=lazy)
+            self._model.extend_vocabulary(vocab)
+
+        if vocabulary.is_empty(self.vocab, self.config.features.configured_namespaces):
+            raise EmptyVocabError(
+                "All your features need a non-empty vocabulary for a training!"
+            )
 
     def copy(self) -> "Pipeline":
         """Returns a copy of the pipeline"""
-        model = self._model_from_config(self._config, vocab=self.backbone.vocab)
+        model = PipelineModel.from_params(
+            Params({"config": self.config}), vocab=copy.deepcopy(self.vocab)
+        )
         config = copy.deepcopy(self._config)
 
         pipeline_copy = Pipeline(model, config)
@@ -612,15 +631,6 @@ class Pipeline:
         finally:
             self._model.to(prior_device if prior_device >= 0 else "cpu")
 
-    def save_vocabulary(self, directory: str) -> None:
-        """Saves the pipeline's vocabulary in a directory
-
-        Parameters
-        ----------
-        directory: str
-        """
-        self._model.vocab.save_to_files(directory)
-
     def serve(self, port: int = 9998):
         """Launches a REST prediction service with the current model
 
@@ -676,6 +686,11 @@ class Pipeline:
         return self._model.head
 
     @property
+    def vocab(self) -> Vocabulary:
+        """Gets the pipeline vocabulary"""
+        return self._model.vocab
+
+    @property
     def config(self) -> PipelineConfiguration:
         """Gets the pipeline configuration"""
         return self._config
@@ -691,20 +706,20 @@ class Pipeline:
 
         At training time, this number can change when freezing/unfreezing certain parameter groups.
         """
-        if vocabulary.is_empty(self._model.vocab, self.config.features.keys):
+        if vocabulary.is_empty(self.vocab, self.config.features.configured_namespaces):
             self.__LOGGER.warning(
-                "Your vocabulary is still empty! "
-                "The number of trainable parameters usually depend on the size of your vocabulary."
+                "At least one vocabulary of your features is still empty! "
+                "The number of trainable parameters usually depends on the size of your vocabulary."
             )
         return sum(p.numel() for p in self._model.parameters() if p.requires_grad)
 
     @property
     def num_parameters(self) -> int:
         """Number of parameters present in the model."""
-        if vocabulary.is_empty(self._model.vocab, self.config.features.keys):
+        if vocabulary.is_empty(self.vocab, self.config.features.configured_namespaces):
             self.__LOGGER.warning(
-                "Your vocabulary is still empty! "
-                "The number of trainable parameters usually depend on the size of your vocabulary."
+                "At least one vocabulary of your features is still empty! "
+                "The number of trainable parameters usually depends on the size of your vocabulary."
             )
         return sum(p.numel() for p in self._model.parameters())
 
@@ -731,75 +746,6 @@ class Pipeline:
             self.__setattr__(
                 method.__name__, update_method_signature(new_signature, method)
             )
-
-    @staticmethod
-    def _model_from_config(
-        config: PipelineConfiguration,
-        vocab: Optional[Vocabulary] = None,
-        **extra_params,
-    ) -> PipelineModel:
-        """Creates a internal base model from a pipeline configuration
-
-        Parameters
-        ----------
-        config
-            Configuration of the pipeline
-        vocab
-            Vocabulary for the pipeline
-        **extra_params
-
-        Returns
-        -------
-        pipeline_model
-        """
-        return PipelineModel.from_params(
-            Params({"config": config}), vocab=vocab, **extra_params
-        )
-
-    def _extend_vocabulary(
-        self, vocab: Vocabulary, vocab_config: VocabularyConfiguration
-    ) -> Vocabulary:
-        """
-        Extends a data vocabulary from a given configuration.
-
-        The source vocabulary `vocab` won't be changed, instead a new vocabulary is created
-        that includes the source vocabulary `vocab` and a vocabulary created from `vocab_config`
-
-        Parameters
-        ----------
-        vocab
-            The source vocabulary
-        vocab_config
-            The vocab extension configuration
-
-        Returns
-        -------
-        extended_vocab
-            An extended `Vocabulary` using the provided configuration
-        """
-        datasets = []
-        for source in vocab_config.sources:
-            if isinstance(source, Dataset):
-                datasets.append(source.to_instances(pipeline=self))
-            else:
-                datasets.append(source)
-
-        instances_vocab = Vocabulary.from_instances(
-            instances=(instance for dataset in datasets for instance in dataset),
-            max_vocab_size=vocab_config.max_vocab_size,
-            min_count=vocab_config.min_count,
-            pretrained_files=vocab_config.pretrained_files,
-            only_include_pretrained_words=vocab_config.only_include_pretrained_words,
-            min_pretrained_embeddings=vocab_config.min_pretrained_embeddings,
-            tokens_to_add=vocab_config.tokens_to_add,
-        )
-        instances_vocab.extend_from_vocab(vocab)
-
-        return instances_vocab
-
-    def has_empty_vocab(self) -> bool:
-        """Determines if a pipeline has an empty vocab under configured features"""
-        return vocabulary.is_empty(self.backbone.vocab, self.config.features.keys)
 
     @staticmethod
     def _add_transformers_vocab_if_needed(model: PipelineModel):
@@ -837,15 +783,14 @@ class Pipeline:
         return PipelineConfiguration.from_params(config)
 
     def create_vocabulary(self, config: VocabularyConfiguration) -> None:
-        """Creates the vocabulary for the pipeline from scratch
+        """(DEPRECATED) Creates the vocabulary for the pipeline from scratch
 
         Parameters
         ----------
         config
             Specifies the sources of the vocabulary and how to extract it
         """
-        vocab = self._extend_vocabulary(vocabulary.create_empty_vocabulary(), config)
-        # TODO (dcfidalgo): This can maybe optimized, do we really need to create a new PipelineModel
-        #  and add again the transformers vocab?
-        self._model = self._model_from_config(self.config, vocab=vocab)
-        self._add_transformers_vocab_if_needed(self._model)
+        raise DeprecationWarning(
+            "The vocabulary is now created automatically and this method will be removed in a coming release. "
+            "You can directly pass on a `VocabularyConfiguration` to the `train` method or use its default."
+        )

--- a/src/biome/text/vocabulary.py
+++ b/src/biome/text/vocabulary.py
@@ -6,12 +6,15 @@
     Provides management actions such as extending the labels, setting new labels or creating an "empty" vocab.
 """
 import logging
-from typing import Dict, List, Optional
+from typing import Dict
+from typing import List
+from typing import Optional
 
 from allennlp.data import Vocabulary
 from allennlp.data.vocabulary import DEFAULT_NON_PADDED_NAMESPACES
 
 from biome.text.features import TransformersFeatures
+from biome.text.features import WordFeatures
 
 LABELS_NAMESPACE = "gold_labels"
 
@@ -94,8 +97,6 @@ def words_vocab_size(vocab: Vocabulary) -> int:
     size: `int`
         The vocabulary size for the words namespace
     """
-    from biome.text.features import WordFeatures
-
     return vocab.get_vocab_size(WordFeatures.namespace)
 
 
@@ -169,21 +170,20 @@ def is_empty(vocab: Vocabulary, namespaces: List[str]) -> bool:
 def load_vocabulary(vocab_path: str) -> Optional[Vocabulary]:
     """
     Loads a vocabulary from a path
+
     Parameters
     ----------
-    vocab_path: str
+    vocab_path
         The vocab folder path
 
     Returns
     -------
-    An operative `allennlp.data.Vocabulary`
+    vocabulary
     """
     try:
-        if not vocab_path:
-            return None
         return Vocabulary.from_files(vocab_path)
     except TypeError:
         return None
     except FileNotFoundError:
-        _LOGGER.warning("%s folder not found", vocab_path)
+        _LOGGER.warning(f"{vocab_path} folder not found")
         return None

--- a/src/biome/text/vocabulary.py
+++ b/src/biome/text/vocabulary.py
@@ -8,7 +8,6 @@
 import logging
 from typing import Dict
 from typing import List
-from typing import Optional
 
 from allennlp.data import Vocabulary
 from allennlp.data.vocabulary import DEFAULT_NON_PADDED_NAMESPACES
@@ -155,35 +154,19 @@ def create_empty_vocabulary() -> Vocabulary:
 
 
 def is_empty(vocab: Vocabulary, namespaces: List[str]) -> bool:
-    """
-    Checks if a vocab is empty respect to given namespaces
-
-    Returns True vocab size is 0 for all given namespaces
-    """
-    for namespaces in namespaces:
-        # We must drop the padding and out of vocab tokens = 2 tokens
-        if vocab.get_vocab_size(namespaces) > 2:
-            return False
-    return True
-
-
-def load_vocabulary(vocab_path: str) -> Optional[Vocabulary]:
-    """
-    Loads a vocabulary from a path
+    """Checks if at least one of the given namespaces has an empty vocab.
 
     Parameters
     ----------
-    vocab_path
-        The vocab folder path
+    vocab
+        The vocabulary
+    namespaces
+        Namespaces to check in the vocabulary
 
     Returns
     -------
-    vocabulary
+    True if one or more namespaces have an empty vocab
     """
-    try:
-        return Vocabulary.from_files(vocab_path)
-    except TypeError:
-        return None
-    except FileNotFoundError:
-        _LOGGER.warning(f"{vocab_path} folder not found")
-        return None
+    # If a namespace does not exist in the vocab, a default one is created on the fly with a padding and oov token
+    # We must drop the padding and out of vocab (oov) tokens -> 2 tokens
+    return any([vocab.get_vocab_size(namespace) < 3 for namespace in namespaces])

--- a/tests/text/conftest.py
+++ b/tests/text/conftest.py
@@ -1,0 +1,16 @@
+import pytest
+
+from biome.text._helpers import PipelineTrainer
+
+
+@pytest.fixture
+def deactivate_pipeline_trainer(monkeypatch):
+    def mock_init(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(PipelineTrainer, "__init__", mock_init)
+
+    def mock_train(*args, **kwargs):
+        return "mock_output_path", {"mock_metric": 0.0}
+
+    monkeypatch.setattr(PipelineTrainer, "train", mock_train)

--- a/tests/text/modules/heads/classification/test_record_pair_classification.py
+++ b/tests/text/modules/heads/classification/test_record_pair_classification.py
@@ -179,7 +179,6 @@ def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
     """Testing the correct working of prediction, vocab creating and training"""
     pipeline = Pipeline.from_config(pipeline_dict)
     pipeline.predict(record1={"first_name": "Hans"}, record2={"first_name": "Hansel"})
-    pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_dataset]))
 
     pipeline.train(
         output=str(tmp_path / "record_bimpm_experiment"),

--- a/tests/text/modules/heads/classification/test_relation_classifier.py
+++ b/tests/text/modules/heads/classification/test_relation_classifier.py
@@ -88,7 +88,6 @@ def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
             {"start": 16, "end": 22, "label": "SUBJECT", "text": "audits"},
         ],
     )
-    pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_dataset]))
 
     pipeline.train(
         output=str(tmp_path / "relation_classifier"),

--- a/tests/text/modules/heads/test_language_modelling.py
+++ b/tests/text/modules/heads/test_language_modelling.py
@@ -2,7 +2,11 @@ from typing import Dict
 
 import pandas as pd
 import pytest
-from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration, Dataset
+
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import TrainerConfiguration
+from biome.text import VocabularyConfiguration
 
 
 @pytest.fixture
@@ -67,7 +71,6 @@ def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
 
     pipeline = Pipeline.from_config(pipeline_dict)
     pipeline.predict(text="my name is juan")
-    pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_dataset]))
 
     pipeline.train(
         output=str(tmp_path / "lm"),

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -3,13 +3,11 @@ from typing import Dict
 import pandas as pd
 import pytest
 
-from biome.text import (
-    Pipeline,
-    VocabularyConfiguration,
-    TrainerConfiguration,
-    Dataset,
-    vocabulary,
-)
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import TrainerConfiguration
+from biome.text import VocabularyConfiguration
+from biome.text import vocabulary
 from biome.text.modules.heads import TaskOutput
 
 
@@ -90,8 +88,6 @@ def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
 
     assert pipeline.head.span_labels == ["NER"]
     assert pipeline.head.labels == ["B-NER", "I-NER", "U-NER", "L-NER", "O"]
-
-    pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_dataset]))
 
     pipeline.train(
         output=str(tmp_path / "ner_experiment"),

--- a/tests/text/test_features_transformers.py
+++ b/tests/text/test_features_transformers.py
@@ -3,7 +3,10 @@ from pathlib import Path
 import pytest
 from numpy.testing import assert_allclose
 
-from biome.text import Pipeline, TrainerConfiguration, VocabularyConfiguration, Dataset
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import TrainerConfiguration
+from biome.text import VocabularyConfiguration
 from biome.text.features import TransformersFeatures
 
 
@@ -29,7 +32,9 @@ def pipeline_dict() -> dict:
 
     pipeline_dict = {
         "name": "emotions_with_transformers",
-        "features": {"transformers": {"model_name": "sshleifer/tiny-distilbert-base-cased"}},
+        "features": {
+            "transformers": {"model_name": "sshleifer/tiny-distilbert-base-cased"}
+        },
         "head": {
             "type": "TextClassification",
             "labels": [
@@ -66,31 +71,6 @@ def trainer_dict() -> dict:
     }
 
 
-def test_transformers_vocab(train_dataset, pipeline_dict):
-    del pipeline_dict["head"]["pooler"]
-    pipeline_dict["features"].update(
-        {"word": {"embedding_dim": 16, "lowercase_tokens": True}}
-    )
-
-    pl = Pipeline.from_config(pipeline_dict)
-    vocab_config = VocabularyConfiguration(sources=[train_dataset])
-
-    print(pl.backbone.vocab)
-    # ds = Dataset.from_dict({"text": ["check this shit out"], "label": ["whatthefuck"]})
-    # pl.backbone.vocab.extend_from_instances(ds.to_instances(pl))
-    # print(pl.backbone.vocab)
-    # assert False
-    # vocab = pl._extend_vocabulary(pl.backbone.vocab, vocab_config)
-    # print(vocab)
-    # vocab = pl._extend_vocabulary(vocab, vocab_config)
-    # print(vocab)
-    ds = Dataset.from_dict({"text": ["check this shit out"], "label": ["whatthefuck"]})
-    vocab_config = VocabularyConfiguration(sources=[ds])
-    vocab = pl._extend_vocabulary(pl.backbone.vocab, vocab_config)
-    print(vocab)
-    assert False
-
-
 def test_pure_transformers(tmp_path, pipeline_dict, trainer_dict, train_dataset):
     """Testing a Transformer training process and a model load"""
 
@@ -121,19 +101,15 @@ def test_transformers_and_word(tmp_path, pipeline_dict, trainer_dict, train_data
     )
 
     pl = Pipeline.from_config(pipeline_dict)
+    pl.predict(text="test")
+
+    output = tmp_path / "output"
     trainer = TrainerConfiguration(**trainer_dict)
-    vocab = VocabularyConfiguration(sources=[train_dataset])
-    pl.create_vocabulary(vocab)
+    pl.train(output=str(output), trainer=trainer, training=train_dataset)
 
     # Check a fixed vocabulary size for the transformer and the word feature
     assert pl.backbone.vocab.get_vocab_size("transformers") == 28996
     assert pl.backbone.vocab.get_vocab_size("word") == 273
-
-    pl.predict(text="test")
-
-    output = tmp_path / "output"
-
-    pl.train(output=str(output), trainer=trainer, training=train_dataset)
 
     # Test vocab from a pretrained file
     pl = Pipeline.from_pretrained(str(output / "model.tar.gz"))

--- a/tests/text/test_hpo.py
+++ b/tests/text/test_hpo.py
@@ -2,7 +2,8 @@ import mlflow
 import pytest
 from ray import tune
 
-from biome.text import Pipeline, VocabularyConfiguration
+from biome.text import Pipeline
+from biome.text import VocabularyConfiguration
 from biome.text.dataset import Dataset
 from biome.text.hpo import TuneExperiment
 
@@ -64,14 +65,15 @@ def test_tune_exp_save_dataset_and_vocab(
     dataset, pipeline_config, trainer_config, monkeypatch
 ):
     pl = Pipeline.from_config(pipeline_config)
-    pl.create_vocabulary(VocabularyConfiguration(sources=[dataset]))
+    vocab = VocabularyConfiguration(datasets=[dataset]).build_vocab(pipeline=pl)
+    pl._model.extend_vocabulary(vocab)
 
     my_exp = TuneExperiment(
         pipeline_config=pipeline_config,
         trainer_config=trainer_config,
         train_dataset=dataset,
         valid_dataset=dataset,
-        vocab=pl.backbone.vocab,
+        vocab=vocab,
     )
 
     config = my_exp.config
@@ -85,7 +87,9 @@ def test_tune_exp_save_dataset_and_vocab(
 
 
 def test_tune_exp_custom_trainable(
-    dataset, pipeline_config, trainer_config,
+    dataset,
+    pipeline_config,
+    trainer_config,
 ):
     def my_trainable(config):
         pass

--- a/tests/text/test_hpo.py
+++ b/tests/text/test_hpo.py
@@ -66,7 +66,6 @@ def test_tune_exp_save_dataset_and_vocab(
 ):
     pl = Pipeline.from_config(pipeline_config)
     vocab = VocabularyConfiguration(datasets=[dataset]).build_vocab(pipeline=pl)
-    pl._model.extend_vocabulary(vocab)
 
     my_exp = TuneExperiment(
         pipeline_config=pipeline_config,
@@ -79,6 +78,7 @@ def test_tune_exp_save_dataset_and_vocab(
     config = my_exp.config
     pl2 = Pipeline.from_config(config["pipeline_config"], config["vocab_path"])
 
+    pl._model.extend_vocabulary(vocab)
     assert pl.backbone.vocab._index_to_token == pl2.backbone.vocab._index_to_token
     assert pl.backbone.vocab._token_to_index == pl2.backbone.vocab._token_to_index
 

--- a/tests/text/test_pipeline_copy.py
+++ b/tests/text/test_pipeline_copy.py
@@ -41,7 +41,6 @@ def test_copy(pipeline):
 def test_train_from_pretrained(pipeline, dataset, tmp_path):
     output_path = tmp_path / "test_train_from_pretrained_output"
     trainer_config = TrainerConfiguration(num_epochs=1, batch_size=2, cuda_device=-1)
-    pipeline.create_vocabulary(VocabularyConfiguration(sources=[dataset]))
     pipeline.train(output=str(output_path), training=dataset, trainer=trainer_config)
 
     prediction = pipeline.predict("a test")

--- a/tests/text/test_pipeline_find_lr.py
+++ b/tests/text/test_pipeline_find_lr.py
@@ -3,12 +3,11 @@ from pathlib import Path
 import pytest
 from numpy.testing import assert_allclose
 
-from biome.text import Pipeline, Dataset
-from biome.text.configuration import (
-    TrainerConfiguration,
-    FindLRConfiguration,
-    VocabularyConfiguration,
-)
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text.configuration import FindLRConfiguration
+from biome.text.configuration import TrainerConfiguration
+from biome.text.configuration import VocabularyConfiguration
 
 
 @pytest.fixture
@@ -96,8 +95,6 @@ def test_find_lr(train_data_source, pipeline_dict, trainer_config, find_lr_confi
 
     # Creation of pipeline and vocabulary
     pl = Pipeline.from_config(pipeline_dict)
-    vocab_config = VocabularyConfiguration(sources=[train_data_source])
-    pl.create_vocabulary(vocab_config)
 
     # Test prediction
     prev_prediction = pl.predict("test")
@@ -110,4 +107,6 @@ def test_find_lr(train_data_source, pipeline_dict, trainer_config, find_lr_confi
     )
 
     assert len(learning_rates) == len(losses) == 12
-    assert_allclose(prev_prediction["probabilities"], pl.predict("test")["probabilities"])
+    assert_allclose(
+        prev_prediction["probabilities"], pl.predict("test")["probabilities"]
+    )

--- a/tests/text/test_pipeline_vocab.py
+++ b/tests/text/test_pipeline_vocab.py
@@ -1,0 +1,137 @@
+import pytest
+
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import TrainerConfiguration
+from biome.text import VocabularyConfiguration
+from biome.text._helpers import PipelineTrainer
+from biome.text.errors import EmptyVocabError
+from biome.text.features import CharFeatures
+from biome.text.features import TransformersFeatures
+from biome.text.features import WordFeatures
+
+
+@pytest.fixture
+def pipeline():
+    config = {
+        "name": "vocab_test",
+        "features": {
+            "transformers": {"model_name": "sshleifer/tiny-distilbert-base-cased"},
+            "word": {"embedding_dim": 2},
+            "char": {
+                "embedding_dim": 2,
+                "dropout": 0.1,
+                "encoder": {
+                    "type": "gru",
+                    "hidden_size": 2,
+                    "num_layers": 1,
+                    "bidirectional": False,
+                },
+            },
+        },
+        "head": {
+            "type": "TextClassification",
+            "labels": ["good", "bad"],
+        },
+    }
+
+    return Pipeline.from_config(config)
+
+
+@pytest.fixture
+def train_dataset():
+    data = {"text": ["this is a test", "and another one"], "label": ["good", "bad"]}
+    return Dataset.from_dict(data)
+
+
+@pytest.fixture
+def valid_dataset():
+    data = {
+        "text": ["and what about the validation", "do not forget this one"],
+        "label": ["bad", "good"],
+    }
+    return Dataset.from_dict(data)
+
+
+def test_default_vocab(
+    pipeline, train_dataset, valid_dataset, tmp_path, deactivate_pipeline_trainer
+):
+    # Transformer vocab is added on pipeline creation
+    assert pipeline.vocab.get_vocab_size(TransformersFeatures.namespace) == 28996
+    # While word and char vocab should be empty (except for the oov and padding token)
+    assert pipeline.vocab.get_vocab_size(WordFeatures.namespace) == 2
+    assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 2
+
+    # Training should build a default vocab with only the training dataset
+    pipeline.train(
+        str(tmp_path / "vocab_test_output"),
+        training=train_dataset,
+    )
+    assert pipeline.vocab.get_vocab_size(WordFeatures.namespace) == 9
+    assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 12
+    assert pipeline.vocab.get_vocab_size(TransformersFeatures.namespace) == 28996
+
+    # Pretrained pipelines should extend the vocab by default
+    pipeline.train(
+        str(tmp_path / "vocab_test_output"),
+        training=valid_dataset,
+    )
+    assert pipeline.vocab.get_vocab_size(WordFeatures.namespace) == 16
+    assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 19
+    assert pipeline.vocab.get_vocab_size(TransformersFeatures.namespace) == 28996
+
+
+def test_specific_vocab_config(
+    pipeline, train_dataset, valid_dataset, deactivate_pipeline_trainer, tmp_path
+):
+    pipeline.train(
+        output=str(tmp_path / "vocab_test_output"),
+        training=valid_dataset,
+        vocab_config=VocabularyConfiguration(datasets=[train_dataset, valid_dataset]),
+    )
+    assert pipeline.vocab.get_vocab_size(WordFeatures.namespace) == 16
+    assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 19
+    assert pipeline.vocab.get_vocab_size(TransformersFeatures.namespace) == 28996
+
+
+def test_not_touching_vocab(
+    pipeline, train_dataset, valid_dataset, tmp_path, deactivate_pipeline_trainer
+):
+    # vocab_config=None leaves the pipeline's vocab empty from an unpretrained pipeline
+    with pytest.raises(EmptyVocabError):
+        pipeline.train(
+            output=str(tmp_path / "vocab_test_output"),
+            training=train_dataset,
+            vocab_config=None,
+        )
+
+    # vocab_config=None should not extend the vocab for a pretrained pipeline
+    pipeline.train(
+        output=str(tmp_path / "vocab_test_output"),
+        training=train_dataset,
+    )
+    assert pipeline.vocab.get_vocab_size(WordFeatures.namespace) == 9
+    assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 12
+    pipeline.train(
+        output=str(tmp_path / "vocab_test_output"),
+        training=valid_dataset,
+        vocab_config=None,
+    )
+    assert pipeline.vocab.get_vocab_size(WordFeatures.namespace) == 9
+    assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 12
+
+
+def test_restore_vocab(pipeline, train_dataset, tmp_path, deactivate_pipeline_trainer):
+    output = tmp_path / "test_restore_vocab_output"
+    pipeline.train(
+        output=str(output),
+        training=train_dataset,
+    )
+    assert pipeline.vocab.get_vocab_size(WordFeatures.namespace) == 9
+    assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 12
+
+    pipeline.vocab.save_to_files(str(output / "vocabulary"))
+
+    pipeline.train(output=str(output), training=valid_dataset, restore=True)
+    assert pipeline.vocab.get_vocab_size(WordFeatures.namespace) == 9
+    assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 12

--- a/tests/text/test_pipeline_with_custom_head.py
+++ b/tests/text/test_pipeline_with_custom_head.py
@@ -4,9 +4,13 @@ from tempfile import mkdtemp
 
 import pytest
 
-from biome.text import Pipeline, PipelineConfiguration, Dataset
-from biome.text.configuration import FeaturesConfiguration, VocabularyConfiguration
-from biome.text.modules.heads import TaskHeadConfiguration, TextClassification
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import PipelineConfiguration
+from biome.text.configuration import FeaturesConfiguration
+from biome.text.configuration import VocabularyConfiguration
+from biome.text.modules.heads import TaskHeadConfiguration
+from biome.text.modules.heads import TextClassification
 
 
 class MyCustomHead(TextClassification):
@@ -57,12 +61,11 @@ def test_load_pipeline_with_custom_head(training_dataset):
 
     # Training the model and saving it to output
     output = mkdtemp()
-    pipeline.create_vocabulary(VocabularyConfiguration(sources=[training_dataset]))
     pipeline.train(output=output, training=training_dataset)
 
     # Loading model from output
     trained_pl = Pipeline.from_pretrained(os.path.join(output, "model.tar.gz"))
     trained_pl.predict("Oh yeah")
 
-    #Asserting that the pipeline head is recognized as `MyCustomHead` instance after loading from a model.tar.gz
+    # Asserting that the pipeline head is recognized as `MyCustomHead` instance after loading from a model.tar.gz
     assert isinstance(trained_pl.head, MyCustomHead)

--- a/tests/text/test_pretrained_word_vectors.py
+++ b/tests/text/test_pretrained_word_vectors.py
@@ -1,0 +1,113 @@
+import logging
+from pathlib import Path
+from typing import cast
+
+import pytest
+import torch
+from torch.testing import assert_allclose
+
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import TrainerConfiguration
+
+
+@pytest.fixture
+def pretrained_word_vectors(tmp_path) -> Path:
+    file_path = tmp_path / "pretrained_word_vectors.txt"
+    file_path.write_text("2 2\ntest 0.66 0.33\nthis 0.25 0.75")
+
+    return file_path
+
+
+@pytest.fixture
+def dataset() -> Dataset:
+    data = {"text": ["test"], "label": ["good"]}
+    return Dataset.from_dict(data)
+
+
+@pytest.fixture
+def dataset2() -> Dataset:
+    data = {"text": ["this"], "label": ["good"]}
+    return Dataset.from_dict(data)
+
+
+@pytest.fixture
+def pipeline_config(pretrained_word_vectors) -> dict:
+    config = {
+        "name": "pretrained_word_vectors_test",
+        "features": {
+            "word": {
+                "embedding_dim": 2,
+                "weights_file": str(pretrained_word_vectors.absolute()),
+            }
+        },
+        "head": {"type": "TextClassification", "labels": ["good"]},
+    }
+    return config
+
+
+def test_create_pipeline_with_weights_file(pipeline_config, dataset, tmp_path):
+    pipeline = Pipeline.from_config(pipeline_config)
+
+    output = tmp_path / "pretrained_word_vector_output"
+    pipeline.train(
+        output=str(output),
+        training=dataset,
+        trainer=TrainerConfiguration(num_epochs=1),
+    )
+    instance = pipeline.head.featurize("test")
+    instance.index_fields(pipeline.vocab)
+
+    assert_allclose(
+        pipeline.backbone.embedder(instance.as_tensor_dict()["text"]),
+        torch.tensor([[0.66, 0.33]]),
+    )
+
+    # Loading a pretrained model without the weights file should work
+    Path(pipeline_config["features"]["word"]["weights_file"]).unlink()
+    assert isinstance(Pipeline.from_pretrained(str(output / "model.tar.gz")), Pipeline)
+
+
+def test_extending_vocab_with_weights_file(
+    pipeline_config, dataset, dataset2, deactivate_pipeline_trainer, caplog
+):
+    pipeline = Pipeline.from_config(pipeline_config)
+    # create vocab
+    pipeline.train(
+        output="dummy",
+        training=dataset,
+    )
+
+    # extending the vocab with the weights file available should apply the pretrained weights
+    pipeline.train(
+        output="dummy",
+        training=dataset2,
+    )
+    instance = pipeline.head.featurize("this")
+    instance.index_fields(pipeline.vocab)
+
+    assert_allclose(
+        pipeline.backbone.embedder(instance.as_tensor_dict()["text"]),
+        torch.tensor([[0.25, 0.75]]),
+    )
+
+    # extending the vocab with the weights file deleted should trigger a warning
+    logging.captureWarnings(True)
+    Path(pipeline_config["features"]["word"]["weights_file"]).unlink()
+    pipeline.train(
+        output="dummy",
+        training=Dataset.from_dict({"text": ["that"], "label": ["good"]}),
+    )
+    assert caplog.records[0].module == "embedding"
+    assert "cannot locate the pretrained_file" in caplog.records[0].message
+
+
+def test_raise_filenotfound_error(pipeline_config, deactivate_pipeline_trainer):
+    Path(pipeline_config["features"]["word"]["weights_file"]).unlink()
+    pipeline = Pipeline.from_config(pipeline_config)
+
+    with pytest.raises(FileNotFoundError):
+        pipeline.train(
+            output="dummy",
+            training=cast(Dataset, None),
+        )

--- a/tests/text/test_trainer.py
+++ b/tests/text/test_trainer.py
@@ -1,14 +1,15 @@
 import pytest
 import torch
-from biome.text import Dataset, Pipeline, TrainerConfiguration, VocabularyConfiguration
+
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import TrainerConfiguration
+from biome.text import VocabularyConfiguration
 
 
 @pytest.fixture(scope="module")
 def dataset() -> Dataset:
-    data = {
-        "text": ["Test", "this", "shaight", "!"],
-        "label": ["0", "1", "0", "0"]
-    }
+    data = {"text": ["Test", "this", "shaight", "!"], "label": ["0", "1", "0", "0"]}
 
     return Dataset.from_dict(data)
 
@@ -17,21 +18,18 @@ def dataset() -> Dataset:
 def pipeline(dataset) -> Pipeline:
     config = {
         "name": "test_trainer",
-        "features": {
-            "word": {"embedding_dim": 2}
-        },
-        "head": {
-            "type": "TextClassification",
-            "labels": list(set(dataset["label"]))
-        }
+        "features": {"word": {"embedding_dim": 2}},
+        "head": {"type": "TextClassification", "labels": list(set(dataset["label"]))},
     }
     pl = Pipeline.from_config(config)
-    pl.create_vocabulary(VocabularyConfiguration(sources=[dataset]))
+    pl.create_vocabulary(VocabularyConfiguration(datasets=[dataset]))
 
     return pl
 
 
-@pytest.mark.skipif(torch.cuda.device_count() < 1, reason="Using AMP requires a cuda device")
+@pytest.mark.skipif(
+    torch.cuda.device_count() < 1, reason="Using AMP requires a cuda device"
+)
 def test_use_amp(dataset, pipeline, tmp_path, capsys):
     trainer_config = TrainerConfiguration(
         num_epochs=1,
@@ -42,7 +40,7 @@ def test_use_amp(dataset, pipeline, tmp_path, capsys):
     pipeline.train(
         output=str(tmp_path / "test_use_amp_output"),
         training=dataset,
-        trainer=trainer_config
+        trainer=trainer_config,
     )
 
     captured = capsys.readouterr()

--- a/tests/text_classification_integration_test.py
+++ b/tests/text_classification_integration_test.py
@@ -6,7 +6,10 @@ import numpy as np
 import pytest
 import torch
 
-from biome.text import Pipeline, Dataset, TrainerConfiguration, VocabularyConfiguration
+from biome.text import Dataset
+from biome.text import Pipeline
+from biome.text import TrainerConfiguration
+from biome.text import VocabularyConfiguration
 from biome.text.configuration import CharFeatures
 from biome.text.configuration import WordFeatures
 
@@ -112,21 +115,24 @@ def test_text_classification(
         torch.cuda.manual_seed_all(4222)
 
     pl = Pipeline.from_config(pipeline_dict)
-    train_ds = train_valid_dataset[0].to_instances(pipeline=pl)
-    valid_ds = train_valid_dataset[1].to_instances(pipeline=pl)
+    train_ds = train_valid_dataset[0]
+    valid_ds = train_valid_dataset[1]
     trainer = TrainerConfiguration(**trainer_dict)
-    vocab = VocabularyConfiguration(sources=[train_ds], max_vocab_size={"word": 50})
-
-    pl.create_vocabulary(vocab)
-
-    assert pl._model.vocab.get_vocab_size(WordFeatures.namespace) == 52
-    assert pl._model.vocab.get_vocab_size(CharFeatures.namespace) == 83
+    vocab_config = VocabularyConfiguration(
+        datasets=[train_ds], max_vocab_size={"word": 50}
+    )
 
     output = tmp_path / "output"
 
     pl.train(
-        output=str(output), trainer=trainer, training=train_ds, validation=valid_ds
+        output=str(output),
+        trainer=trainer,
+        training=train_ds,
+        validation=valid_ds,
+        vocab_config=vocab_config,
     )
+    assert pl.vocab.get_vocab_size(WordFeatures.namespace) == 52
+    assert pl.vocab.get_vocab_size(CharFeatures.namespace) == 83
 
     assert pl.num_trainable_parameters == 22070
 
@@ -134,10 +140,10 @@ def test_text_classification(
         metrics = json.load(file)
 
     # It may fail in some systems
-    assert metrics["training_loss"] == pytest.approx(0.665, abs=0.003)
+    assert metrics["training_loss"] == pytest.approx(0.684, abs=0.003)
 
     # Test vocab from a pretrained file
     pl = Pipeline.from_pretrained(str(output / "model.tar.gz"))
 
-    assert pl._model.vocab.get_vocab_size(WordFeatures.namespace) == 52
-    assert pl._model.vocab.get_vocab_size(CharFeatures.namespace) == 83
+    assert pl.vocab.get_vocab_size(WordFeatures.namespace) == 52
+    assert pl.vocab.get_vocab_size(CharFeatures.namespace) == 83


### PR DESCRIPTION
This PR removes the necessity of creating a vocab manually before the training. 

So in the most common use case you just have to create the pipeline, maybe a trainer config and then call the train method:
```python
pipeline = Pipeline.from_config(...)
trainer_config = TrainerConfiguration(...)
pipeline.train(...)
```
If you want more control over the vocab creation, you can pass in a vocab config:
```python
pipeline.train(..., vocab_config=VocabularyConfiguration(...))
```
The default value of vocab_config is basically `VocabularyConfiguration(datasets=[training_dataset])`.
If you set `vocab_config=None` the pipeline's vocabulary will be kept untouched, but i am not 100% sure about its use cases.

Now we basically always use the `extend_vocabulary` / `extend_vocab` method to extend our vocabulary either from an empty vocab, or from a populated vocab in case of a pretrained pipeline. I think i found a bug when we were extending the vocab before: we extended the vocab by first creating the new vocab and then adding the source vocab, which destroyed the right mapping of the embedding matrix when we extended it. 

One of the trickier part was to include the case where we have a pretrained word vector file. But i managed to keep the information of the pretrained_file in the `model.tar.gz` and if the file still exists when loading the model, it will be used when extending the vocab. If it does not exist it will simply print out a warning. Actually this warning is also printed out when we did not specify any pretrained_file, but this is a bug in allennlp, i will open an issue on there side.

As a side note, if you do not want the training to modify the vocab or weights of your pipeline you can now do:
```python
pipeline.copy().train(...)
```

@frascuchon @dvsrepo Sorry for this monster PR, most of the changes are actually tests and doc strings, but maybe we can have a quick call and go over it together in case you have further questions. 
