### PR TITLE
Refactor: Reordering pipeline methods

### DIFF
--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -208,7 +208,7 @@ class PipelineTrainer:
         for logger in self._epoch_callbacks:
             try:
                 logger.init_train(
-                    pipeline=self,
+                    pipeline=self._pipeline,
                     trainer_configuration=self._trainer_config,
                     training=self._training,
                     validation=self._validation,

--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -29,6 +29,7 @@ from biome.text import helpers
 from biome.text._model import PipelineModel
 from biome.text.dataset import InstancesDataset
 from biome.text.errors import http_error_handling
+from biome.text.training_results import TrainingResults
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -193,7 +194,7 @@ class PipelineTrainer:
             batch_weight_key=self._batch_weight_key,
         )
 
-    def train(self) -> Tuple[str, Dict[str, Any]]:
+    def train(self) -> TrainingResults:
         """
         Train the inner model with given configuration on initialization
 
@@ -203,6 +204,18 @@ class PipelineTrainer:
         """
 
         from allennlp.models.model import _DEFAULT_WEIGHTS
+
+        for logger in self._epoch_callbacks:
+            try:
+                logger.init_train(
+                    pipeline=self,
+                    trainer_configuration=self._trainer_config,
+                    training=self._training,
+                    validation=self._validation,
+                    test=self._test,
+                )
+            except Exception as e:
+                self.__LOGGER.warning("Logger %s failed on init_train: %s", logger, e)
 
         try:
             metrics = self._trainer.train()
@@ -225,7 +238,17 @@ class PipelineTrainer:
             metrics_json = json.dumps(metrics, indent=2)
             metrics_file.write(metrics_json)
 
-        return os.path.join(self._output_dir, "model.tar.gz"), metrics
+        training_results = TrainingResults(
+            os.path.join(self._output_dir, "model.tar.gz"), metrics
+        )
+
+        for logger in self._epoch_callbacks:
+            try:
+                logger.end_train(training_results)
+            except Exception as e:
+                self.__LOGGER.warning("Logger %s failed on end_traing: %s", logger, e)
+
+        return training_results
 
     def save_best_model(self):
         """Packages the best model as tar.gz archive"""

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -721,9 +721,7 @@ class Pipeline:
         pipeline_copy = Pipeline(model, config)
         pipeline_copy._model.load_state_dict(self._model.state_dict())
 
-        self.__setattr__(
-            self.predict.__name__, update_method_signature(new_signature, self.predict)
-        )
+        return pipeline_copy
 
     @staticmethod
     def _add_transformers_vocab_if_needed(model: PipelineModel):

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -71,14 +71,14 @@ class Pipeline:
 
         Parameters
         ----------
-        path : `str`
+        path
             The path to a YAML configuration file
-        vocab_path : `Optional[str]`
+        vocab_path
             If provided, the pipeline vocab will be loaded from this path
 
         Returns
         -------
-        pipeline: `Pipeline`
+        pipeline
             A configured pipeline
         """
         pipeline_configuration = PipelineConfiguration.from_yaml(path)
@@ -95,14 +95,14 @@ class Pipeline:
 
         Parameters
         ----------
-        config: `Union[PipelineConfiguration, dict]`
+        config
             A `PipelineConfiguration` object or a configuration dict
-        vocab_path: `Optional[str]`
+        vocab_path
             If provided, the pipeline vocabulary will be loaded from this path
 
         Returns
         -------
-        pipeline: `Pipeline`
+        pipeline
             A configured pipeline
         """
         if isinstance(config, dict):
@@ -125,12 +125,12 @@ class Pipeline:
 
         Parameters
         ----------
-        path: `str`
+        path
             The path to the *model.tar.gz* file of a pretrained `Pipeline`
 
         Returns
         -------
-        pipeline: `Pipeline`
+        pipeline
             A pretrained pipeline
         """
         archive = load_archive(

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -136,7 +136,7 @@ class Pipeline:
         return cls(model, config)
 
     @classmethod
-    def from_pretrained(cls, path: str) -> "Pipeline":
+    def from_pretrained(cls, path: Union[str, Path]) -> "Pipeline":
         """Loads a pretrained pipeline providing a *model.tar.gz* file path
 
         Parameters
@@ -156,7 +156,7 @@ class Pipeline:
             overrides={"dataset_reader": {"type": "interleaving", "readers": {}}},
         )
         model = cls._model_from_archive(archive)
-        model.file_path = path
+        model.file_path = str(path)
         config = cls._config_from_archive(archive)
 
         if not isinstance(model, PipelineModel):

--- a/tests/text/conftest.py
+++ b/tests/text/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from biome.text._helpers import PipelineTrainer
+from biome.text.training_results import TrainingResults
 
 
 @pytest.fixture
@@ -11,6 +12,8 @@ def deactivate_pipeline_trainer(monkeypatch):
     monkeypatch.setattr(PipelineTrainer, "__init__", mock_init)
 
     def mock_train(*args, **kwargs):
-        return "mock_output_path", {"mock_metric": 0.0}
+        return TrainingResults(
+            model_path="mock_output_path", metrics={"mock_metric": 0.0}
+        )
 
     monkeypatch.setattr(PipelineTrainer, "train", mock_train)

--- a/tests/text/test_pipeline_datasets.py
+++ b/tests/text/test_pipeline_datasets.py
@@ -52,7 +52,7 @@ def test_training_with_data_bucketing(
     pipeline: Pipeline, dataset: Dataset, tmp_path: str
 ):
     configuration = TrainerConfiguration(
-        data_bucketing=True, batch_size=2, num_epochs=5
+        data_bucketing=True, batch_size=2, num_epochs=5, cuda_device=-1
     )
 
     pipeline.copy().train(
@@ -102,7 +102,7 @@ def test_training_from_pretrained_with_head_replace(
 
 def test_training_with_logging(pipeline: Pipeline, dataset: Dataset, tmp_path: str):
     configuration = TrainerConfiguration(
-        data_bucketing=True, batch_size=2, num_epochs=5
+        data_bucketing=True, batch_size=2, num_epochs=5, cuda_device=-1
     )
     output_dir = os.path.join(tmp_path, "output")
     pipeline.train(


### PR DESCRIPTION
This PR is just a small refactoring/cleanup:
- reordered methods in the `Pipeline` class
- moved the init/end epoch callbacks to the `PipelineTrainer`