### PR TITLE
Bugfix: Tuples in classification output

### DIFF
--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -173,15 +173,13 @@ class ClassificationHead(TaskHead):
             all_classes_probs, descending=True
         ).tolist()
 
-        labels, probabilities = zip(
-            *[
-                (
-                    vocabulary.label_for_index(self.backbone.vocab, idx),
-                    float(all_classes_probs[idx]),
-                )
-                for idx in sorted_indexes_by_prob
-            ]
-        )
+        labels = [
+            vocabulary.label_for_index(self.backbone.vocab, idx)
+            for idx in sorted_indexes_by_prob
+        ]
+        probabilities = [
+            float(all_classes_probs[idx]) for idx in sorted_indexes_by_prob
+        ]
 
         return labels, probabilities
 

--- a/tests/text/modules/heads/classification/test_document_classification.py
+++ b/tests/text/modules/heads/classification/test_document_classification.py
@@ -51,6 +51,9 @@ def test_make_task_prediction(pipeline):
     prediction = pipeline.head._make_task_prediction(forward_output[0], None)
 
     assert isinstance(prediction, DocumentClassificationPrediction)
+    assert isinstance(prediction.labels, list) and isinstance(
+        prediction.probabilities, list
+    )
     assert len(prediction.labels) == len(prediction.probabilities) == 6
     # check descending order
     assert_allclose(

--- a/tests/text/modules/heads/classification/test_text_classification.py
+++ b/tests/text/modules/heads/classification/test_text_classification.py
@@ -24,6 +24,9 @@ def test_make_task_prediction(pipeline):
     prediction = pipeline.head._make_task_prediction(forward_output[0], None)
 
     assert isinstance(prediction, TextClassificationPrediction)
+    assert isinstance(prediction.labels, list) and isinstance(
+        prediction.probabilities, list
+    )
     assert len(prediction.labels) == len(prediction.probabilities) == 6
     # check descending order
     assert_allclose(


### PR DESCRIPTION
This PR fixes a bug where the TaskPrediction of the `ClassificationHead`s contain tuples instead of lists.