### PR TITLE
Feat/add doctest to our test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ check: ## applies a code pylint with autopep8 reformating
 
 test: ## launch package tests
 	@python -m pytest
+	@python -m pytest --doctest-modules src/biome/text
 
 ui: ## serve the UI for development
 	@cd ui && npm install && npm run serve

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -24,7 +24,7 @@ from elasticsearch import Elasticsearch
 from spacy.tokens import Token as SpacyToken
 from spacy.tokens.doc import Doc
 
-from . import environment
+from biome.text import environment
 
 _INVALID_TAG_CHARACTERS = re.compile(r"[^-/\w\.]")
 
@@ -387,9 +387,12 @@ def merge_dicts(source: Dict[str, Any], destination: Dict[str, Any]) -> Dict[str
     """
     Merge two dictionaries recursivelly
 
+    Examples
+    --------
     >>> a = { 'first' : { 'all_rows' : { 'pass' : 'dog', 'number' : '1' } } }
     >>> b = { 'first' : { 'all_rows' : { 'fail' : 'cat', 'number' : '5' } } }
-    >>> merge_dicts(b, a) == { 'first' : { 'all_rows' : { 'pass' : 'dog', 'fail' : 'cat', 'number' : '5' } } }
+    >>> merge_dicts(b, a)
+    {'first': {'all_rows': {'pass': 'dog', 'number': '5', 'fail': 'cat'}}}
 
     """
     if not isinstance(destination, dict):

--- a/src/biome/text/hpo.py
+++ b/src/biome/text/hpo.py
@@ -1,6 +1,6 @@
 """
-This module includes all components related to a HPO experiment execution.
-It tries to allow for a simple integration with HPO libraries like Ray Tune.
+This module includes all components related to an HPO experiment execution.
+It tries to allow for a simple integration with the HPO library 'Ray Tune'.
 """
 import tempfile
 from datetime import datetime
@@ -54,10 +54,6 @@ class TuneMetricsLogger(BaseTrainLogger):
 class TuneExperiment(tune.Experiment):
     """This class provides a trainable function and a config to conduct an HPO with `ray.tune.run`
 
-    Minimal usage:
-    >>> my_exp = TuneExperiment(pipeline_config, trainer_config, train_dataset, valid_dataset)
-    >>> tune.run(my_exp)
-
     Parameters
     ----------
     pipeline_config
@@ -88,6 +84,25 @@ class TuneExperiment(tune.Experiment):
         The trainable function used by ray tune
     config
         The config dict passed on to the trainable function
+
+    Examples
+    --------
+    A minimal usage would be:
+
+    >>> from biome.text import Dataset
+    >>> from ray import tune
+    >>> pipeline_config = {
+    ...     "name": "tune_experiment_example",
+    ...     "head": {"type": "TextClassification", "labels": ["a", "b"]},
+    ... }
+    >>> trainer_config = {
+    ...     "optimizer": {"type": "adam", "lr": tune.loguniform([1e-3, 1e-2])}
+    ... }
+    >>> train_dataset = Dataset.from_dict({"text": ["test", "this"], "label": ["a", "b"]})
+    >>> valid_dataset = Dataset.from_dict({"text": ["test", "this"], "label": ["a", "b"]})
+    >>> my_exp = TuneExperiment(pipeline_config, trainer_config, train_dataset, valid_dataset, num_samples=10)
+    >>> tune.run(my_exp) # doctest: +SKIP
+
     """
 
     def __init__(

--- a/src/biome/text/hpo.py
+++ b/src/biome/text/hpo.py
@@ -96,7 +96,7 @@ class TuneExperiment(tune.Experiment):
     ...     "head": {"type": "TextClassification", "labels": ["a", "b"]},
     ... }
     >>> trainer_config = {
-    ...     "optimizer": {"type": "adam", "lr": tune.loguniform([1e-3, 1e-2])}
+    ...     "optimizer": {"type": "adam", "lr": tune.loguniform(1e-3, 1e-2)}
     ... }
     >>> train_dataset = Dataset.from_dict({"text": ["test", "this"], "label": ["a", "b"]})
     >>> valid_dataset = Dataset.from_dict({"text": ["test", "this"], "label": ["a", "b"]})

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -704,10 +704,18 @@ class Pipeline:
     def model_parameters(self):
         """Returns an iterator over all model parameters, yielding the name and the parameter itself.
 
-        You can use this to freeze certain parameters in the training, example:
-        >>> for name, parameter in self.model_parameters():
-        >>>     if not name.endswith("bias"):
-        >>>         parameter.requires_grad = False
+        Examples
+        --------
+        You can use this to freeze certain parameters in the training:
+
+        >>> pipeline = Pipeline.from_config({
+        ...     "name": "model_parameters_example",
+        ...     "head": {"type": "TextClassification", "labels": ["a", "b"]},
+        ... })
+        >>> for name, parameter in pipeline.model_parameters():
+        ...     if not name.endswith("bias"):
+        ...         parameter.requires_grad = False
+
         """
         return self._model.named_parameters()
 


### PR DESCRIPTION
This PR runs the doc string examples in our source code via [doctest](https://docs.python.org/3/library/doctest.html) as part of our test suite.