### PR TITLE
Feat/pipeline as mlflow model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
             "gevent~=20.9.0",
             "ipywidgets~=7.5.1",
             "lxml~=4.6.2",
-            "mlflow~=1.9.0",
+            "mlflow~=1.13.1",
             "pandas~=1.1.0",
             "ray[tune]~=1.0.0",
             "s3fs~=0.4.0",

--- a/src/biome/text/mlflow_model.py
+++ b/src/biome/text/mlflow_model.py
@@ -1,3 +1,8 @@
+"""Docstring for the mlflow_model.py module
+
+This module is only used by MLFlow internally for loading a Pipeline as MLFlow model from an MLFlow Tracking server.
+"""
+
 import pandas as pd
 
 from biome.text import Pipeline

--- a/src/biome/text/mlflow_model.py
+++ b/src/biome/text/mlflow_model.py
@@ -10,9 +10,6 @@ class BiomeTextModel:
     def predict(self, dataframe: pd.DataFrame):
         batch = dataframe.to_dict(orient="records")
         predictions = self.pipeline.predict(batch=batch)
-        # covering the case when batch size is 1
-        if not isinstance(predictions, list):
-            predictions = [predictions]
 
         return pd.DataFrame(predictions)
 

--- a/src/biome/text/mlflow_model.py
+++ b/src/biome/text/mlflow_model.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+from biome.text import Pipeline
+
+
+class BiomeTextModel:
+    def __init__(self, pipeline: Pipeline):
+        self.pipeline = pipeline
+
+    def predict(self, dataframe: pd.DataFrame):
+        batch = dataframe.to_dict(orient="records")
+        predictions = self.pipeline.predict(batch=batch)
+        # covering the case when batch size is 1
+        if not isinstance(predictions, list):
+            predictions = [predictions]
+
+        return pd.DataFrame(predictions)
+
+
+def _load_pyfunc(path: str):
+    pipeline = Pipeline.from_pretrained(path)
+
+    return BiomeTextModel(pipeline)

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -9,8 +9,10 @@ from inspect import Parameter
 from pathlib import Path
 from typing import Any
 from typing import Dict
+from typing import Iterator
 from typing import List
 from typing import Optional
+from typing import Tuple
 from typing import Type
 from typing import Union
 from typing import cast
@@ -704,7 +706,7 @@ class Pipeline:
         self._config.head = TaskHeadConfiguration(type=type, **kwargs)
         self._model.set_head(self._config.head.compile(backbone=self.backbone))
 
-    def model_parameters(self):
+    def model_parameters(self) -> Iterator[Tuple[str, torch.Tensor]]:
         """Returns an iterator over all model parameters, yielding the name and the parameter itself.
 
         Examples

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -734,8 +734,19 @@ class Pipeline:
 
         return pipeline_copy
 
-    def save(self, directory: Union[str, Path]):
-        """Saves the pipeline in the given directory as `model.tar.gz` file."""
+    def save(self, directory: Union[str, Path]) -> str:
+        """Saves the pipeline in the given directory as `model.tar.gz` file.
+
+        Parameters
+        ----------
+        directory
+            Save the 'model.tar.gz' file to this directory.
+
+        Returns
+        -------
+        file_path
+            Path to the 'model.tar.gz' file.
+        """
         if isinstance(directory, str):
             directory = Path(directory)
 

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -807,7 +807,7 @@ class Pipeline:
         ... })
         >>> model_uri = pipeline.to_mlflow()
         >>> model = mlflow.pyfunc.load_model(model_uri)
-        >>> model.predict(pandas.DataFrame([{"text": "Test this text"}]))
+        >>> preciction: pandas.DataFrame = model.predict(pandas.DataFrame([{"text": "Test this text"}]))
         """
         if tracking_uri:
             mlflow.set_tracking_uri(tracking_uri)

--- a/tests/text/test_pipeline_save.py
+++ b/tests/text/test_pipeline_save.py
@@ -1,0 +1,26 @@
+import pytest
+from numpy.testing import assert_allclose
+
+from biome.text import Pipeline
+
+
+@pytest.fixture
+def pipeline():
+    return Pipeline.from_config(
+        {
+            "name": "test_pipeline_copy",
+            "head": {"type": "TextClassification", "labels": ["a", "b"]},
+        }
+    )
+
+
+def test_save(pipeline, tmp_path):
+    pipeline.save(tmp_path)
+
+    assert (tmp_path / "model.tar.gz").is_file()
+
+    expected_prediction = pipeline.predict("test")
+    prediction = Pipeline.from_pretrained(tmp_path / "model.tar.gz").predict("test")
+
+    assert prediction["labels"] == expected_prediction["labels"]
+    assert_allclose(prediction["probabilities"], expected_prediction["probabilities"])

--- a/tests/text/test_pipeline_to_mlflow.py
+++ b/tests/text/test_pipeline_to_mlflow.py
@@ -1,0 +1,40 @@
+import mlflow
+import pandas as pd
+import pytest
+from numpy.testing import assert_allclose
+
+from biome.text import Pipeline
+
+
+@pytest.fixture
+def pipeline():
+    return Pipeline.from_config(
+        {
+            "name": "test_pipeline_copy",
+            "head": {"type": "TextClassification", "labels": ["a", "b"]},
+        }
+    )
+
+
+def test_to_mlflow(pipeline, tmp_path):
+    test_str_for_prediction = "test this prediction"
+    expected_prediction = pipeline.predict(text=test_str_for_prediction)
+
+    model_uri = pipeline.to_mlflow(
+        tracking_uri=str(tmp_path / "to_mlflow_test"), experiment_id=0
+    )
+
+    df = mlflow.search_runs(experiment_ids=["0"])
+    assert len(df) == 1 and df["tags.mlflow.runName"][0] == "Log biome.text model"
+
+    # load MLFlow model and make predictions
+    model = mlflow.pyfunc.load_model(model_uri=model_uri)
+    prediction: pd.DataFrame = model.predict(
+        pd.DataFrame([{"text": test_str_for_prediction}])
+    )
+
+    assert len(prediction) == 1
+    assert expected_prediction["labels"] == prediction["labels"][0]
+    assert_allclose(
+        expected_prediction["probabilities"], prediction["probabilities"][0]
+    )


### PR DESCRIPTION
This PR adds the feature of logging a pipeline as an MLFlow model to an MLFlow Tracking server. As a side feature you can now simply save the Pipeline as a `model.tar.gz` file via `Pipeline.save(output_path)`.

Example usage of the new feature:
```python
>>> import mlflow, pandas, biome.text
>>> pipeline = biome.text.Pipeline.from_config({
...     "name": "to_mlflow_example",
...     "head": {"type": "TextClassification", "labels": ["a", "b"]},
... })
>>> model_uri = pipeline.to_mlflow()
>>> model = mlflow.pyfunc.load_model(model_uri)
>>> preciction: pandas.DataFrame = model.predict(pandas.DataFrame([{"text": "Test this text"}]))
```