### PR TITLE
Fix tutorial versioning and doc fonts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
+      - name: Set BIOME_TEXT_DOC_VERSION for Release 🥦
+        if: ${{ github.event_name == 'release' }}
+        run: echo BIOME_TEXT_DOC_VERSION=${{ github.event.release.tag_name }} >> $GITHUB_ENV
       - name: Checkout Code 🛎
         uses: actions/checkout@v2
       - name: Setup ElasticSearch 🔎
@@ -44,9 +47,6 @@ jobs:
         run: pre-commit run --all-files
       - name: Run Tests 📈
         run: make test
-      - name: Set BIOME_TEXT_DOC_VERSION for Release 🥦
-        if: ${{ github.event_name == 'release' }}
-        run: echo BIOME_TEXT_DOC_VERSION=${{ github.event.release.tag_name }} >> $GITHUB_ENV
       - name: Prepare Docs for Versioning 🥓
         working-directory: ./docs
         run: |
@@ -75,6 +75,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
+      - name: Set BIOME_TEXT_DOC_VERSION for Release 🥦
+        if: ${{ github.event_name == 'release' }}
+        run: echo BIOME_TEXT_DOC_VERSION=${{ github.event.release.tag_name }} >> $GITHUB_ENV
       - name: Checkout Code 🛎
         # Recommended and required by JamesIves/github-pages-deploy-action
         uses: actions/checkout@v2
@@ -86,9 +89,6 @@ jobs:
           name: docs_build_output
       - name: Extract Build Output 🍗
         run: tar -xzf docs_build_output.tar.gz
-      - name: Set BIOME_TEXT_DOC_VERSION for Release 🥦
-        if: ${{ github.event_name == 'release' }}
-        run: echo BIOME_TEXT_DOC_VERSION=${{ github.event.release.tag_name }} >> $GITHUB_ENV
       - name: Deploy Docs 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Set BIOME_TEXT_DOC_VERSION for Release 🥦
         if: ${{ github.event_name == 'release' }}
         run: echo BIOME_TEXT_DOC_VERSION=${{ github.event.release.tag_name }} >> $GITHUB_ENV
+      - name: Prepare Docs for Versioning 🥓
+        working-directory: ./docs
+        run: |
+          chmod +x ./prepare_versioned_build.sh
+          bash ./prepare_versioned_build.sh
       - name: Build Docs 📘
         # build and zip the docs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     name: Run Tests & Build Docs
     runs-on: ubuntu-latest
     env:
-      BIOME_TEXT_DOC_VERSION_PATH: /master/
+      BIOME_TEXT_DOC_VERSION: master
     # make sure commands run in a bash shell
     defaults:
       run:
@@ -44,10 +44,9 @@ jobs:
         run: pre-commit run --all-files
       - name: Run Tests 📈
         run: make test
-      - name: Set BIOME_TEXT_DOC_VERSION_PATH for Release 🥦
+      - name: Set BIOME_TEXT_DOC_VERSION for Release 🥦
         if: ${{ github.event_name == 'release' }}
-        # For tags $GITHUB_REF looks like refs/tags/<tag_name>
-        run: echo BIOME_TEXT_DOC_VERSION_PATH=/$(echo $GITHUB_REF | cut -d / -f 3)/ >> $GITHUB_ENV
+        run: echo BIOME_TEXT_DOC_VERSION=${{ github.event.release.tag_name }} >> $GITHUB_ENV
       - name: Build Docs 📘
         # build and zip the docs
         run: |
@@ -65,7 +64,7 @@ jobs:
     needs: tests_docs
     if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
     env:
-      BIOME_TEXT_DOC_VERSION_PATH: /master/
+      BIOME_TEXT_DOC_VERSION: master
     # make sure commands run in a bash shell
     defaults:
       run:
@@ -82,17 +81,16 @@ jobs:
           name: docs_build_output
       - name: Extract Build Output 🍗
         run: tar -xzf docs_build_output.tar.gz
-      - name: Set BIOME_TEXT_DOC_VERSION_PATH for Release 🥦
+      - name: Set BIOME_TEXT_DOC_VERSION for Release 🥦
         if: ${{ github.event_name == 'release' }}
-        # For tags $GITHUB_REF looks like refs/tags/<tag_name>
-        run: echo BIOME_TEXT_DOC_VERSION_PATH=/${{ github.event.release.tag_name }}/ >> $GITHUB_ENV
+        run: echo BIOME_TEXT_DOC_VERSION=${{ github.event.release.tag_name }} >> $GITHUB_ENV
       - name: Deploy Docs 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs/site # The folder the action should deploy.
-          TARGET_FOLDER: ${{ env.BIOME_TEXT_DOC_VERSION_PATH }}
+          TARGET_FOLDER: /${{ env.BIOME_TEXT_DOC_VERSION }}/
           CLEAN: true # Automatically remove deleted files from the deploy branch
       - name: Checkout gh-pages for Release 🛎
         if: ${{ github.event_name == 'release' }}
@@ -102,8 +100,8 @@ jobs:
       - name: Update Versions and Index for Release 🍗
         if: ${{ github.event_name == 'release' }}
         run: |
-          sed -i 's/master/master\n${{ github.event.release.tag_name }}/' versions.txt
-          sed -i 's/biome-text\/.*\//biome-text\/${{ github.event.release.tag_name }}\//' index.html
+          sed -i 's/master/master\n${{ env.BIOME_TEXT_DOC_VERSION }}/' versions.txt
+          sed -i 's/biome-text\/.*\//biome-text\/${{ env.BIOME_TEXT_DOC_VERSION }}\//' index.html
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add versions.txt index.html

--- a/docs/docs/.vuepress/config.js
+++ b/docs/docs/.vuepress/config.js
@@ -2,8 +2,10 @@ const path = require("path");
 const glob = require("glob");
 
 // The env variable is set in our GitHub Action CI when building the docs.
-// It should look like: `BIOME_TEXT_DOC_VERSION_PATH="/v2.0.0/"` or `BIOME_TEXT_DOC_VERSION_PATH="/master/"`
-const basePath = `/biome-text${process.env.BIOME_TEXT_DOC_VERSION_PATH || "/"}`
+// It must be the same as the release tag or 'master', that is e.g. "v2.0.0" or "v2.1.0rc1" or "master"
+const basePath = process.env.BIOME_TEXT_DOC_VERSION
+    ? `/biome-text/${process.env.BIOME_TEXT_DOC_VERSION}/`
+    : "/biome-text/"
 
 function getSidebarChildren(location, replacement) {
     if (!replacement) {

--- a/docs/docs/.vuepress/theme/styles/fonts.styl
+++ b/docs/docs/.vuepress/theme/styles/fonts.styl
@@ -2,18 +2,18 @@
   font-family: 'Basis Grotesque Pro'
   font-style: normal
   font-weight: normal
-  src: local('Basis Grotesque Pro'), url('/assets/fonts/BasisGrotesquePro-Regular.woff') format('woff')
+  src: local('Basis Grotesque Pro'), url('/biome-text/assets/fonts/BasisGrotesquePro-Regular.woff') format('woff')
 
 
 @font-face
   font-family: 'Basis Grotesque Pro Bold'
   font-style: normal
   font-weight: normal
-  src: local('Basis Grotesque Pro Bold'), url('/assets/fonts/BasisGrotesquePro-Bold.woff') format('woff')
+  src: local('Basis Grotesque Pro Bold'), url('/biome-text/assets/fonts/BasisGrotesquePro-Bold.woff') format('woff')
 
 
 @font-face
   font-family: 'Basis Grotesque Pro Light'
   font-style: normal
   font-weight: normal
-  src: local('Basis Grotesque Pro Light'), url('/assets/fonts/BasisGrotesquePro-Light.woff') format('woff')
+  src: local('Basis Grotesque Pro Light'), url('/biome-text/assets/fonts/BasisGrotesquePro-Light.woff') format('woff')

--- a/docs/docs/documentation/tutorials/1-Training_a_text_classifier.ipynb
+++ b/docs/docs/documentation/tutorials/1-Training_a_text_classifier.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "!pip install -U pip\n",
-    "!pip install -U biome-text\n",
+    "!pip install -U git+https://github.com/recognai/biome-text.git\n",
     "exit(0)  # Force restart of the runtime"
    ]
   },

--- a/docs/docs/documentation/tutorials/1-Training_a_text_classifier.ipynb
+++ b/docs/docs/documentation/tutorials/1-Training_a_text_classifier.ipynb
@@ -11,8 +11,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html\"><img class=\"icon\" src=\"https://www.recogn.ai/biome-text/assets/img/biome-isotype.svg\" width=24 /></a>\n",
-    "[View on recogn.ai](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html)\n",
+    "<a target=\"_blank\" href=\"https://www.recogn.ai/biome-text/master/documentation/tutorials/1-Training_a_text_classifier.html\"><img class=\"icon\" src=\"https://www.recogn.ai/biome-text/master/assets/img/biome-isotype.svg\" width=24 /></a>\n",
+    "[View on recogn.ai](https://www.recogn.ai/biome-text/master/documentation/tutorials/1-Training_a_text_classifier.html)\n",
     "\n",
     "<a target=\"_blank\" href=\"https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/1-Training_a_text_classifier.ipynb\"><img class=\"icon\" src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" width=24 /></a>\n",
     "[Run in Google Colab](https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/1-Training_a_text_classifier.ipynb)\n",
@@ -92,7 +92,7 @@
    "source": [
     "## Explore the training data\n",
     "\n",
-    "Let's take a look at the data we will use for training. For this we will use the [`Dataset`](https://www.recogn.ai/biome-text/api/biome/text/dataset.html#dataset) class that is a very thin wrapper around HuggingFace's awesome [datasets.Dataset](https://huggingface.co/docs/datasets/master/package_reference/main_classes.html#datasets.Dataset). \n",
+    "Let's take a look at the data we will use for training. For this we will use the [`Dataset`](https://www.recogn.ai/biome-text/master/api/biome/text/dataset.html#dataset) class that is a very thin wrapper around HuggingFace's awesome [datasets.Dataset](https://huggingface.co/docs/datasets/master/package_reference/main_classes.html#datasets.Dataset). \n",
     "We will download the data first to create `Dataset` instances.\n",
     "\n",
     "Apart from the training data we will also download an optional validation data set to estimate the generalization error."
@@ -273,7 +273,7 @@
    "source": [
     "::: tip Tip\n",
     "\n",
-    "The [TaskHead](https://www.recogn.ai/biome-text/api/biome/text/modules/heads/task_head.html#taskhead) of our model below will expect a *text* and a *label* column to be present in the `Dataset`. In our data set this is already the case, otherwise we would need to change or map the corresponding column names via `Dataset.rename_column_()` or `Dataset.map()`.\n",
+    "The [TaskHead](https://www.recogn.ai/biome-text/master/api/biome/text/modules/heads/task_head.html#taskhead) of our model below will expect a *text* and a *label* column to be present in the `Dataset`. In our data set this is already the case, otherwise we would need to change or map the corresponding column names via `Dataset.rename_column_()` or `Dataset.map()`.\n",
     "\n",
     ":::"
    ]
@@ -345,12 +345,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A typical [Pipeline](https://www.recogn.ai/biome-text/api/biome/text/pipeline.html#pipeline) consists of tokenizing the input, extracting features, applying a language encoding (optionally) and executing a task-specific head in the end.\n",
+    "A typical [Pipeline](https://www.recogn.ai/biome-text/master/api/biome/text/pipeline.html#pipeline) consists of tokenizing the input, extracting features, applying a language encoding (optionally) and executing a task-specific head in the end.\n",
     "\n",
     "After training a pipeline, you can use it to make predictions or explore the underlying model via the explore UI.\n",
     "\n",
     "As a first step we must define a configuration for our pipeline. \n",
-    "In this tutorial we will create a configuration dictionary and use the `Pipeline.from_config()` method to create our pipeline, but there are [other ways](https://www.recogn.ai/biome-text/api/biome/text/pipeline.html#pipeline).\n",
+    "In this tutorial we will create a configuration dictionary and use the `Pipeline.from_config()` method to create our pipeline, but there are [other ways](https://www.recogn.ai/biome-text/master/api/biome/text/pipeline.html#pipeline).\n",
     "\n",
     "A *biome.text* pipeline has the following main components:\n",
     "\n",
@@ -367,7 +367,7 @@
     "\n",
     "```\n",
     "\n",
-    "See the [Configuration section](https://www.recogn.ai/biome-text/documentation/user-guides/2-configuration.html) for a detailed description of how these main components can be configured.\n",
+    "See the [Configuration section](https://www.recogn.ai/biome-text/master/documentation/user-guides/2-configuration.html) for a detailed description of how these main components can be configured.\n",
     "\n",
     "Our complete configuration for this tutorial will be following:"
    ]
@@ -448,7 +448,7 @@
     "\n",
     "If you want to have more control over this step, you can define a `VocabularyConfiguration` and pass it to the `Pipeline.train()` method later on.\n",
     "In our business name classifier we only want to include words with a general meaning to our word feature vocabulary (like \"Computer\" or \"Autohaus\", for example), and want to exclude specific names that will not help to generally classify the kind of business.\n",
-    "This can be achieved by including only the most frequent words in our training set via the `min_count` argument. For a complete list of available arguments see the [VocabularyConfiguration API](https://www.recogn.ai/biome-text/api/biome/text/configuration.html#vocabularyconfiguration)."
+    "This can be achieved by including only the most frequent words in our training set via the `min_count` argument. For a complete list of available arguments see the [VocabularyConfiguration API](https://www.recogn.ai/biome-text/master/api/biome/text/configuration.html#vocabularyconfiguration)."
    ]
   },
   {
@@ -470,7 +470,7 @@
     "\n",
     "The default trainer has sensible defaults and should work alright for most of your cases.\n",
     "In this tutorial, however, we want to tune a bit the learning rate and limit the training time to three epochs only.\n",
-    "For a complete list of available arguments see the [TrainerConfiguration API](https://www.recogn.ai/biome-text/api/biome/text/configuration.html#trainerconfiguration).\n",
+    "For a complete list of available arguments see the [TrainerConfiguration API](https://www.recogn.ai/biome-text/master/api/biome/text/configuration.html#trainerconfiguration).\n",
     "\n",
     "::: tip Tip\n",
     "\n",
@@ -620,7 +620,7 @@
     "## Explore the model's predictions\n",
     "\n",
     "To check and understand the predictions of the model, we can use the *biome.text explore UI*.\n",
-    "Just calling the [explore.create](https://www.recogn.ai/biome-text/api/biome/text/explore.html#create) method will open the UI in the output of our cell.\n",
+    "Just calling the [explore.create](https://www.recogn.ai/biome-text/master/api/biome/text/explore.html#create) method will open the UI in the output of our cell.\n",
     "We will set the `explain` argument to true, which automatically visualizes the attribution of each token by means of [integrated gradients](https://arxiv.org/abs/1703.01365).\n"
    ]
   },

--- a/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb
+++ b/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "!pip install -U pip\n",
-    "!pip install -U biome-text\n",
+    "!pip install -U git+https://github.com/recognai/biome-text.git\n",
     "exit(0)  # Force restart of the runtime"
    ]
   },

--- a/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb
+++ b/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb
@@ -11,8 +11,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://www.recogn.ai/biome-text/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.html\"><img class=\"icon\" src=\"https://www.recogn.ai/biome-text/assets/img/biome-isotype.svg\" width=24 /></a>\n",
-    "[View on recogn.ai](https://www.recogn.ai/biome-text/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.html)\n",
+    "<a target=\"_blank\" href=\"https://www.recogn.ai/biome-text/master/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.html\"><img class=\"icon\" src=\"https://www.recogn.ai/biome-text/master/assets/img/biome-isotype.svg\" width=24 /></a>\n",
+    "[View on recogn.ai](https://www.recogn.ai/biome-text/master/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.html)\n",
     "    \n",
     "<a target=\"_blank\" href=\"https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb\"><img class=\"icon\" src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" width=24 /></a>\n",
     "[Run in Google Colab](https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb)\n",
@@ -135,7 +135,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [Dataset](https://www.recogn.ai/biome-text/api/biome/text/dataset.html#dataset) class is a very thin wrapper around HuggingFace's awesome [datasets.Dataset](https://huggingface.co/docs/datasets/master/package_reference/main_classes.html#datasets.Dataset).\n",
+    "The [Dataset](https://www.recogn.ai/biome-text/master/api/biome/text/dataset.html#dataset) class is a very thin wrapper around HuggingFace's awesome [datasets.Dataset](https://huggingface.co/docs/datasets/master/package_reference/main_classes.html#datasets.Dataset).\n",
     "Most of HuggingFace's `Dataset` API is exposed and you can checkout their nice [documentation](https://huggingface.co/docs/datasets/master/processing.html) on how to work with data in a `Dataset`. For example, let's quickly check the size of our training data and print the first 10 examples as a pandas DataFrame:"
    ]
   },
@@ -307,7 +307,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Since the the [TaskHead](https://www.recogn.ai/biome-text/api/biome/text/modules/heads/task_head.html#taskhead) of our model (the [TokenClassification](https://www.recogn.ai/biome-text/api/biome/text/modules/heads/token_classification.html#tokenclassification) head) expects a *text* and a *tags* column to be present in the Dataset, we need to rename the *labels* column:"
+    "Since the the [TaskHead](https://www.recogn.ai/biome-text/master/api/biome/text/modules/heads/task_head.html#taskhead) of our model (the [TokenClassification](https://www.recogn.ai/biome-text/master/api/biome/text/modules/heads/token_classification.html#tokenclassification) head) expects a *text* and a *tags* column to be present in the Dataset, we need to rename the *labels* column:"
    ]
   },
   {
@@ -326,7 +326,7 @@
    "source": [
     "::: tip Tip\n",
     "\n",
-    "The [TokenClassification](https://www.recogn.ai/biome-text/api/biome/text/modules/heads/token_classification.html#tokenclassification) head also supports a *entities* column instead of a *tags* column, in which case the entities have to be a list of python dictionaries with a `start`, `end` and `label` key that correspond to the char indexes and the label of the entity, respectively. \n",
+    "The [TokenClassification](https://www.recogn.ai/biome-text/master/api/biome/text/modules/heads/token_classification.html#tokenclassification) head also supports a *entities* column instead of a *tags* column, in which case the entities have to be a list of python dictionaries with a `start`, `end` and `label` key that correspond to the char indexes and the label of the entity, respectively. \n",
     "\n",
     ":::"
    ]
@@ -342,7 +342,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A typical [Pipeline](https://www.recogn.ai/biome-text/api/biome/text/pipeline.html#pipeline) consists of tokenizing the input, extracting features, applying a language encoding (optionally) and executing a task-specific head in the end.\n",
+    "A typical [Pipeline](https://www.recogn.ai/biome-text/master/api/biome/text/pipeline.html#pipeline) consists of tokenizing the input, extracting features, applying a language encoding (optionally) and executing a task-specific head in the end.\n",
     "After training a pipeline, you can use it to make predictions or explore the underlying model via the explore UI.\n",
     "\n",
     "A *biome.text* pipeline has the following main components:\n",
@@ -360,12 +360,12 @@
     "\n",
     "```\n",
     "\n",
-    "See the [Configuration section](https://www.recogn.ai/biome-text/documentation/user-guides/2-configuration.html) for a detailed description of how these main components can be configured.\n",
+    "See the [Configuration section](https://www.recogn.ai/biome-text/master/documentation/user-guides/2-configuration.html) for a detailed description of how these main components can be configured.\n",
     "\n",
-    "In this tutorial we will create a [PipelineConfiguration](https://www.recogn.ai/biome-text/api/biome/text/configuration.html#pipelineconfiguration) programmatically, and use it to initialize the [Pipeline](https://www.recogn.ai/biome-text/api/biome/text/pipeline.html#pipeline).\n",
-    "You can also create your pipelines by providing a [python dictionary](https://www.recogn.ai/biome-text/api/biome/text/pipeline.html#from-config) (see the text classification [tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html)), a YAML [configuration file](https://www.recogn.ai/biome-text/api/biome/text/pipeline.html#from-yaml) or a [pretrained model](https://www.recogn.ai/biome-text/api/biome/text/pipeline.html#from-pretrained).\n",
+    "In this tutorial we will create a [PipelineConfiguration](https://www.recogn.ai/biome-text/master/api/biome/text/configuration.html#pipelineconfiguration) programmatically, and use it to initialize the [Pipeline](https://www.recogn.ai/biome-text/master/api/biome/text/pipeline.html#pipeline).\n",
+    "You can also create your pipelines by providing a [python dictionary](https://www.recogn.ai/biome-text/master/api/biome/text/pipeline.html#from-config) (see the text classification [tutorial](https://www.recogn.ai/biome-text/master/documentation/tutorials/1-Training_a_text_classifier.html)), a YAML [configuration file](https://www.recogn.ai/biome-text/master/api/biome/text/pipeline.html#from-yaml) or a [pretrained model](https://www.recogn.ai/biome-text/master/api/biome/text/pipeline.html#from-pretrained).\n",
     "\n",
-    "A pipeline configuration is composed of several other [configuration classes](https://www.recogn.ai/biome-text/api/biome/text/configuration.html#biome-text-configuration), each one corresponding to one of the main components."
+    "A pipeline configuration is composed of several other [configuration classes](https://www.recogn.ai/biome-text/master/api/biome/text/configuration.html#biome-text-configuration), each one corresponding to one of the main components."
    ]
   },
   {
@@ -458,16 +458,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The final configuration belongs to our [TaskHead](https://www.recogn.ai/biome-text/api/biome/text/modules/heads/task_head.html#taskhead).\n",
+    "The final configuration belongs to our [TaskHead](https://www.recogn.ai/biome-text/master/api/biome/text/modules/heads/task_head.html#taskhead).\n",
     "It reflects the task our problem belongs to and can be easily exchanged with other types of heads keeping the same features and encoder.\n",
     "\n",
     "::: tip Tip\n",
     "\n",
-    "Exchanging the heads you can easily pretrain a model on a certain task, such as [language modelling](https://www.recogn.ai/biome-text/api/biome/text/modules/heads/language_modelling.html#languagemodelling), and use its pretrained features and encoder for training the model on another task.\n",
+    "Exchanging the heads you can easily pretrain a model on a certain task, such as [language modelling](https://www.recogn.ai/biome-text/master/api/biome/text/modules/heads/language_modelling.html#languagemodelling), and use its pretrained features and encoder for training the model on another task.\n",
     "\n",
     ":::\n",
     "\n",
-    "For our task we will use a [TokenClassification](https://www.recogn.ai/biome-text/api/biome/text/modules/heads/token_classification.html#tokenclassification) head that allows us to tag each token individually:"
+    "For our task we will use a [TokenClassification](https://www.recogn.ai/biome-text/master/api/biome/text/modules/heads/token_classification.html#tokenclassification) head that allows us to tag each token individually:"
    ]
   },
   {
@@ -500,7 +500,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can create a [PipelineConfiguration](https://www.recogn.ai/biome-text/api/biome/text/configuration.html#pipelineconfiguration) and finally initialize our [Pipeline](https://www.recogn.ai/biome-text/api/biome/text/pipeline.html#pipeline)."
+    "Now we can create a [PipelineConfiguration](https://www.recogn.ai/biome-text/master/api/biome/text/configuration.html#pipelineconfiguration) and finally initialize our [Pipeline](https://www.recogn.ai/biome-text/master/api/biome/text/pipeline.html#pipeline)."
    ]
   },
   {
@@ -542,7 +542,7 @@
     "\n",
     "Since we use pretrained word embeddings we will not only consider the training data, but also the validation data when creating the vocabulary. \n",
     "In addition, we get rid of the rarest words by adding the `min_count` argument and set it to 2 for the word feature vocabulary.\n",
-    "For a complete list of available arguments see the [VocabularyConfiguration API](https://www.recogn.ai/biome-text/api/biome/text/configuration.html#vocabularyconfiguration)."
+    "For a complete list of available arguments see the [VocabularyConfiguration API](https://www.recogn.ai/biome-text/master/api/biome/text/configuration.html#vocabularyconfiguration)."
    ]
   },
   {
@@ -573,12 +573,12 @@
     "- pipeline\n",
     "\n",
     "As `trainer` we will use the default configuration that has sensible values and works alright for our experiment.\n",
-    "[This tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html) shows you an example of how to configure a trainer. \n",
+    "[This tutorial](https://www.recogn.ai/biome-text/master/documentation/tutorials/1-Training_a_text_classifier.html) shows you an example of how to configure a trainer. \n",
     "\n",
     "::: tip Tip\n",
     "\n",
     "By default we will automatically use a CUDA device if available. If you want to tune the trainer or specifically not use a CUDA device, you can pass a `trainer = TrainerConfiguration(cuda_device=-1, ...)` to the `Pipeline.train()` method. \n",
-    "See the [TrainerConfiguration API](https://www.recogn.ai/biome-text/api/biome/text/configuration.html#trainerconfiguration) for a complete list of available configurations.\n",
+    "See the [TrainerConfiguration API](https://www.recogn.ai/biome-text/master/api/biome/text/configuration.html#trainerconfiguration) for a complete list of available configurations.\n",
     "\n",
     ":::\n",
     "\n",

--- a/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
+++ b/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "!pip install -U pip\n",
-    "!pip install -U biome-text\n",
+    "!pip install -U git+https://github.com/recognai/biome-text.git\n",
     "exit(0)  # Force restart of the runtime"
    ]
   },

--- a/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
+++ b/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
@@ -11,8 +11,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a target=\"_blank\" href=\"https://www.recogn.ai/biome-text/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.html\"><img class=\"icon\" src=\"https://www.recogn.ai/biome-text/assets/img/biome-isotype.svg\" width=24 /></a>\n",
-    "[View on recogn.ai](https://www.recogn.ai/biome-text/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.html)\n",
+    "<a target=\"_blank\" href=\"https://www.recogn.ai/biome-text/master/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.html\"><img class=\"icon\" src=\"https://www.recogn.ai/biome-text/master/assets/img/biome-isotype.svg\" width=24 /></a>\n",
+    "[View on recogn.ai](https://www.recogn.ai/biome-text/master/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.html)\n",
     "\n",
     "<a target=\"_blank\" href=\"https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb\"><img class=\"icon\" src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" width=24 /></a>\n",
     "[Run in Google Colab](https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb)\n",
@@ -79,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we will optimize the hyperparameters of the short-text classifier from [this tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html), hence we recommend to have a look at it first before going through this tutorial.\n",
+    "Here we will optimize the hyperparameters of the short-text classifier from [this tutorial](https://www.recogn.ai/biome-text/master/documentation/tutorials/1-Training_a_text_classifier.html), hence we recommend to have a look at it first before going through this tutorial.\n",
     "For the Hyper-Parameter Optimization (HPO) we rely on the awesome [Ray Tune library](https://docs.ray.io/en/latest/tune.html#tune-index).\n",
     "\n",
     "For a short introduction to HPO with Ray Tune you can have a look at this nice [talk](https://www.youtube.com/watch?v=VX7HvEoMrsA) by Richard Liaw. \n",
@@ -155,7 +155,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As mentioned in the introduction we will use the same pipeline configuration as used in the [base tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html)).\n",
+    "As mentioned in the introduction we will use the same pipeline configuration as used in the [base tutorial](https://www.recogn.ai/biome-text/master/documentation/tutorials/1-Training_a_text_classifier.html)).\n",
     "\n",
     "To perform a random hyperparameter search (as well as a grid search) we simply have to replace the parameters we want to optimize with methods from the [Random Distributions API](https://docs.ray.io/en/latest/tune/api_docs/search_space.html#random-distributions-api) or the [Grid Search API](https://docs.ray.io/en/latest/tune/api_docs/search_space.html#grid-search-api) in our configuration dictionaries.\n",
     "For a complete description of both APIs and how they interplay with each other, see the corresponding section in the [Ray Tune docs](https://docs.ray.io/en/latest/tune/api_docs/search_space.html). \n",
@@ -169,7 +169,7 @@
     "- and the learning rate\n",
     "\n",
     "For most of the parameters we will provide discrete values from which Tune will sample randomly, while for the dropout and learning rate we will provide a continuous linear and logarithmic range, respectively.\n",
-    "Since we want to directly compare the outcome of the optimization with the base configuration of the [underlying tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html), we will fix the number of epochs to 3.\n",
+    "Since we want to directly compare the outcome of the optimization with the base configuration of the [underlying tutorial](https://www.recogn.ai/biome-text/master/documentation/tutorials/1-Training_a_text_classifier.html), we will fix the number of epochs to 3.\n",
     "\n",
     "Not all of the parameters above are worth tuning, but we want to stress the flexibility that *Ray Tune* and *biome.text* offers you.\n",
     "\n",
@@ -405,7 +405,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Event though with 50 trials we visit just a small space of our possible configurations, we should have achieved an accuracy of ~0.94, an increase of roughly 3 points compared to the original configuration of the [base tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html).\n",
+    "Event though with 50 trials we visit just a small space of our possible configurations, we should have achieved an accuracy of ~0.94, an increase of roughly 3 points compared to the original configuration of the [base tutorial](https://www.recogn.ai/biome-text/master/documentation/tutorials/1-Training_a_text_classifier.html).\n",
     "\n",
     "In a real-life example, though, you probably should increase the number of epochs, since the validation loss in general seems to be decreasing further.\n",
     "\n",

--- a/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb
+++ b/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb
@@ -15,8 +15,8 @@
     "id": "qgfpoXsuVoso"
    },
    "source": [
-    "<a target=\"_blank\" href=\"https://www.recogn.ai/biome-text/documentation/tutorials/4-Using_Transformers_in_biome_text.html\"><img class=\"icon\" src=\"https://www.recogn.ai/biome-text/assets/img/biome-isotype.svg\" width=24 /></a>\n",
-    "[View on recogn.ai](https://www.recogn.ai/biome-text/documentation/tutorials/4-Using_Transformers_in_biome_text.html)\n",
+    "<a target=\"_blank\" href=\"https://www.recogn.ai/biome-text/master/documentation/tutorials/4-Using_Transformers_in_biome_text.html\"><img class=\"icon\" src=\"https://www.recogn.ai/biome-text/master/assets/img/biome-isotype.svg\" width=24 /></a>\n",
+    "[View on recogn.ai](https://www.recogn.ai/biome-text/master/documentation/tutorials/4-Using_Transformers_in_biome_text.html)\n",
     "    \n",
     "<a target=\"_blank\" href=\"https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb\"><img class=\"icon\" src=\"https://www.tensorflow.org/images/colab_logo_32px.png\" width=24 /></a>\n",
     "[Run in Google Colab](https://colab.research.google.com/github/recognai/biome-text/blob/master/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb)\n",
@@ -143,7 +143,7 @@
     "\n",
     "We preprocessed the data in a separate [notebook](https://drive.google.com/file/d/1zUSz81x15RH5mL5GoN7i7xqiNGEqclU0/view?usp=sharing) producing three csv files (train, validate and test datasets) that contain the title, the abstract and the category of the corresponding paper. \n",
     "\n",
-    "Our NLP task will be to classify the papers into the given categories based on the title and abstract. Below we download the preprocessed data and create our [Datasets](https://www.recogn.ai/biome-text/api/biome/text/dataset.html#dataset) with it."
+    "Our NLP task will be to classify the papers into the given categories based on the title and abstract. Below we download the preprocessed data and create our [Datasets](https://www.recogn.ai/biome-text/master/api/biome/text/dataset.html#dataset) with it."
    ]
   },
   {
@@ -319,7 +319,7 @@
     "id": "-UlEwBj4C6Zj"
    },
    "source": [
-    "Our pipeline defined in the next section, or to be more precise the `TaskClassification` task [head](https://www.recogn.ai/biome-text/documentation/basics.html#head), will expect a *text* and *label* column to be present in our data.\n",
+    "Our pipeline defined in the next section, or to be more precise the `TaskClassification` task [head](https://www.recogn.ai/biome-text/master/documentation/basics.html#head), will expect a *text* and *label* column to be present in our data.\n",
     "Therefore, we need to map our input to these two columns:"
    ]
   },
@@ -350,7 +350,7 @@
    "source": [
     "## Configuring and training the pipeline\n",
     "\n",
-    "As we have seen in [previous tutorials](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html#explore-the-training-data), a *biome.text* [`Pipeline`](https://www.recogn.ai/biome-text/documentation/basics.html#pipeline) consists of tokenizing the input, extracting text features, applying a language encoding (optionally) and executing a task-specific head in the end. In *biome.text* the pre-trained transformers by Hugging Face are treated as a text feature, just like the *word* and *char* feature.\n",
+    "As we have seen in [previous tutorials](https://www.recogn.ai/biome-text/master/documentation/tutorials/1-Training_a_text_classifier.html#explore-the-training-data), a *biome.text* [`Pipeline`](https://www.recogn.ai/biome-text/master/documentation/basics.html#pipeline) consists of tokenizing the input, extracting text features, applying a language encoding (optionally) and executing a task-specific head in the end. In *biome.text* the pre-trained transformers by Hugging Face are treated as a text feature, just like the *word* and *char* feature.\n",
     "\n",
     "In this section we will configure and train 3 different pipelines to showcase the usage of transformers in *biome.text*."
    ]
@@ -751,7 +751,7 @@
    "source": [
     "## Optimizing the trainer configuration\n",
     "\n",
-    "As described in the [HPO tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.html#imports), *biome.text* relies on the [Ray Tune library](https://docs.ray.io/en/latest/tune.html#tune-index) to perform hyperparameter optimization. \n",
+    "As described in the [HPO tutorial](https://www.recogn.ai/biome-text/master/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.html#imports), *biome.text* relies on the [Ray Tune library](https://docs.ray.io/en/latest/tune.html#tune-index) to perform hyperparameter optimization. \n",
     "We recommend to go through that tutorial first, as we will be skipping most of the implementation details here."
    ]
   },

--- a/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb
+++ b/docs/docs/documentation/tutorials/4-Using_Transformers_in_biome_text.ipynb
@@ -43,7 +43,7 @@
    "outputs": [],
    "source": [
     "!pip install -U pip\n",
-    "!pip install -U biome-text\n",
+    "!pip install -U git+https://github.com/recognai/biome-text.git\n",
     "exit(0)  # Force restart of the runtime"
    ]
   },

--- a/docs/prepare_versioned_build.sh
+++ b/docs/prepare_versioned_build.sh
@@ -23,7 +23,8 @@ fi
 echo " - Modifying tutorials ..."
 
 modified=$(find ./docs/documentation/tutorials -maxdepth 1 -name "*.ipynb" \
-  -exec sed -i -e "s|/biome-text/master/|/biome-text/$BIOME_TEXT_DOC_VERSION/|g" \
+  -exec sed -i -e "s|pip install -U git+https://github.com/recognai/biome-text.git|pip install -U biome-text|g" \
+    -e "s|/biome-text/master/|/biome-text/$BIOME_TEXT_DOC_VERSION/|g" \
     -e "s|/biome-text/blob/master/|/biome-text/blob/$BIOME_TEXT_DOC_VERSION/|g" {} \; \
   -exec echo {} \; | wc -l)
 if [ "$modified" -eq 0 ]; then

--- a/docs/prepare_versioned_build.sh
+++ b/docs/prepare_versioned_build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+print_help(){
+  echo "Usage: bash" "$0"
+  echo ""
+  echo "  Small bash script to prepare the docs for a _versioned_ build."
+  echo ""
+  echo "  The environment variable BIOME_TEXT_DOC_VERSION must be set!"
+  echo "  This env variable must match the release tag (for a new release) or 'master'."
+}
+
+if [ "$1" == "--help" ] || [ "$1" == "-h" ]; then
+    print_help
+    exit 0
+fi
+
+if [ -z "$BIOME_TEXT_DOC_VERSION" ]; then
+  echo "ERROR: BIOME_TEXT_DOC_VERSION not set!"
+  print_help
+  exit 1
+fi
+
+echo " - Modifying tutorials ..."
+
+modified=$(find ./docs/documentation/tutorials -maxdepth 1 -name "*.ipynb" \
+  -exec sed -i -e "s|/biome-text/master/|/biome-text/$BIOME_TEXT_DOC_VERSION/|g" \
+    -e "s|/biome-text/blob/master/|/biome-text/blob/$BIOME_TEXT_DOC_VERSION/|g" {} \; \
+  -exec echo {} \; | wc -l)
+if [ "$modified" -eq 0 ]; then
+  echo "ERROR: No tutorials modified!"
+  exit 1
+fi
+
+echo " - Modifying font urls  ..."
+
+if ! sed -i "s|/biome-text/|/biome-text/$BIOME_TEXT_DOC_VERSION/|g" ./docs/.vuepress/theme/styles/fonts.styl; then
+  echo "ERROR: Could not modify 'fonts.styl'!"
+  exit 1
+fi
+
+echo " - Done!"
+
+exit 0


### PR DESCRIPTION
This is hopefully the final working solution for versioning our docs, including:
 - correct links in the versioned tutorials
 - fix font paths in all versions

It is basically all managed via the BIOME_TEXT_DOC_VERSION env variable and a small helper script in `docs/prepare_versioned_build.sh`. Check out our GitHub Action CI to see how to build and deploy a versioned version of our docs.