### PR TITLE
Refactor/Rewrite of the `TaskOutput` class

### DIFF
--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -89,7 +89,7 @@ class PipelineModel(allennlp.models.Model):
     inputs: List[str]
         The model inputs
     output: List[str]
-        The model output
+        The model outputs (not prediction): Corresponding to the `TaskHead.featurize` optional arguments.
     """
 
     PREDICTION_FILE_NAME = "predictions.json"
@@ -362,10 +362,10 @@ class PipelineModel(allennlp.models.Model):
 
         instances = [self.text_to_instance(**input_dict) for input_dict in input_dicts]
         try:
-            forward_output = self.forward_on_instances(instances)
+            forward_outputs = self.forward_on_instances(instances)
             predictions = [
-                self.head.make_task_output(output).as_dict()
-                for output in forward_output
+                self.head.make_task_prediction(output).as_dict()
+                for output in forward_outputs
             ]
         except Exception as error:
             raise WrongValueError(

--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -39,7 +39,6 @@ from .errors import MissingArgumentError
 from .errors import WrongValueError
 from .helpers import split_signature_params_by_predicate
 from .modules.heads import TaskHead
-from .modules.heads import TaskOutput
 
 
 class _HashDict(dict):
@@ -338,7 +337,7 @@ class PipelineModel(allennlp.models.Model):
         return predictions
 
     def _get_instances_and_predictions(
-        self, input_dicts: Dict[str, Any]
+        self, input_dicts: Iterable[Dict[str, Any]]
     ) -> Tuple[List[Instance], List[Dict[str, numpy.ndarray]]]:
         """Returns instances from the input_dicts and their predictions.
 

--- a/src/biome/text/modules/heads/__init__.py
+++ b/src/biome/text/modules/heads/__init__.py
@@ -15,7 +15,7 @@ from .language_modelling import LanguageModellingConfiguration
 from .task_head import TaskHead
 from .task_head import TaskHeadConfiguration
 from .task_head import TaskName
-from .task_head import TaskOutput
+from .task_head import TaskPrediction
 from .token_classification import TokenClassification
 from .token_classification import TokenClassificationConfiguration
 

--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -85,7 +85,7 @@ class ClassificationHead(TaskHead):
         """Returns a dict with the logits and optionally the loss"""
         if label is not None:
             return {
-                "loss": self.compute_metrics_and_return_loss(logits, label),
+                "loss": self._compute_metrics_and_return_loss(logits, label),
                 "logits": logits,
             }
 

--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -19,7 +19,7 @@ from biome.text.backbone import ModelBackbone
 from biome.text.metrics import MultiLabelF1Measure
 from biome.text.modules.heads.task_head import TaskHead
 from biome.text.modules.heads.task_head import TaskName
-from biome.text.modules.heads.task_output import ClassificationOutput
+from biome.text.modules.heads.task_prediction import ClassificationPrediction
 
 
 class ClassificationHead(TaskHead):
@@ -107,9 +107,9 @@ class ClassificationHead(TaskHead):
 
         return self._loss(logits, label.long())
 
-    def make_task_output(
+    def make_task_prediction(
         self, single_forward_output: Dict[str, numpy.ndarray]
-    ) -> ClassificationOutput:
+    ) -> ClassificationPrediction:
         logits = torch.from_numpy(single_forward_output["logits"])
 
         if self._multilabel:
@@ -123,7 +123,7 @@ class ClassificationHead(TaskHead):
             else ([], [])
         )
 
-        return ClassificationOutput(labels=labels, probabilities=all_probabilities)
+        return ClassificationPrediction(labels=labels, probabilities=all_probabilities)
 
     def _add_and_sort_labels_and_probabilities(
         self, probabilities: torch.Tensor

--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -24,9 +24,7 @@ from biome.text.modules.configuration import FeedForwardConfiguration
 from biome.text.modules.configuration import Seq2SeqEncoderConfiguration
 from biome.text.modules.configuration import Seq2VecEncoderConfiguration
 from biome.text.modules.encoders import TimeDistributedEncoder
-
-from ..task_head import TaskOutput
-from .classification import ClassificationHead
+from biome.text.modules.heads.classification.classification import ClassificationHead
 
 
 class DocumentClassification(ClassificationHead):

--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -96,11 +96,11 @@ class DocumentClassification(ClassificationHead):
         instance = self.backbone.featurizer(
             document, to_field=self.forward_arg_name, exclude_record_keys=True
         )
-        return self.add_label(instance, label, to_field=self.label_name)
+        return self._add_label(instance, label, to_field=self.label_name)
 
     def forward(
         self, document: TextFieldTensors, label: torch.IntTensor = None
-    ) -> TaskOutput:
+    ) -> Dict[str, Any]:
         mask = get_text_field_mask(
             document, num_wrapping_dims=1
         )  # Why num_wrapping_dims=1 !?
@@ -117,7 +117,8 @@ class DocumentClassification(ClassificationHead):
             embedded_text = self.feedforward(embedded_text)
 
         logits = self._classification_layer(embedded_text)
-        return self.calculate_output(logits=logits, label=label)
+
+        return self._make_forward_output(logits, label)
 
     def explain_prediction(
         self, prediction: Dict[str, numpy.array], instance: Instance, n_steps: int

--- a/src/biome/text/modules/heads/classification/record_classification.py
+++ b/src/biome/text/modules/heads/classification/record_classification.py
@@ -57,7 +57,7 @@ class RecordClassification(DocumentClassification):
             {input_key: inputs[input_key] for input_key in self._inputs},
             to_field="document",
         )
-        return self.add_label(instance, label)
+        return self._add_label(instance, label)
 
 
 class RecordClassificationConfiguration(ComponentConfiguration[RecordClassification]):

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -164,7 +164,7 @@ class RecordPairClassification(ClassificationHead):
                 self._RECORD2_ARG_NAME_IN_FORWARD: record2_instance.get("record"),
             }
         )
-        instance = self.add_label(instance, label)
+        instance = self._add_label(instance, label)
 
         return instance
 
@@ -173,7 +173,7 @@ class RecordPairClassification(ClassificationHead):
         record1: TextFieldTensors,
         record2: TextFieldTensors,
         label: torch.LongTensor = None,
-    ) -> TaskOutput:
+    ) -> Dict[str, Any]:
         # pylint: disable=arguments-differ
         """
         Parameters
@@ -214,9 +214,7 @@ class RecordPairClassification(ClassificationHead):
             record_mask_record2,
         )
 
-        output: TaskOutput = self.single_label_output(logits, label)
-
-        return output
+        return self._make_forward_output(logits, label)
 
     def _field_encoding(
         self,

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -26,9 +26,7 @@ from biome.text.modules.configuration import FeedForwardConfiguration
 from biome.text.modules.configuration import Seq2SeqEncoderConfiguration
 from biome.text.modules.configuration import Seq2VecEncoderConfiguration
 from biome.text.modules.encoders import TimeDistributedEncoder
-
-from ..task_head import TaskOutput
-from .classification import ClassificationHead
+from biome.text.modules.heads.classification.classification import ClassificationHead
 
 
 class RecordPairClassification(ClassificationHead):

--- a/src/biome/text/modules/heads/classification/relation_classification.py
+++ b/src/biome/text/modules/heads/classification/relation_classification.py
@@ -20,14 +20,12 @@ from biome.text.modules.configuration import ComponentConfiguration
 from biome.text.modules.configuration import EmbeddingConfiguration
 from biome.text.modules.configuration import FeedForwardConfiguration
 from biome.text.modules.configuration import Seq2VecEncoderConfiguration
-
-from ..task_head import TaskOutput
-from .text_classification import TextClassification
+from biome.text.modules.heads.classification.classification import ClassificationHead
 
 # from biome.text.modules.encoders.multi_head_self_attention_encoder import MultiheadSelfAttentionEncoder
 
 
-class RelationClassification(TextClassification):
+class RelationClassification(ClassificationHead):
     """
     Task head for relation classification
     """
@@ -46,13 +44,7 @@ class RelationClassification(TextClassification):
         # self_attention: Optional[MultiheadSelfAttentionEncoder] = None
     ) -> None:
 
-        super(RelationClassification, self).__init__(
-            backbone,
-            labels,
-            pooler=pooler,
-            feedforward=feedforward,
-            multilabel=multilabel,
-        )
+        super().__init__(backbone=backbone, labels=labels, multilabel=multilabel)
 
         self._label_encoding = entity_encoding
         self._entity_tags_namespace = "entities"
@@ -74,34 +66,11 @@ class RelationClassification(TextClassification):
             if not feedforward
             else feedforward.input_dim(self.pooler.get_output_dim()).compile()
         )
+
         self._classification_layer = torch.nn.Linear(
             (self.feedforward or self.pooler).get_output_dim(), self.num_labels
         )
         # self.self_attention = self_attention
-
-    def forward(  # type: ignore
-        self,
-        text: TextFieldTensors,
-        entities: torch.IntTensor,
-        label: torch.IntTensor = None,
-    ) -> TaskOutput:
-
-        mask = get_text_field_mask(text)
-        embedded_text = self.backbone.forward(text, mask)
-
-        embedded_ents = self.entities_embedder(entities)
-        embedded_text = torch.cat((embedded_text, embedded_ents), dim=-1)
-        """
-        if self.self_attention:
-            embedded_text = self.self_attention(embedded_text)
-        """
-        embedded_text = self.pooler(embedded_text, mask=mask)
-
-        if self.feedforward is not None:
-            embedded_text = self.feedforward(embedded_text)
-
-        logits = self._classification_layer(embedded_text)
-        return self.calculate_output(logits=logits, label=label)
 
     def featurize(
         self,
@@ -135,7 +104,32 @@ class RelationClassification(TextClassification):
             ),
         )
 
-        return self.add_label(instance, label, to_field=self.label_name)
+        return self._add_label(instance, label, to_field=self.label_name)
+
+    def forward(  # type: ignore
+        self,
+        text: TextFieldTensors,
+        entities: torch.IntTensor,
+        label: torch.IntTensor = None,
+    ) -> Dict[str, Any]:
+
+        mask = get_text_field_mask(text)
+        embedded_text = self.backbone.forward(text, mask)
+
+        embedded_ents = self.entities_embedder(entities)
+        embedded_text = torch.cat((embedded_text, embedded_ents), dim=-1)
+        """
+        if self.self_attention:
+            embedded_text = self.self_attention(embedded_text)
+        """
+        embedded_text = self.pooler(embedded_text, mask=mask)
+
+        if self.feedforward is not None:
+            embedded_text = self.feedforward(embedded_text)
+
+        logits = self._classification_layer(embedded_text)
+
+        return self._make_forward_output(logits=logits, label=label)
 
 
 class RelationClassificationConfiguration(

--- a/src/biome/text/modules/heads/classification/relation_classification.py
+++ b/src/biome/text/modules/heads/classification/relation_classification.py
@@ -30,6 +30,8 @@ class RelationClassification(ClassificationHead):
     Task head for relation classification
     """
 
+    _TEXT_ARG_NAME_IN_FORWARD = "text"
+    _LABEL_ARG_NAME_IN_FORWARD = "label"
     __LOGGER = logging.getLogger(__name__)
 
     def __init__(
@@ -81,7 +83,7 @@ class RelationClassification(ClassificationHead):
 
         instance = self.backbone.featurizer(
             text,
-            to_field=self.forward_arg_name,
+            to_field=self._TEXT_ARG_NAME_IN_FORWARD,
             aggregate=True,
             exclude_record_keys=True,
         )
@@ -104,7 +106,9 @@ class RelationClassification(ClassificationHead):
             ),
         )
 
-        return self._add_label(instance, label, to_field=self.label_name)
+        return self._add_label(
+            instance, label, to_field=self._LABEL_ARG_NAME_IN_FORWARD
+        )
 
     def forward(  # type: ignore
         self,

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -67,7 +67,7 @@ class TextClassification(ClassificationHead):
             aggregate=True,
             exclude_record_keys=True,
         )
-        return self.add_label(instance, label, to_field=self.label_name)
+        return self._add_label(instance, label, to_field=self.label_name)
 
     def forward(  # type: ignore
         self,
@@ -84,13 +84,7 @@ class TextClassification(ClassificationHead):
 
         logits = self._classification_layer(embedded_text)
 
-        if label is not None:
-            return {
-                "loss": self.compute_metrics_and_return_loss(logits, label),
-                "logits": logits,
-            }
-
-        return {"logits": logits}
+        return self._make_forward_output(logits, label)
 
     def explain_prediction(
         self, prediction: Dict[str, numpy.array], instance: Instance, n_steps: int

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -73,7 +73,7 @@ class TextClassification(ClassificationHead):
         self,
         text: TextFieldTensors,
         label: torch.IntTensor = None,
-    ) -> TaskOutput:
+    ) -> Dict[str, Any]:
 
         mask = get_text_field_mask(text)
         embedded_text = self.backbone.forward(text, mask)
@@ -83,7 +83,14 @@ class TextClassification(ClassificationHead):
             embedded_text = self.feedforward(embedded_text)
 
         logits = self._classification_layer(embedded_text)
-        return self.calculate_output(logits=logits, label=label)
+
+        if label is not None:
+            return {
+                "loss": self.compute_metrics_and_return_loss(logits, label),
+                "logits": logits,
+            }
+
+        return {"logits": logits}
 
     def explain_prediction(
         self, prediction: Dict[str, numpy.array], instance: Instance, n_steps: int

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -21,7 +21,7 @@ from biome.text.modules.configuration import ComponentConfiguration
 from biome.text.modules.configuration import FeedForwardConfiguration
 from biome.text.modules.configuration import Seq2VecEncoderConfiguration
 
-from ..task_head import TaskOutput
+from ..task_head import TaskPrediction
 from .classification import ClassificationHead
 
 

--- a/src/biome/text/modules/heads/language_modelling.py
+++ b/src/biome/text/modules/heads/language_modelling.py
@@ -19,8 +19,8 @@ from biome.text.modules.configuration import ComponentConfiguration
 
 from .task_head import TaskHead
 from .task_head import TaskName
-from .task_head import TaskOutput
-from .task_output import LanguageModellingOutput
+from .task_head import TaskPrediction
+from .task_prediction import LanguageModellingPrediction
 
 
 class LanguageModelling(TaskHead):
@@ -184,17 +184,17 @@ class LanguageModelling(TaskHead):
 
         return self._loss(non_masked_embeddings, non_masked_targets)
 
-    def make_task_output(
+    def make_task_prediction(
         self, single_forward_output: Dict[str, numpy.ndarray]
-    ) -> LanguageModellingOutput:
-        task_output = LanguageModellingOutput(
+    ) -> LanguageModellingPrediction:
+        task_prediction = LanguageModellingPrediction(
             lm_embeddings=single_forward_output["lm_embeddings"],
             mask=single_forward_output["mask"],
         )
         if "loss" in single_forward_output:
-            task_output.loss = float(single_forward_output["loss"])
+            task_prediction.loss = float(single_forward_output["loss"])
 
-        return task_output
+        return task_prediction
 
 
 class LanguageModellingConfiguration(ComponentConfiguration[LanguageModelling]):

--- a/src/biome/text/modules/heads/language_modelling.py
+++ b/src/biome/text/modules/heads/language_modelling.py
@@ -1,7 +1,9 @@
+from typing import Any
 from typing import Dict
 from typing import Optional
 from typing import Tuple
 
+import numpy
 import torch
 from allennlp.common.checks import ConfigurationError
 from allennlp.data import Instance
@@ -18,6 +20,7 @@ from biome.text.modules.configuration import ComponentConfiguration
 from .task_head import TaskHead
 from .task_head import TaskName
 from .task_head import TaskOutput
+from .task_output import LanguageModellingOutput
 
 
 class LanguageModelling(TaskHead):
@@ -80,7 +83,7 @@ class LanguageModelling(TaskHead):
     def featurize(self, text: str) -> Optional[Instance]:
         return self.backbone.featurizer(text, to_field="text", aggregate=True)
 
-    def forward(self, text: TextFieldTensors) -> TaskOutput:  # type: ignore
+    def forward(self, text: TextFieldTensors) -> Dict[str, Any]:  # type: ignore
 
         mask = get_text_field_mask(text)
         contextual_embeddings = self.backbone.forward(text, mask)
@@ -130,11 +133,10 @@ class LanguageModelling(TaskHead):
             # Perplexity needs the value to be on the cpu
             metric(average_loss.to("cpu"))
 
-        return TaskOutput(
-            logits=None,
-            probs=None,
+        return dict(
             loss=average_loss,
-            **{"lm_embeddings": contextual_embeddings, "mask": mask},
+            lm_embeddings=contextual_embeddings,
+            mask=mask,
         )
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
@@ -181,6 +183,18 @@ class LanguageModelling(TaskHead):
         ).view(-1, self._forward_dim)
 
         return self._loss(non_masked_embeddings, non_masked_targets)
+
+    def make_task_output(
+        self, single_forward_output: Dict[str, numpy.ndarray]
+    ) -> LanguageModellingOutput:
+        task_output = LanguageModellingOutput(
+            lm_embeddings=single_forward_output["lm_embeddings"],
+            mask=single_forward_output["mask"],
+        )
+        if "loss" in single_forward_output:
+            task_output.loss = float(single_forward_output["loss"])
+
+        return task_output
 
 
 class LanguageModellingConfiguration(ComponentConfiguration[LanguageModelling]):

--- a/src/biome/text/modules/heads/task_head.py
+++ b/src/biome/text/modules/heads/task_head.py
@@ -88,7 +88,7 @@ class TaskHead(torch.nn.Module, Registrable):
         raise NotImplementedError
 
     def featurize(self, *args, **kwargs) -> Optional[Instance]:
-        """Converts incoming data into an allennlp `Instance`, used for pyTorch tensors generation"""
+        """Converts incoming data into an Allennlp `Instance`, used for pyTorch tensors generation"""
         raise NotImplementedError
 
     def make_task_output(

--- a/src/biome/text/modules/heads/task_head.py
+++ b/src/biome/text/modules/heads/task_head.py
@@ -12,7 +12,7 @@ from allennlp.data import Instance
 from biome.text import vocabulary
 from biome.text.backbone import ModelBackbone
 from biome.text.modules.configuration import ComponentConfiguration
-from biome.text.modules.heads.task_output import TaskOutput
+from biome.text.modules.heads.task_prediction import TaskPrediction
 
 
 class TaskName(Enum):
@@ -91,9 +91,9 @@ class TaskHead(torch.nn.Module, Registrable):
         """Converts incoming data into an Allennlp `Instance`, used for pyTorch tensors generation"""
         raise NotImplementedError
 
-    def make_task_output(
+    def make_task_prediction(
         self, single_forward_output: Dict[str, numpy.ndarray]
-    ) -> TaskOutput:
+    ) -> TaskPrediction:
         """Transforms the forward output to a task output, only used for predictions.
 
         Parameters
@@ -103,12 +103,14 @@ class TaskHead(torch.nn.Module, Registrable):
 
         Returns
         -------
-        task_output
+        task_prediction
             A task specific output for the prediction
         """
-        # One could implement a generic solution to just forward the forward_output:
-        # dataclass with necessary fields: C = dataclasses.make_dataclass(...)
-        # inherit from TaskOutput: return type("...", (C, TaskOutput, ), {})(**forward_output)
+        # One could implement a generic solution to just pass on the forward_output, but it would be slow and i
+        # recommend thinking about what a prediction should return, it is very likely not the same as for the forward.
+        # Possible solution:
+        # Dynamically create a dataclass with necessary fields: C = dataclasses.make_dataclass(...)
+        # Inherit from TaskPrediction: return type("...", (C, TaskPrediction, ), {})(**forward_output)
         raise NotImplementedError
 
     def explain_prediction(

--- a/src/biome/text/modules/heads/task_head.py
+++ b/src/biome/text/modules/heads/task_head.py
@@ -12,33 +12,7 @@ from allennlp.data import Instance
 from biome.text import vocabulary
 from biome.text.backbone import ModelBackbone
 from biome.text.modules.configuration import ComponentConfiguration
-
-
-class TaskOutput:
-    """
-    Task output data class
-
-    A task output will contains almost the logits and probs properties
-    """
-
-    def __init__(
-        self,
-        logits: torch.Tensor = None,
-        loss: Optional[torch.Tensor] = None,
-        **extra_data
-    ):
-        self.logits = logits
-        self.loss = loss
-
-        for k, v in extra_data.items():
-            self.__setattr__(k, v)
-
-    def __setattr__(self, key, value):
-        self.__dict__[key] = value
-
-    def as_dict(self) -> Dict[str, torch.Tensor]:
-        """Dict representation of task output"""
-        return {k: v for k, v in self.__dict__.items() if v is not None}
+from biome.text.modules.heads.task_output import TaskOutput
 
 
 class TaskName(Enum):

--- a/src/biome/text/modules/heads/task_head.py
+++ b/src/biome/text/modules/heads/task_head.py
@@ -74,7 +74,7 @@ class TaskHead(torch.nn.Module, Registrable):
         """
         return None
 
-    def forward(self, *args: Any, **kwargs: Any) -> Dict:
+    def forward(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
         """The head's forward pass, it must include the backbone's `forward`.
 
         When trained, the returned dict has to have a 'loss' key pointing to a

--- a/src/biome/text/modules/heads/task_output.py
+++ b/src/biome/text/modules/heads/task_output.py
@@ -1,0 +1,68 @@
+import dataclasses
+from typing import Dict
+from typing import List
+from typing import Tuple
+from typing import cast
+
+# this sentinel is used to omit certain dataclass fields when the dataclass is converted to a dict
+SENTINEL = cast(None, "SENTINEL TO SKIP DATACLASS FIELDS WHEN CONVERTING TO DICT")
+
+
+@dataclasses.dataclass
+class AttributionsOutput:
+    text: str
+    start: int
+    end: int
+    attribution: float
+
+
+@dataclasses.dataclass
+class TokensOutput:
+    text: str
+    start: int
+    end: int
+
+
+@dataclasses.dataclass
+class TaskOutput:
+    """Base class for the TaskOutput classes.
+
+    Each head should implement a proper task output class that defines its prediction output.
+    You can use the SENTINEL as default value if you want to omit certain fields when converting to a dict.
+    """
+
+    @staticmethod
+    def _dict_factory(key_value_pairs: List[Tuple]) -> Dict:
+        """input is a list of (key, value) pairs"""
+        return dict(
+            [(key, value) for key, value in key_value_pairs if value is not SENTINEL]
+        )
+
+    def as_dict(self) -> Dict:
+        return dataclasses.asdict(self, dict_factory=self._dict_factory)
+
+
+@dataclasses.dataclass
+class ClassificationOutput(TaskOutput):
+    """Output dataclass for all `ClassificationHead`s:
+    - `TextClassification`
+    - `RecordClassification`
+    - `DocumentClassification`
+    - `RecordPairClassification`
+    """
+
+    labels: List[str]
+    probabilities: List[float]
+    attributions: AttributionsOutput = SENTINEL
+    tokens: TokensOutput = SENTINEL
+
+
+@dataclasses.dataclass
+class TokenClassificationOutput(TaskOutput):
+    """Output dataclass for the `TokenClassification` head"""
+
+
+def test_output():
+    a = AttributionsOutput(text="a", start=1, attribution=1, end=SENTINEL)
+    c = ClassificationOutput(labels=1, probabilities=1, attributions=a)
+    print(c.as_dict())

--- a/src/biome/text/modules/heads/task_output.py
+++ b/src/biome/text/modules/heads/task_output.py
@@ -60,9 +60,3 @@ class ClassificationOutput(TaskOutput):
 @dataclasses.dataclass
 class TokenClassificationOutput(TaskOutput):
     """Output dataclass for the `TokenClassification` head"""
-
-
-def test_output():
-    a = AttributionsOutput(text="a", start=1, attribution=1, end=SENTINEL)
-    c = ClassificationOutput(labels=1, probabilities=1, attributions=a)
-    print(c.as_dict())

--- a/src/biome/text/modules/heads/task_output.py
+++ b/src/biome/text/modules/heads/task_output.py
@@ -5,6 +5,8 @@ from typing import Optional
 from typing import Tuple
 from typing import cast
 
+import numpy
+
 # this sentinel is used to omit certain dataclass fields when the dataclass is converted to a dict
 SENTINEL = cast(None, "SENTINEL TO SKIP DATACLASS FIELDS WHEN CONVERTING TO DICT")
 
@@ -130,3 +132,13 @@ class TokenClassificationOutput(TaskOutput):
     entities: List[List[EntityOutput]]
     scores: List[float]
     tokens: Optional[List[TokenOutput]] = SENTINEL
+
+
+@dataclasses.dataclass
+class LanguageModellingOutput(TaskOutput):
+    """Output dataclass for the `LanguageModelling` head"""
+
+    lm_embeddings: numpy.array
+    mask: numpy.array
+    # Is only included if
+    loss: Optional[float] = SENTINEL

--- a/src/biome/text/modules/heads/task_output.py
+++ b/src/biome/text/modules/heads/task_output.py
@@ -128,5 +128,5 @@ class LanguageModellingOutput(TaskOutput):
 
     lm_embeddings: numpy.array
     mask: numpy.array
-    # Is only included if
+    # Is only included if batch size == 1
     loss: Optional[float] = SENTINEL

--- a/src/biome/text/modules/heads/task_output.py
+++ b/src/biome/text/modules/heads/task_output.py
@@ -1,6 +1,7 @@
 import dataclasses
 from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 from typing import cast
 
@@ -9,7 +10,9 @@ SENTINEL = cast(None, "SENTINEL TO SKIP DATACLASS FIELDS WHEN CONVERTING TO DICT
 
 
 @dataclasses.dataclass
-class AttributionsOutput:
+class AttributionOutput:
+    """Output dataclass for a attribution."""
+
     text: str
     start: int
     end: int
@@ -17,10 +20,47 @@ class AttributionsOutput:
 
 
 @dataclasses.dataclass
-class TokensOutput:
+class TokenOutput:
+    """Output dataclass for a token.
+
+    Parameters
+    ----------
+    text
+        Text of the token
+    start
+        Start char id
+    end
+        End char id
+    """
+
     text: str
     start: int
     end: int
+
+
+@dataclasses.dataclass
+class EntityOutput:
+    """Output dataclass for a NER entity
+
+    Parameters
+    ----------
+    label
+        Label of the entity
+    start_token
+        Start token id
+    end_token
+        End token id
+    start
+        Start char id
+    end
+        End char id
+    """
+
+    label: str
+    start_token: int
+    end_token: int
+    start: Optional[int] = SENTINEL
+    end: Optional[int] = SENTINEL
 
 
 @dataclasses.dataclass
@@ -49,14 +89,44 @@ class ClassificationOutput(TaskOutput):
     - `RecordClassification`
     - `DocumentClassification`
     - `RecordPairClassification`
+
+    Parameters
+    ----------
+    labels
+        Ordered list of predictions, from the label with the highest to the label with the lowest probability.
+    probabilities
+        Ordered list of probabilities, from highest to lowest probability.
+    attributions
+        Attribution of each token to the prediction with the highest probability.
+    tokens
+        Tokens of the tokenized input
     """
 
     labels: List[str]
     probabilities: List[float]
-    attributions: AttributionsOutput = SENTINEL
-    tokens: TokensOutput = SENTINEL
+    attributions: Optional[AttributionOutput] = SENTINEL
+    tokens: Optional[List[TokenOutput]] = SENTINEL
 
 
 @dataclasses.dataclass
 class TokenClassificationOutput(TaskOutput):
-    """Output dataclass for the `TokenClassification` head"""
+    """Output dataclass for the `TokenClassification` head
+
+    Parameters
+    ----------
+    tags
+        List of lists of NER tags, ordered by score.
+        The list of NER tags with the highest score comes first.
+    entities
+        List of list of entities, ordered by score.
+        The list of entities with the highest score comes first.
+    scores
+        Ordered list of scores for each list of NER tags (highest to lowest).
+    tokens
+        Tokens of the tokenized input
+    """
+
+    tags: List[List[str]]
+    entities: List[List[EntityOutput]]
+    scores: List[float]
+    tokens: Optional[List[TokenOutput]] = SENTINEL

--- a/src/biome/text/modules/heads/task_output.py
+++ b/src/biome/text/modules/heads/task_output.py
@@ -12,16 +12,6 @@ SENTINEL = cast(None, "SENTINEL TO SKIP DATACLASS FIELDS WHEN CONVERTING TO DICT
 
 
 @dataclasses.dataclass
-class AttributionOutput:
-    """Output dataclass for a attribution."""
-
-    text: str
-    start: int
-    end: int
-    attribution: float
-
-
-@dataclasses.dataclass
 class TokenOutput:
     """Output dataclass for a token.
 
@@ -106,8 +96,6 @@ class ClassificationOutput(TaskOutput):
 
     labels: List[str]
     probabilities: List[float]
-    attributions: Optional[AttributionOutput] = SENTINEL
-    tokens: Optional[List[TokenOutput]] = SENTINEL
 
 
 @dataclasses.dataclass

--- a/src/biome/text/modules/heads/task_prediction.py
+++ b/src/biome/text/modules/heads/task_prediction.py
@@ -12,8 +12,8 @@ SENTINEL = cast(None, "SENTINEL TO SKIP DATACLASS FIELDS WHEN CONVERTING TO DICT
 
 
 @dataclasses.dataclass
-class TokenOutput:
-    """Output dataclass for a token.
+class Token:
+    """Output dataclass for a token in a prediction.
 
     Parameters
     ----------
@@ -31,7 +31,7 @@ class TokenOutput:
 
 
 @dataclasses.dataclass
-class EntityOutput:
+class Entity:
     """Output dataclass for a NER entity
 
     Parameters
@@ -56,10 +56,10 @@ class EntityOutput:
 
 
 @dataclasses.dataclass
-class TaskOutput:
+class TaskPrediction:
     """Base class for the TaskOutput classes.
 
-    Each head should implement a proper task output class that defines its prediction output.
+    Each head should implement a proper task prediction class that defines its prediction output.
     You can use the SENTINEL as default value if you want to omit certain fields when converting to a dict.
     """
 
@@ -75,7 +75,7 @@ class TaskOutput:
 
 
 @dataclasses.dataclass
-class ClassificationOutput(TaskOutput):
+class ClassificationPrediction(TaskPrediction):
     """Output dataclass for all `ClassificationHead`s:
     - `TextClassification`
     - `RecordClassification`
@@ -95,7 +95,7 @@ class ClassificationOutput(TaskOutput):
 
 
 @dataclasses.dataclass
-class TokenClassificationOutput(TaskOutput):
+class TokenClassificationPrediction(TaskPrediction):
     """Output dataclass for the `TokenClassification` head
 
     Parameters
@@ -113,13 +113,13 @@ class TokenClassificationOutput(TaskOutput):
     """
 
     tags: List[List[str]]
-    entities: List[List[EntityOutput]]
+    entities: List[List[Entity]]
     scores: List[float]
-    tokens: Optional[List[TokenOutput]] = SENTINEL
+    tokens: Optional[List[Token]] = SENTINEL
 
 
 @dataclasses.dataclass
-class LanguageModellingOutput(TaskOutput):
+class LanguageModellingPrediction(TaskPrediction):
     """Output dataclass for the `LanguageModelling` head"""
 
     lm_embeddings: numpy.array

--- a/src/biome/text/modules/heads/task_prediction.py
+++ b/src/biome/text/modules/heads/task_prediction.py
@@ -88,10 +88,6 @@ class ClassificationOutput(TaskOutput):
         Ordered list of predictions, from the label with the highest to the label with the lowest probability.
     probabilities
         Ordered list of probabilities, from highest to lowest probability.
-    attributions
-        Attribution of each token to the prediction with the highest probability.
-    tokens
-        Tokens of the tokenized input
     """
 
     labels: List[str]

--- a/src/biome/text/modules/heads/task_prediction.py
+++ b/src/biome/text/modules/heads/task_prediction.py
@@ -32,7 +32,7 @@ class Token:
 
 @dataclasses.dataclass
 class Entity:
-    """Output dataclass for a NER entity
+    """Output dataclass for a NER entity in a prediction.
 
     Parameters
     ----------

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -24,16 +24,17 @@ from spacy.vocab import Vocab
 
 from biome.text import vocabulary
 from biome.text.backbone import ModelBackbone
+from biome.text.errors import WrongValueError
 from biome.text.helpers import offsets_from_tags
 from biome.text.helpers import span_labels_to_tag_labels
 from biome.text.helpers import tags_from_offsets
 from biome.text.modules.configuration import ComponentConfiguration
 from biome.text.modules.configuration import FeedForwardConfiguration
-
-from ...errors import WrongValueError
-from .task_head import TaskHead
-from .task_head import TaskName
-from .task_head import TaskOutput
+from biome.text.modules.heads.task_head import TaskHead
+from biome.text.modules.heads.task_head import TaskName
+from biome.text.modules.heads.task_output import EntityOutput
+from biome.text.modules.heads.task_output import TokenClassificationOutput
+from biome.text.modules.heads.task_output import TokenOutput
 
 
 class TokenClassification(TaskHead):
@@ -206,7 +207,7 @@ class TokenClassification(TaskHead):
         text: TextFieldTensors,
         raw_text: List[Union[str, List[str]]],
         tags: torch.IntTensor = None,
-    ) -> TaskOutput:
+    ) -> Dict:
 
         mask = get_text_field_mask(text)
         embedded_text = self.dropout(self.backbone.forward(text, mask))
@@ -227,86 +228,75 @@ class TokenClassification(TaskHead):
             for j, tag_id in enumerate(instance_tags):
                 class_probabilities[i, j, tag_id] = 1
 
-        output = TaskOutput(
-            logits=logits,
-            probs=class_probabilities,
+        output = dict(
             viterbi_paths=viterbi_paths,
-            mask=mask,
             raw_text=raw_text,
         )
 
         if tags is not None:
-            output.loss = self._loss(logits, tags, mask)
+            output["loss"] = self._loss(logits, tags, mask)
             for metric in self.__all_metrics:
                 metric(class_probabilities, tags, mask)
 
         return output
 
-    def _decode_tags(
+    def make_task_output(
+        self, single_forward_output: Dict
+    ) -> TokenClassificationOutput:
+        # The dims are: top_k, tags
+        tags: List[List[str]] = self._make_tags_output(
+            single_forward_output["viterbi_paths"]
+        )
+        # construct a spacy Doc
+        pre_tokenized = not isinstance(single_forward_output["raw_text"], str)
+        if pre_tokenized:
+            # compose doc from tokens
+            doc = Doc(Vocab(), words=single_forward_output["raw_text"])
+        else:
+            doc = self.backbone.tokenizer.nlp(single_forward_output["raw_text"])
+
+        task_output = TokenClassificationOutput(
+            tags=tags,
+            scores=[score for tags, score in single_forward_output["viterbi_paths"]],
+            entities=self._make_entities_output(doc, tags, pre_tokenized),
+        )
+        if not pre_tokenized:
+            task_output.tokens = self._make_tokens_output(doc)
+
+        return task_output
+
+    def _make_tags_output(
         self, viterbi_paths: List[Tuple[List[int], float]]
     ) -> List[List[str]]:
-        """Decode predicted tags"""
+        """Makes the 'tags' key of the task output"""
         return [
             [vocabulary.label_for_index(self.backbone.vocab, idx) for idx in tags]
             for tags, score in viterbi_paths
         ]
 
-    def _decode_entities(
+    def _make_entities_output(
         self,
         doc: Doc,
         k_tags: List[List[str]],
         pre_tokenized: bool,
-    ) -> List[List[Dict]]:
-        """Decode predicted entities from tags"""
+    ) -> List[List[EntityOutput]]:
+        """Makes the 'entities' key of the task output. Computes offsets with respect to char and token id"""
         return [
-            offsets_from_tags(
-                doc, tags, self._label_encoding, only_token_spans=pre_tokenized
-            )
+            [
+                EntityOutput(**entity)
+                for entity in offsets_from_tags(
+                    doc, tags, self._label_encoding, only_token_spans=pre_tokenized
+                )
+            ]
             for tags in k_tags
         ]
 
-    def _decode_tokens(self, doc: Doc) -> List[Dict]:
-        """Decode tokens"""
+    def _make_tokens_output(self, doc: Doc) -> List[TokenOutput]:
+        """Makes the 'tokens' key of the task output"""
         return [
-            {"text": token.text, "start": token.idx, "end": token.idx + len(token)}
+            TokenOutput(text=token.text, start=token.idx, end=token.idx + len(token))
             for token in doc
         ]
-
-    def decode(self, output: TaskOutput) -> TaskOutput:
-        # The dims are: batch, top_k, tags
-        output.tags: List[List[List[str]]] = [
-            self._decode_tags(paths) for paths in output.viterbi_paths
-        ]
-        output.scores: List[List[float]] = [
-            [score for tags, score in paths] for paths in output.viterbi_paths
-        ]
-
-        output.entities: List[List[List[Dict]]] = []
-        output.tokens: List[List[Dict]] = []
-        # iterate over batch
-        for raw_text, k_tags in zip(output.raw_text, output.tags):
-            pre_tokenized = not isinstance(raw_text, str)
-            if pre_tokenized:
-                # compose spacy doc from tokens
-                doc = Doc(Vocab(), words=raw_text)
-            else:
-                doc = self.backbone.tokenizer.nlp(raw_text)
-
-            output.entities.append(self._decode_entities(doc, k_tags, pre_tokenized))
-            output.tokens.append(
-                self._decode_tokens(doc) if not pre_tokenized else None
-            )
-
-        if not any(output.tokens):  # drop tokens field if no data
-            del output.tokens
-
-        del output.logits
-        del output.mask
-        del output.probs
-        del output.raw_text
-        del output.viterbi_paths
-
-        return output
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
         metrics = {

--- a/tests/text/modules/heads/test_language_modelling.py
+++ b/tests/text/modules/heads/test_language_modelling.py
@@ -1,12 +1,10 @@
 from typing import Dict
 
-import pandas as pd
 import pytest
 
 from biome.text import Dataset
 from biome.text import Pipeline
 from biome.text import TrainerConfiguration
-from biome.text import VocabularyConfiguration
 
 
 @pytest.fixture

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -6,9 +6,11 @@ import pytest
 from biome.text import Dataset
 from biome.text import Pipeline
 from biome.text import TrainerConfiguration
-from biome.text import VocabularyConfiguration
 from biome.text import vocabulary
 from biome.text.modules.heads import TaskOutput
+from biome.text.modules.heads.task_output import EntityOutput
+from biome.text.modules.heads.task_output import TokenClassificationOutput
+from biome.text.modules.heads.task_output import TokenOutput
 
 
 @pytest.fixture
@@ -96,53 +98,52 @@ def test_train(pipeline_dict, training_dataset, trainer_dict, tmp_path):
     )
 
 
-class TestDecode:
-    def test_pretokenized_decode(self, pipeline_dict):
+class TestMakeTaskOutput:
+    def test_pretokenized_input(self, pipeline_dict):
         pipeline = Pipeline.from_config(pipeline_dict)
         output = self._input_top_k2(pipeline)
+        expected_output = TokenClassificationOutput(
+            tags=[["O", "O", "O", "U-NER"], ["O", "B-NER", "I-NER", "L-NER"]],
+            entities=[
+                [EntityOutput(start_token=3, end_token=4, label="NER")],
+                [EntityOutput(start_token=1, end_token=4, label="NER")],
+            ],
+            scores=[2, 1],
+        )
 
-        assert output.keys() == dict(entities=None, tags=None, scores=None).keys()
-        assert output["entities"] == [
-            [
-                [dict(start_token=3, end_token=4, label="NER")],
-                [dict(start_token=1, end_token=4, label="NER")],
-            ]
-        ]
-        assert output["tags"] == [
-            [["O", "O", "O", "U-NER"], ["O", "B-NER", "I-NER", "L-NER"]]
-        ]
-        assert output["scores"] == [[2, 1]]
+        assert output == expected_output
 
-    def test_untokenized_decode(self, pipeline_dict):
+    def test_untokenized_input(self, pipeline_dict):
         pipeline = Pipeline.from_config(pipeline_dict)
         output = self._input_top_k2(pipeline, pretokenized=False)
-
-        assert (
-            output.keys()
-            == dict(entities=None, tags=None, scores=None, tokens=None).keys()
+        expected_output = TokenClassificationOutput(
+            tags=[["O", "O", "O", "U-NER"], ["O", "B-NER", "I-NER", "L-NER"]],
+            entities=[
+                [
+                    EntityOutput(
+                        start_token=3, end_token=4, label="NER", start=10, end=14
+                    )
+                ],
+                [
+                    EntityOutput(
+                        start_token=1, end_token=4, label="NER", start=5, end=14
+                    )
+                ],
+            ],
+            scores=[2, 1],
+            tokens=[
+                TokenOutput(end=4, start=0, text="this"),
+                TokenOutput(end=7, start=5, text="is"),
+                TokenOutput(end=9, start=8, text="a"),
+                TokenOutput(end=14, start=10, text="test"),
+            ],
         )
-        assert output["entities"] == [
-            [
-                [dict(start_token=3, end_token=4, label="NER", start=10, end=14)],
-                [dict(start_token=1, end_token=4, label="NER", start=5, end=14)],
-            ]
-        ]
-        assert output["tags"] == [
-            [["O", "O", "O", "U-NER"], ["O", "B-NER", "I-NER", "L-NER"]]
-        ]
-        assert output["scores"] == [[2, 1]]
-        assert output["tokens"] == [
-            [
-                {"end": 4, "start": 0, "text": "this"},
-                {"end": 7, "start": 5, "text": "is"},
-                {"end": 9, "start": 8, "text": "a"},
-                {"end": 14, "start": 10, "text": "test"},
-            ]
-        ]
+
+        assert output == expected_output
 
     @staticmethod
     def _input_top_k2(pipeline, pretokenized=True):
-        raw_text = [["this", "is", "a", "test"]] if pretokenized else ["this is a test"]
+        raw_text = ["this", "is", "a", "test"] if pretokenized else "this is a test"
         tag_idx_sequence = [
             vocabulary.index_for_label(pipeline.backbone.vocab, tag)
             for tag in ["O", "O", "O", "U-NER"]
@@ -151,48 +152,13 @@ class TestDecode:
             vocabulary.index_for_label(pipeline.backbone.vocab, tag)
             for tag in ["O", "B-NER", "I-NER", "L-NER"]
         ]
-        viterbi_paths = [[(tag_idx_sequence, 2), (tag_idx_sequence2, 1)]]
-        task_output = TaskOutput(
-            viterbi_paths=viterbi_paths, raw_text=raw_text, mask=None, probs=None
+        viterbi_paths = [(tag_idx_sequence, 2), (tag_idx_sequence2, 1)]
+        single_forward_output = dict(
+            viterbi_paths=viterbi_paths,
+            raw_text=raw_text,
         )
 
-        return pipeline.head.decode(task_output).as_dict()
-
-    def test_mixed_decode(self, pipeline_dict):
-        pipeline = Pipeline.from_config(pipeline_dict)
-        output = self._mixed_input_top_k1(pipeline)
-
-        assert (
-            output.keys()
-            == dict(entities=None, tags=None, scores=None, tokens=None).keys()
-        )
-        assert output["entities"] == [
-            [[dict(start_token=3, end_token=4, label="NER")]],
-            [[dict(start_token=3, end_token=4, label="NER", start=10, end=14)]],
-        ]
-        assert output["tokens"] == [
-            None,
-            [
-                {"end": 4, "start": 0, "text": "this"},
-                {"end": 7, "start": 5, "text": "is"},
-                {"end": 9, "start": 8, "text": "a"},
-                {"end": 14, "start": 10, "text": "test"},
-            ],
-        ]
-
-    @staticmethod
-    def _mixed_input_top_k1(pipeline):
-        raw_text = [["this", "is", "a", "test"], "this is a test"]
-        tag_idx_sequence = [
-            vocabulary.index_for_label(pipeline.backbone.vocab, tag)
-            for tag in ["O", "O", "O", "U-NER"]
-        ]
-        viterbi_paths = [[(tag_idx_sequence, 1)]] * 2
-        task_output = TaskOutput(
-            viterbi_paths=viterbi_paths, raw_text=raw_text, mask=None, probs=None
-        )
-
-        return pipeline.head.decode(task_output).as_dict()
+        return pipeline.head.make_task_output(single_forward_output)
 
 
 def test_preserve_pretokenization(

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -7,10 +7,10 @@ from biome.text import Dataset
 from biome.text import Pipeline
 from biome.text import TrainerConfiguration
 from biome.text import vocabulary
-from biome.text.modules.heads import TaskOutput
-from biome.text.modules.heads.task_output import EntityOutput
-from biome.text.modules.heads.task_output import TokenClassificationOutput
-from biome.text.modules.heads.task_output import TokenOutput
+from biome.text.modules.heads import TaskPrediction
+from biome.text.modules.heads.task_prediction import Entity
+from biome.text.modules.heads.task_prediction import Token
+from biome.text.modules.heads.task_prediction import TokenClassificationPrediction
 
 
 @pytest.fixture
@@ -102,11 +102,11 @@ class TestMakeTaskOutput:
     def test_pretokenized_input(self, pipeline_dict):
         pipeline = Pipeline.from_config(pipeline_dict)
         output = self._input_top_k2(pipeline)
-        expected_output = TokenClassificationOutput(
+        expected_output = TokenClassificationPrediction(
             tags=[["O", "O", "O", "U-NER"], ["O", "B-NER", "I-NER", "L-NER"]],
             entities=[
-                [EntityOutput(start_token=3, end_token=4, label="NER")],
-                [EntityOutput(start_token=1, end_token=4, label="NER")],
+                [Entity(start_token=3, end_token=4, label="NER")],
+                [Entity(start_token=1, end_token=4, label="NER")],
             ],
             scores=[2, 1],
         )
@@ -116,26 +116,18 @@ class TestMakeTaskOutput:
     def test_untokenized_input(self, pipeline_dict):
         pipeline = Pipeline.from_config(pipeline_dict)
         output = self._input_top_k2(pipeline, pretokenized=False)
-        expected_output = TokenClassificationOutput(
+        expected_output = TokenClassificationPrediction(
             tags=[["O", "O", "O", "U-NER"], ["O", "B-NER", "I-NER", "L-NER"]],
             entities=[
-                [
-                    EntityOutput(
-                        start_token=3, end_token=4, label="NER", start=10, end=14
-                    )
-                ],
-                [
-                    EntityOutput(
-                        start_token=1, end_token=4, label="NER", start=5, end=14
-                    )
-                ],
+                [Entity(start_token=3, end_token=4, label="NER", start=10, end=14)],
+                [Entity(start_token=1, end_token=4, label="NER", start=5, end=14)],
             ],
             scores=[2, 1],
             tokens=[
-                TokenOutput(end=4, start=0, text="this"),
-                TokenOutput(end=7, start=5, text="is"),
-                TokenOutput(end=9, start=8, text="a"),
-                TokenOutput(end=14, start=10, text="test"),
+                Token(end=4, start=0, text="this"),
+                Token(end=7, start=5, text="is"),
+                Token(end=9, start=8, text="a"),
+                Token(end=14, start=10, text="test"),
             ],
         )
 
@@ -158,7 +150,7 @@ class TestMakeTaskOutput:
             raw_text=raw_text,
         )
 
-        return pipeline.head.make_task_output(single_forward_output)
+        return pipeline.head.make_task_prediction(single_forward_output)
 
 
 def test_preserve_pretokenization(

--- a/tests/text/test_pipeline_with_optional_inputs.py
+++ b/tests/text/test_pipeline_with_optional_inputs.py
@@ -30,7 +30,7 @@ class MyCustomHead(TextClassification):
             aggregate=True,
             exclude_record_keys=True,
         )
-        return self.add_label(instance, label, to_field=self.label_name)
+        return self._add_label(instance, label, to_field=self.label_name)
 
 
 def test_check_pipeline_inputs_and_output():


### PR DESCRIPTION
This PR is basically a rewrite/refactor of the `TaskOutput` class. It became larger than expected, but i think the follow up PR combining predict/explain will become smaller because of this.

 This is a rough list of all important changes:
- *task output* is now defined as output of a prediction; the output of the `forward` method is referred to as *forward output* through out the code
- `TaskOutput` is now a base class for specific output classes depending on the task; all output classes are *dataclasses*.
- these classes are located in `biome.text.modules.heads.task_output`
- the former `decode` method is replaced by a `make_task_output` method that works on an instance level, **not** batch level (this was recommended before by @frascuchon)
- the `forward` methods return a dict -> less friction with AllenNLP's API
- some "cosmetics" in the base `Classification` head

advantages:
- the `TaskOutput` classes clearly show what predictions of each task look like
- simplified code structure + naming is more explicit -> less complexity

disadvantage:
- There should be a tiny speed penalty for certain batch predictions. In the `ClassificationHead`s for example, we used to compute the probabilities in a batch, now we compute them per instance. I don't expect this penalty to be noticeable, but wanted to keep track of it.

 

  