### PR TITLE
Fix: Batch predictions always return a list

### DIFF
--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -535,9 +535,9 @@ class Pipeline:
         predictions = self._model.predict(batch, prediction_config)
 
         return (
-            [prediction.as_dict() for prediction in predictions]
-            if len(predictions) > 1
-            else predictions[0].as_dict()
+            predictions[0].as_dict()
+            if (args or kwargs)
+            else [prediction.as_dict() for prediction in predictions]
         )
 
     def _map_args_kwargs_to_input(self, *args, **kwargs) -> Dict[str, Any]:

--- a/tests/text/test_pipeline_predict.py
+++ b/tests/text/test_pipeline_predict.py
@@ -52,7 +52,10 @@ def test_return_single_or_list(pipeline, monkeypatch):
     monkeypatch.setattr(pipeline._model, "predict", mock_predict)
 
     assert isinstance(pipeline.predict("test"), dict)
-    assert isinstance(pipeline.predict(batch=[{"text": "test"}]), dict)
+
+    batch_prediction = pipeline.predict(batch=[{"text": "test"}])
+    assert isinstance(batch_prediction, list) and len(batch_prediction) == 1
+    assert isinstance(batch_prediction[0], dict)
 
     batch_prediction = pipeline.predict(batch=[{"text": "test"}, {"text": "test"}])
     assert isinstance(batch_prediction, list) and len(batch_prediction) == 2


### PR DESCRIPTION
With this PR a batch prediction (`Pipeline.predict(batch=...)`) always returns a list, **also** with length == 1.