### PR TITLE
Log wandb data to `.wandb`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 import glob
 
-from packaging import version
 from pip import __version__ as pip_version
+from pkg_resources import parse_version
 from setuptools import setup
 
 try:
@@ -16,7 +16,7 @@ REQUIRED_PIP_VERSION = "20.3.0"
 
 
 if __name__ == "__main__":
-    if version.parse(pip_version) <= version.parse(REQUIRED_PIP_VERSION):
+    if parse_version(pip_version) <= parse_version(REQUIRED_PIP_VERSION):
         raise OSError(
             f"Minimal required pip version is {REQUIRED_PIP_VERSION}, found: {pip_version}\n"
             "Please upgrade pip: pip install --upgrade pip"
@@ -52,7 +52,6 @@ if __name__ == "__main__":
             "ipywidgets~=7.5.1",
             "lxml~=4.6.2",
             "mlflow~=1.9.0",
-            "packaging",
             "pandas~=1.1.0",
             "ray[tune]~=1.0.0",
             "s3fs~=0.4.0",

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import glob
-import os
+
+from packaging import version
+from pip import __version__ as pip_version
+from setuptools import setup
 
 try:
     from setuptools import find_namespace_packages
-    from setuptools import setup
 except ImportError as error:
     raise ImportError("Make sure you have setuptools >= 40.1.0 installed!") from error
-
-from pip import __version__ as pip_version
 
 # We require a fairly new version to make use of the new dependency resolver!
 REQUIRED_PIP_VERSION = "20.3.0"
 
 
-def check_pip_version():
-    def version2int(version: str) -> int:
-        version_fractions = [f"{int(n):02d}" for n in version.split(".")]
-        return int("".join(version_fractions))
-
-    if version2int(pip_version) < version2int(REQUIRED_PIP_VERSION):
+if __name__ == "__main__":
+    if version.parse(pip_version) <= version.parse(REQUIRED_PIP_VERSION):
         raise OSError(
             f"Minimal required pip version is {REQUIRED_PIP_VERSION}, found: {pip_version}\n"
             "Please upgrade pip: pip install --upgrade pip"
         )
-
-
-if __name__ == "__main__":
-    check_pip_version()
 
     setup(
         name="biome-text",
@@ -45,28 +37,29 @@ if __name__ == "__main__":
         package_dir={"": "src"},
         install_requires=[
             "allennlp~=1.3.0",
-            "spacy~=2.3.0",
-            "gevent~=20.9.0",
+            "beautifulsoup4~=4.9.0",
+            "cachey~=0.2.0",
+            "captum~=0.2.0",
+            "click~=7.1.0",
+            "datasets~=1.1.2",
+            "distributed~=2.17.0",
+            "elasticsearch>=6.8.0,<7.5.0",
+            "fastapi~=0.55.0",
             "flask~=1.1.2",
             "flask-cors~=3.0.8",
-            "click~=7.1.0",
-            "beautifulsoup4~=4.9.0",
-            "lxml~=4.6.2",
-            "fastapi~=0.55.0",
-            "uvicorn~=0.11.0",
-            "distributed~=2.17.0",
-            "cachey~=0.2.0",
-            "pandas~=1.1.0",
-            "xlrd~=1.2.0",
             "flatdict~=4.0.0",
-            "s3fs~=0.4.0",
-            "captum~=0.2.0",
+            "gevent~=20.9.0",
             "ipywidgets~=7.5.1",
+            "lxml~=4.6.2",
             "mlflow~=1.9.0",
-            "elasticsearch>=6.8.0,<7.5.0",
+            "packaging",
+            "pandas~=1.1.0",
             "ray[tune]~=1.0.0",
-            "datasets~=1.1.2",
+            "s3fs~=0.4.0",
+            "spacy~=2.3.0",
             "tqdm>=4.49.0",
+            "uvicorn~=0.11.0",
+            "xlrd~=1.2.0",
         ],
         extras_require={
             "dev": [
@@ -75,6 +68,7 @@ if __name__ == "__main__":
                 "pytest-cov>=2.10.0",
                 "pytest-pylint>=0.14.0",
                 "pytest-notebook~=0.6.0",
+                "wandb>=0.10.12",
                 # documentation
                 "pdoc3~=0.8.1",
                 # development

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -19,9 +19,9 @@ from biome.text.training_results import TrainingResults
 _HAS_WANDB = False
 try:
     import wandb
-    from packaging import version
+    from pkg_resources import parse_version
 
-    assert version.parse(wandb.__version__) >= version.parse("0.10.12")
+    assert parse_version(wandb.__version__) >= parse_version("0.10.12")
 except ImportError:
     pass
 except AssertionError:

--- a/tests/text/test_trainer.py
+++ b/tests/text/test_trainer.py
@@ -4,7 +4,6 @@ import torch
 from biome.text import Dataset
 from biome.text import Pipeline
 from biome.text import TrainerConfiguration
-from biome.text import VocabularyConfiguration
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
This PR solves issues if you do not have wandb installed but have a folder with the same name. We encountered this a few times now, so i finally fixed it. I also included some maintenance and little improvements here.