### PR TITLE
CI: Only upload docs build if necessary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
           make build_docs
           tar -czf docs_build_output.tar.gz docs/site
       - name: Upload Build Output 🍕
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
         uses: actions/upload-artifact@v2
         with:
           name: docs_build_output


### PR DESCRIPTION
Small improvement of our CI, by avoiding the upload of the docs build if not necessary.