### PR TITLE
Reactivate testpypi in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,14 +95,14 @@ jobs:
           activate-environment: biome
       - name: Build Package 🍟
         run: make dist
-#      - name: Publish Package to TestPyPI 🥪
-#        uses: pypa/gh-action-pypi-publish@master
-#        with:
-#          user: __token__
-#          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-#          repository_url: https://test.pypi.org/legacy/
-#      - name: Test Installing 🍿
-#        run: pip install --index-url https://test.pypi.org/simple --no-deps biome-text==${GITHUB_REF#refs/*/v}
+      - name: Publish Package to TestPyPI 🥪
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: Test Installing 🍿
+        run: pip install --index-url https://test.pypi.org/simple --no-deps biome-text==${GITHUB_REF#refs/*/v}
       - name: Publish Package to PyPI 🥩
         uses: pypa/gh-action-pypi-publish@master
         with:


### PR DESCRIPTION
Deactivated manually for the 2.0.0 release, since i screwed this up on the testpypi server.