### PR TITLE
Fix/attributions tokens when token idx is none

### DIFF
--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -184,7 +184,9 @@ class DocumentClassification(ClassificationHead):
                 Attribution(
                     text=token.text,
                     start=token.idx,
-                    end=token.idx + len(token.text),
+                    end=token.idx + len(token.text)
+                    if isinstance(token.idx, int)
+                    else None,
                     field=self.forward_arg_name,
                     attribution=attribution,
                 )

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -146,7 +146,7 @@ class TextClassification(ClassificationHead):
             Attribution(
                 text=token.text,
                 start=token.idx,
-                end=token.idx + len(token.text),
+                end=token.idx + len(token.text) if isinstance(token.idx, int) else None,
                 field=self.forward_arg_name,
                 attribution=attribution,
             )

--- a/src/biome/text/modules/heads/task_head.py
+++ b/src/biome/text/modules/heads/task_head.py
@@ -199,7 +199,7 @@ class TaskHead(torch.nn.Module, Registrable):
             Token(
                 text=token.text,
                 start=token.idx,
-                end=token.idx + len(token.text),
+                end=token.idx + len(token.text) if isinstance(token.idx, int) else None,
                 field=name,
             )
             for token in field


### PR DESCRIPTION
This PR fixes an issue found by @ignacioct when trying to extract tokens or calculate attributions when `Token.idx` is `None` for the input.