### PR TITLE
Allow transformers in Token/RelationClassification

### DIFF
--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -26,7 +26,9 @@ from .featurizer import InputFeaturizer
 from .helpers import sanitize_for_params
 from .helpers import save_dict_as_yaml
 from .modules.encoders import Encoder
+from .modules.heads.classification.relation_classification import RelationClassification
 from .modules.heads.task_head import TaskHeadConfiguration
+from .modules.heads.token_classification import TokenClassification
 from .tokenizer import Tokenizer
 from .tokenizer import TransformersTokenizer
 
@@ -220,10 +222,13 @@ class TokenizerConfiguration(FromParams):
         A list of token strings to the sequence before tokenized input text.
     end_tokens
         A list of token strings to the sequence after tokenized input text.
+    use_transformers
+        If true, we will use a transformers tokenizer from HuggingFace and disregard all other parameters above.
+        If you specify any of the above parameters you want to set this to false.
+        If None, we automatically choose a sensible value based on your feature and head configuration.
     transformers_kwargs
-        If specified, we will use a pretrained transformers tokenizer and disregard all other parameters above.
-        This dict will be passed directly on to allenNLP's `PretrainedTransformerTokenizer` and should at least include
-        a `model_name` key.
+        This dict is passed on to AllenNLP's `PretrainedTransformerTokenizer`.
+        If no `model_name` key is provided, we will infer one from the features configuration.
     """
 
     # note: It's important that it inherits from FromParas so that `Pipeline.from_pretrained()` works!
@@ -238,6 +243,7 @@ class TokenizerConfiguration(FromParams):
         remove_space_tokens: bool = True,
         start_tokens: Optional[List[str]] = None,
         end_tokens: Optional[List[str]] = None,
+        use_transformers: Optional[bool] = None,
         transformers_kwargs: Optional[Dict] = None,
     ):
         self.lang = lang
@@ -249,6 +255,7 @@ class TokenizerConfiguration(FromParams):
         self.end_tokens = end_tokens
         self.use_spacy_tokens = use_spacy_tokens
         self.remove_space_tokens = remove_space_tokens
+        self.use_transformers = use_transformers
         self.transformers_kwargs = transformers_kwargs
 
     def __eq__(self, other):
@@ -273,12 +280,14 @@ class PipelineConfiguration(FromParams):
     """
 
     __LOGGER = logging.getLogger(__name__)
+    # To be able to skip the configuration checks when testing
+    _SKIP_CHECKS = False
 
     def __init__(
         self,
         name: str,
         head: TaskHeadConfiguration,
-        features: FeaturesConfiguration = None,
+        features: Optional[FeaturesConfiguration] = None,
         tokenizer: Optional[TokenizerConfiguration] = None,
         encoder: Optional[Encoder] = None,
     ):
@@ -287,50 +296,58 @@ class PipelineConfiguration(FromParams):
         self.name = name
         self.head = head
         self.features = features or FeaturesConfiguration()
-        self.tokenizer_config = tokenizer or self._get_default_tokenizer()
+        self.tokenizer_config = tokenizer or TokenizerConfiguration()
 
-        # make sure we use the right tokenizer/indexer/embedder for the transformers feature
-        if self.tokenizer_config.transformers_kwargs:
-            if self.features.transformers.mismatched is None:
-                self.features.transformers.mismatched = False
+        # figure out if we need a transformers tokenizer
+        if self.tokenizer_config.use_transformers is None:
+            self._use_transformers_tokenizer_if_sensible()
+
+        # make sure we use the right indexer/embedder for the transformers feature
+        if self.tokenizer_config.use_transformers:
+            self.features.transformers.mismatched = False
             if self.tokenizer_config.transformers_kwargs.get("model_name") is None:
                 self.tokenizer_config.transformers_kwargs[
                     "model_name"
                 ] = self.features.transformers.model_name
-        else:
-            if self.features.transformers.mismatched is None:
-                self.features.transformers.mismatched = True
 
-        self._check_for_incompatible_configurations()
+        if not self._SKIP_CHECKS:
+            self._check_for_incompatible_configurations()
 
         self.encoder = encoder
 
-    def _get_default_tokenizer(self):
+    def _use_transformers_tokenizer_if_sensible(self):
         if (
+            # Only use word pieces if no word-based feature was chosen
             self.features.transformers is not None
             and self.features.word is None
             and self.features.char is None
+            # NER tags are usually given per word not per word pieces
+            and TokenClassification.__name__ not in self.head.config["type"]
+            and RelationClassification.__name__ not in self.head.config["type"]
         ):
-            return TokenizerConfiguration(
-                transformers_kwargs={
-                    "model_name": self.features.transformers.model_name
-                },
+            self.tokenizer_config.use_transformers = True
+            self.tokenizer_config.transformers_kwargs = (
+                self.tokenizer_config.transformers_kwargs
+                or {"model_name": self.features.transformers.model_name}
             )
-
-        return TokenizerConfiguration()
+        else:
+            self.tokenizer_config.use_transformers = False
 
     def _check_for_incompatible_configurations(self):
-        if self.tokenizer_config.transformers_kwargs:
+        if self.tokenizer_config.use_transformers:
             if self.features.word is not None or self.features.char is not None:
                 raise ConfigurationError(
                     "You are trying to use word or char features on subwords and possibly special tokens."
                     "This is not recommended!"
                 )
 
-            if "TokenClassification" in self.head.config["type"]:
+            if (
+                TokenClassification.__name__ in self.head.config["type"]
+                or RelationClassification.__name__ in self.head.config["type"]
+            ):
                 raise NotImplementedError(
-                    "You specified a transformers tokenizer, "
-                    "but the 'TokenClassification' head is still not capable of dealing with subword/special tokens."
+                    "You specified a transformers tokenizer, but the 'TokenClassification' and "
+                    "'RelationClassification' heads are still not capable of dealing with subword/special tokens."
                 )
 
             if (
@@ -413,7 +430,7 @@ class PipelineConfiguration(FromParams):
 
     def build_tokenizer(self) -> Tokenizer:
         """Build the pipeline tokenizer"""
-        if self.tokenizer_config.transformers_kwargs is not None:
+        if self.tokenizer_config.use_transformers:
             return TransformersTokenizer(self.tokenizer_config)
         return Tokenizer(self.tokenizer_config)
 

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -291,11 +291,15 @@ class PipelineConfiguration(FromParams):
 
         # make sure we use the right tokenizer/indexer/embedder for the transformers feature
         if self.tokenizer_config.transformers_kwargs:
-            self.features.transformers.is_mismatched = False
+            if self.features.transformers.mismatched is None:
+                self.features.transformers.mismatched = False
             if self.tokenizer_config.transformers_kwargs.get("model_name") is None:
                 self.tokenizer_config.transformers_kwargs[
                     "model_name"
                 ] = self.features.transformers.model_name
+        else:
+            if self.features.transformers.mismatched is None:
+                self.features.transformers.mismatched = True
 
         self._check_for_incompatible_configurations()
 

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -225,7 +225,7 @@ class TokenizerConfiguration(FromParams):
     use_transformers
         If true, we will use a transformers tokenizer from HuggingFace and disregard all other parameters above.
         If you specify any of the above parameters you want to set this to false.
-        If None, we automatically choose a sensible value based on your feature and head configuration.
+        If None, we automatically choose the right value based on your feature and head configuration.
     transformers_kwargs
         This dict is passed on to AllenNLP's `PretrainedTransformerTokenizer`.
         If no `model_name` key is provided, we will infer one from the features configuration.
@@ -256,7 +256,7 @@ class TokenizerConfiguration(FromParams):
         self.use_spacy_tokens = use_spacy_tokens
         self.remove_space_tokens = remove_space_tokens
         self.use_transformers = use_transformers
-        self.transformers_kwargs = transformers_kwargs
+        self.transformers_kwargs = transformers_kwargs or {}
 
     def __eq__(self, other):
         return all(a == b for a, b in zip(vars(self), vars(other)))

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -242,4 +242,5 @@ class TransformersFeatures(Features):
             "trainable": self.trainable,
             "max_length": self.max_length,
             "last_layer_only": self.last_layer_only,
+            "mismatched": self.mismatched,
         }

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -185,6 +185,13 @@ class TransformersFeatures(Features):
         When `True`, only the final layer of the pretrained transformer is taken
         for the embeddings. But if set to `False`, a scalar mix of all of the layers
         is used.
+    mismatched
+        Set this to True, if you are not using the corresponding transformers tokenizer. We then assume taht you are
+        using a tokenizer that splits the strings into words and will simply sum up the wordpiece vectors in a word
+        to pull out a single vector for each word.
+        If this is set to False, we assume you are using the corresponding transformers tokenizer
+        and we will provide vectors for each wordpiece.
+        By default this is set to None, and we will automatically choose the value based on your pipeline configuration.
     """
 
     namespace = "transformers"
@@ -195,11 +202,12 @@ class TransformersFeatures(Features):
         trainable: bool = False,
         max_length: Optional[int] = None,
         last_layer_only: bool = True,
+        mismatched: Optional[bool] = None,
     ):
         self.model_name = model_name
         self.trainable = trainable
         self.max_length = max_length
-        self.is_mismatched = True
+        self.mismatched = mismatched
         self.last_layer_only = last_layer_only
 
     @property
@@ -208,7 +216,7 @@ class TransformersFeatures(Features):
         config = {
             "indexer": {
                 "type": "pretrained_transformer_mismatched"
-                if self.is_mismatched
+                if self.mismatched
                 else "pretrained_transformer",
                 "model_name": self.model_name,
                 "namespace": self.namespace,
@@ -216,7 +224,7 @@ class TransformersFeatures(Features):
             },
             "embedder": {
                 "type": "pretrained_transformer_mismatched"
-                if self.is_mismatched
+                if self.mismatched
                 else "pretrained_transformer",
                 "model_name": self.model_name,
                 "train_parameters": self.trainable,

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -206,7 +206,7 @@ class TransformersFeatures(Features):
         self.trainable = trainable
         self.max_length = max_length
         self.last_layer_only = last_layer_only
-        self.mismatched = False
+        self.mismatched = True
 
     @property
     def config(self) -> Dict:

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -185,13 +185,12 @@ class TransformersFeatures(Features):
         When `True`, only the final layer of the pretrained transformer is taken
         for the embeddings. But if set to `False`, a scalar mix of all of the layers
         is used.
-    mismatched
-        Set this to True, if you are not using the corresponding transformers tokenizer. We then assume taht you are
-        using a tokenizer that splits the strings into words and will simply sum up the wordpiece vectors in a word
-        to pull out a single vector for each word.
-        If this is set to False, we assume you are using the corresponding transformers tokenizer
-        and we will provide vectors for each wordpiece.
-        By default this is set to None, and we will automatically choose the value based on your pipeline configuration.
+
+    Attributes
+    ----------
+    mismatched: bool (default: True)
+        If true, we will sum up the word-piece vectors in a word to pull out a single vector for each word.
+        If you use a transformers tokenizer, this is automatically set to False by the `PipelineConfiguration`.
     """
 
     namespace = "transformers"
@@ -202,13 +201,12 @@ class TransformersFeatures(Features):
         trainable: bool = False,
         max_length: Optional[int] = None,
         last_layer_only: bool = True,
-        mismatched: Optional[bool] = None,
     ):
         self.model_name = model_name
         self.trainable = trainable
         self.max_length = max_length
-        self.mismatched = mismatched
         self.last_layer_only = last_layer_only
+        self.mismatched = False
 
     @property
     def config(self) -> Dict:
@@ -242,5 +240,4 @@ class TransformersFeatures(Features):
             "trainable": self.trainable,
             "max_length": self.max_length,
             "last_layer_only": self.last_layer_only,
-            "mismatched": self.mismatched,
         }

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -20,6 +20,7 @@ from allennlp.nn.util import get_text_field_mask
 from allennlp.training.metrics import CategoricalAccuracy
 from allennlp.training.metrics import SpanBasedF1Measure
 from spacy.tokens.doc import Doc
+from spacy.vocab import Vocab
 
 from biome.text import vocabulary
 from biome.text.backbone import ModelBackbone
@@ -287,7 +288,7 @@ class TokenClassification(TaskHead):
             pre_tokenized = not isinstance(raw_text, str)
             if pre_tokenized:
                 # compose spacy doc from tokens
-                doc = Doc(self.backbone.tokenizer.nlp.vocab, words=raw_text)
+                doc = Doc(Vocab(), words=raw_text)
             else:
                 doc = self.backbone.tokenizer.nlp(raw_text)
 

--- a/tests/text/modules/heads/classification/test_relation_classifier.py
+++ b/tests/text/modules/heads/classification/test_relation_classifier.py
@@ -5,7 +5,6 @@ import pytest
 from biome.text import Dataset
 from biome.text import Pipeline
 from biome.text import TrainerConfiguration
-from biome.text import VocabularyConfiguration
 
 
 @pytest.fixture

--- a/tests/text/test_configuration.py
+++ b/tests/text/test_configuration.py
@@ -170,9 +170,7 @@ def test_pipeline_config(pipeline_yaml):
 
 def test_invalid_tokenizer_features_combination(transformers_pipeline_config):
     transformers_pipeline_config["features"].update({"word": {"embedding_dim": 2}})
-    transformers_pipeline_config["tokenizer"] = {
-        "transformers_kwargs": {"model_name": "sshleifer/tiny-distilroberta-base"}
-    }
+    transformers_pipeline_config["tokenizer"] = {"use_transformers": True}
 
     with pytest.raises(ConfigurationError):
         Pipeline.from_config(transformers_pipeline_config)
@@ -181,6 +179,7 @@ def test_invalid_tokenizer_features_combination(transformers_pipeline_config):
 def test_not_implemented_transformers_with_tokenclassification(
     transformers_pipeline_config,
 ):
+    transformers_pipeline_config["tokenizer"] = {"use_transformers": True}
     transformers_pipeline_config["head"] = {
         "type": "TokenClassification",
         "labels": ["NER"],

--- a/tests/text/test_pipeline_tokenizer.py
+++ b/tests/text/test_pipeline_tokenizer.py
@@ -30,7 +30,7 @@ def test_pipeline_transformers_tokenizer(pipeline_dict):
     assert pl.config.tokenizer_config.transformers_kwargs == {
         "model_name": "sshleifer/tiny-distilroberta-base"
     }
-    assert not pl.config.features.transformers.is_mismatched
+    assert pl.config.features.transformers.mismatched is False
     assert (
         type(pl.backbone.featurizer.indexer["transformers"])
         is PretrainedTransformerIndexer
@@ -45,7 +45,7 @@ def test_pipeline_default_tokenizer(pipeline_dict):
     pl = Pipeline.from_config(pipeline_dict)
 
     assert pl.config.tokenizer_config == TokenizerConfiguration()
-    assert pl.config.features.transformers.is_mismatched
+    assert pl.config.features.transformers.mismatched is True
     assert (
         type(pl.backbone.featurizer.indexer["transformers"])
         is PretrainedTransformerMismatchedIndexer


### PR DESCRIPTION
After the tests we did with @ignacioct, this PR enables transformers for the Token and RelationClassification head by using the mismatched feature of AllenNLP.
If you know what you are doing and are an expert you can now also skip the configuration checks. This allows you to easily perform advanced tests, for example using word pieces in the heads mentioned above.

```python
from biome.text.configuration import PipelineConfiguration
PipelineConfiguration._SKIP_CHECKS = True
``` 