### PR TITLE
feat(ds): select es document fields

### DIFF
--- a/tests/text/test_dataset.py
+++ b/tests/text/test_dataset.py
@@ -151,26 +151,30 @@ def test_from_elasticsearch(dataset, default_pipeline_config):
     es_index = explore.create(
         pipeline, dataset, explore_id="test_index", show_explore=False
     )
-    query = {"match_all": {}}
     es_client = Elasticsearch()
     __wait_for_index_creation__(es_client, es_index)
-    ds = Dataset.from_elasticsearch(es_client, index=es_index, query={"query": query})
+    ds = Dataset.from_elasticsearch(
+        es_client, index=es_index, query={"query": {"match_all": {}}}
+    )
 
     assert len(ds) == len(dataset)
-    for key in ["_id", "_index", "_type"]:
+    for key in ["_id", "_index", "_type", "_score"]:
         assert key in ds.column_names
 
-    query = {"exists": {"field": "not_found.field"}}
-
-    ds = Dataset.from_elasticsearch(es_client, index=es_index, query={"query": query})
+    ds = Dataset.from_elasticsearch(
+        es_client,
+        index=es_index,
+        query={"query": {"exists": {"field": "not_found.field"}}},
+    )
     assert len(ds) == 0
 
     ds = Dataset.from_elasticsearch(
-        es_client, index=es_index, source_fields=["label", "text"]
+        es_client, index=es_index, fields=["label", "text", "_id"]
     )
     assert len(ds) == len(dataset)
     assert "label" in ds.column_names
     assert "text" in ds.column_names
+    assert "_id" in ds.column_names
     assert "prediction" not in ds.column_names
 
 


### PR DESCRIPTION
This PR allow select elastic document fields (`id`,  `_type` and `_index`) as selectable fields for `Dataset.from_elasticsearch` dataset features