### PR TITLE
Make tests gpu safe + bugifx in language_modelling head

### DIFF
--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -31,7 +31,6 @@ from biome.text.helpers import copy_sign_and_docs
 if TYPE_CHECKING:
     import pandas
 
-    from biome.text.features import Features
     from biome.text.pipeline import Pipeline
 
 InstancesDataset = Union[AllennlpDataset, AllennlpLazyDataset]

--- a/src/biome/text/modules/heads/language_modelling.py
+++ b/src/biome/text/modules/heads/language_modelling.py
@@ -124,10 +124,11 @@ class LanguageModelling(TaskHead):
             else:
                 average_loss = forward_loss / num_targets.float()
         else:
-            average_loss = torch.tensor(0.0).to(forward_targets.device)
+            average_loss = torch.tensor(0.0)
 
         for metric in self.metrics.values():
-            metric(average_loss)
+            # Perplexity needs the value to be on the cpu
+            metric(average_loss.to("cpu"))
 
         return TaskOutput(
             logits=None,

--- a/tests/text/test_pipeline_datasets.py
+++ b/tests/text/test_pipeline_datasets.py
@@ -64,7 +64,10 @@ def test_training_from_pretrained_with_head_replace(
     pipeline: Pipeline, dataset: Dataset, tmp_path: str
 ):
     configuration = TrainerConfiguration(
-        data_bucketing=True, batch_size=2, num_epochs=5
+        data_bucketing=True,
+        batch_size=2,
+        num_epochs=5,
+        cuda_device=-1,
     )
     output_dir = os.path.join(tmp_path, "output")
     pipeline.train(

--- a/tests/text/test_pipeline_find_lr.py
+++ b/tests/text/test_pipeline_find_lr.py
@@ -108,5 +108,5 @@ def test_find_lr(train_data_source, pipeline_dict, trainer_config, find_lr_confi
 
     assert len(learning_rates) == len(losses) == 12
     assert_allclose(
-        prev_prediction["probabilities"], pl.predict("test")["probabilities"]
+        prev_prediction["probabilities"], pl.predict("test")["probabilities"], rtol=1e-6
     )

--- a/tests/text/test_pretrained_word_vectors.py
+++ b/tests/text/test_pretrained_word_vectors.py
@@ -53,13 +53,13 @@ def test_create_pipeline_with_weights_file(pipeline_config, dataset, tmp_path):
     pipeline.train(
         output=str(output),
         training=dataset,
-        trainer=TrainerConfiguration(num_epochs=1),
+        trainer=TrainerConfiguration(num_epochs=1, cuda_device=-1),
     )
     instance = pipeline.head.featurize("test")
     instance.index_fields(pipeline.vocab)
 
     assert_allclose(
-        pipeline.backbone.embedder(instance.as_tensor_dict()["text"]),
+        pipeline.backbone.embedder(instance.as_tensor_dict()["text"], 0),
         torch.tensor([[0.66, 0.33]]),
     )
 

--- a/tests/text/test_trainer.py
+++ b/tests/text/test_trainer.py
@@ -22,7 +22,6 @@ def pipeline(dataset) -> Pipeline:
         "head": {"type": "TextClassification", "labels": list(set(dataset["label"]))},
     }
     pl = Pipeline.from_config(config)
-    pl.create_vocabulary(VocabularyConfiguration(datasets=[dataset]))
 
     return pl
 


### PR DESCRIPTION
Makes the tests pass when running on a machine with a cuda device + fixes a cuda related bug in the `LanguageModelling` head