### PR TITLE
Feat/remove pipeline serve

### DIFF
--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -6,10 +6,8 @@ from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import cast
 
-import uvicorn
 from allennlp.common import Params
 from allennlp.common.util import prepare_environment
 from allennlp.common.util import sanitize
@@ -20,7 +18,6 @@ from allennlp.models.archival import CONFIG_NAME
 from allennlp.training import GradientDescentTrainer
 from allennlp.training import Trainer
 from allennlp.training.util import evaluate
-from fastapi import FastAPI
 from torch.utils.data import IterableDataset
 
 from biome.text import Pipeline
@@ -28,41 +25,9 @@ from biome.text import TrainerConfiguration
 from biome.text import helpers
 from biome.text._model import PipelineModel
 from biome.text.dataset import InstancesDataset
-from biome.text.errors import http_error_handling
 from biome.text.training_results import TrainingResults
 
 _LOGGER = logging.getLogger(__name__)
-
-
-def _serve(pipeline: Pipeline, port: int):
-    """Serves an pipeline as rest api"""
-
-    def make_app() -> FastAPI:
-        app = FastAPI()
-
-        @app.post("/predict")
-        async def predict(inputs: Dict[str, Any]):
-            with http_error_handling():
-                return sanitize(pipeline.predict(**inputs))
-
-        @app.post("/predict_with_attributions")
-        async def explain(inputs: Dict[str, Any]):
-            with http_error_handling():
-                return sanitize(pipeline.predict(**inputs, add_attributions=True))
-
-        @app.get("/_config")
-        async def config():
-            with http_error_handling():
-                return pipeline.config.as_dict()
-
-        @app.get("/_status")
-        async def status():
-            with http_error_handling():
-                return {"ok": True}
-
-        return app
-
-    uvicorn.run(make_app(), host="0.0.0.0", port=port)
 
 
 class PipelineTrainer:

--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -12,24 +12,14 @@ from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
-from typing import Tuple
 from typing import Type
-from typing import Union
-from typing import cast
 
 import allennlp
-import numpy
 import torch
 from allennlp.common import Params
 from allennlp.common.util import sanitize
-from allennlp.data import Field
 from allennlp.data import Instance
-from allennlp.data import Token
 from allennlp.data import Vocabulary
-from allennlp.data.fields import ListField
-from allennlp.data.fields import MetadataField
-from allennlp.data.fields import SequenceLabelField
-from allennlp.data.fields import TextField
 from allennlp.models.archival import CONFIG_NAME
 
 from . import vocabulary

--- a/src/biome/text/cli/serve.py
+++ b/src/biome/text/cli/serve.py
@@ -2,6 +2,7 @@ import click
 from click import Path
 
 from biome.text import Pipeline
+from biome.text._helpers import _serve
 
 
 @click.command()
@@ -27,8 +28,9 @@ def serve(pipeline_path: str, port: int, predictions_dir: str) -> None:
     PIPELINE_PATH is the path to a pretrained pipeline (model.tar.gz file).
     """
     pipeline = Pipeline.from_pretrained(pipeline_path)
+    pipeline._model.eval()
 
     if predictions_dir:
         pipeline.init_prediction_logger(predictions_dir)
 
-    pipeline.serve(port)
+    return _serve(pipeline, port)

--- a/src/biome/text/cli/serve.py
+++ b/src/biome/text/cli/serve.py
@@ -95,7 +95,7 @@ def _serve(pipeline: Pipeline, port: int):
     def make_app() -> FastAPI:
         app = FastAPI()
 
-        error_msg = f". Check the docs at '0.0.0.0:{port}/docs' for an example of a valid request body."
+        error_msg = f"\nCheck the docs at '0.0.0.0:{port}/docs' for an example of a valid request body."
 
         @app.exception_handler(RequestValidationError)
         async def validation_exception_handler(request, exc):

--- a/src/biome/text/cli/serve.py
+++ b/src/biome/text/cli/serve.py
@@ -1,14 +1,23 @@
+import inspect
 from typing import Any
+from typing import Callable
 from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
 
 import click
 import uvicorn
 from allennlp.common.util import sanitize
 from click import Path
 from fastapi import FastAPI
+from fastapi import HTTPException
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import PlainTextResponse
+from pydantic import create_model
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from biome.text import Pipeline
-from biome.text.errors import http_error_handling
 
 
 @click.command()
@@ -44,14 +53,69 @@ def serve(pipeline_path: str, port: int, predictions_dir: str) -> None:
 
 def _serve(pipeline: Pipeline, port: int):
     """Serves an pipeline as rest api"""
+    predict_parameters = inspect.signature(pipeline.predict).parameters
+    model_parameters = {
+        name: (
+            par.annotation,
+            None,  # We need a default value to allow for batch predictions!
+        )
+        for name, par in predict_parameters.items()
+        if par.default == inspect.Parameter.empty
+    }
+    optional_parameters = {
+        name: (par.annotation, par.default)
+        for name, par in predict_parameters.items()
+        # The batch parameter needs an extra logic to allow for a proper BaseModel for it
+        if par.default != inspect.Parameter.empty and name != "batch"
+    }
+
+    class Config:
+        extra = "forbid"
+
+    ModelInput = create_model("ModelInput", **model_parameters, __config__=Config)
+    PredictInput = create_model(
+        "PredictInput",
+        **model_parameters,
+        batch=(List[ModelInput], None),
+        **optional_parameters,
+        __config__=Config,
+    )
+
+    class http_error_handling:
+        """Error handling for http error transcription"""
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            if isinstance(exc_val, Exception):
+                # Common http error handling
+                raise HTTPException(status_code=500, detail=str(exc_val))
 
     def make_app() -> FastAPI:
         app = FastAPI()
 
+        error_msg = f". Check the docs at '0.0.0.0:{port}/docs' for an example of a valid request body."
+
+        @app.exception_handler(RequestValidationError)
+        async def validation_exception_handler(request, exc):
+            return PlainTextResponse(str(exc) + error_msg, status_code=400)
+
+        @app.exception_handler(StarletteHTTPException)
+        async def http_exception_handler(request, exc):
+            if exc.status_code == 400:
+                return PlainTextResponse(
+                    str(exc.detail) + error_msg, status_code=exc.status_code
+                )
+            else:
+                return PlainTextResponse(str(exc.detail), status_code=exc.status_code)
+
         @app.post("/predict")
-        async def predict(inputs: Dict[str, Any]):
+        async def predict(predict_input: PredictInput):
             with http_error_handling():
-                return sanitize(pipeline.predict(**inputs))
+                return sanitize(
+                    pipeline.predict(**predict_input.dict(skip_defaults=True))
+                )
 
         @app.get("/_config")
         async def config():

--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -20,6 +20,8 @@ from biome.text.backbone import ModelBackbone
 from biome.text.metrics import MultiLabelF1Measure
 from biome.text.modules.heads.task_head import TaskHead
 from biome.text.modules.heads.task_head import TaskName
+from biome.text.modules.heads.task_prediction import Attribution
+from biome.text.modules.heads.task_prediction import TaskPrediction
 
 
 class ClassificationHead(TaskHead):
@@ -220,3 +222,22 @@ class ClassificationHead(TaskHead):
                     final_metrics.update({"_{}/{}".format(k, label): v})
 
         return final_metrics
+
+    def forward(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
+        raise NotImplementedError
+
+    def featurize(self, *args, **kwargs) -> Optional[Instance]:
+        raise NotImplementedError
+
+    def _make_task_prediction(
+        self, single_forward_output: Dict[str, numpy.ndarray], instance: Instance
+    ) -> TaskPrediction:
+        raise NotImplementedError
+
+    def _compute_attributions(
+        self,
+        single_forward_output: Dict[str, numpy.ndarray],
+        instance: Instance,
+        **kwargs,
+    ) -> List[Union[Attribution, List[Attribution]]]:
+        raise NotImplementedError

--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 from typing import Dict
 from typing import List
@@ -25,6 +26,7 @@ class ClassificationHead(TaskHead):
     """Base abstract class for classification problems"""
 
     task_name = TaskName.text_classification
+    _LOGGER = logging.getLogger(__name__)
 
     def __init__(
         self, backbone: ModelBackbone, labels: List[str], multilabel: bool = False
@@ -76,6 +78,9 @@ class ClassificationHead(TaskHead):
             field = LabelField(label, label_namespace=vocabulary.LABELS_NAMESPACE)
         if not field:
             # We have label info but we cannot build the label field --> discard the instance
+            self._LOGGER.warning(
+                f"Cannot create a label field for {label}, discarding instance."
+            )
             return None
 
         instance.add_field(to_field, field)

--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -88,8 +88,8 @@ class DocumentClassification(ClassificationHead):
 
     def featurize(
         self,
-        text: Any,
-        label: Optional[Union[int, str, List[Union[int, str]]]] = None,
+        text: Union[List[str], Dict[str, str]],
+        label: Optional[Union[str, List[str]]] = None,
     ) -> Optional[Instance]:
         instance = self.backbone.featurizer(
             text, to_field=self.forward_arg_name, exclude_record_keys=True

--- a/src/biome/text/modules/heads/classification/record_classification.py
+++ b/src/biome/text/modules/heads/classification/record_classification.py
@@ -52,7 +52,7 @@ class RecordClassification(DocumentClassification):
         return self._inputs
 
     def featurize(
-        self, label: Optional[Union[List[str], List[int], str, int]] = None, **inputs
+        self, label: Optional[Union[str, List[str]]] = None, **inputs
     ) -> Optional[Instance]:
 
         instance = self.backbone.featurizer(

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -130,19 +130,19 @@ class RecordPairClassification(ClassificationHead):
 
     def featurize(
         self,
-        record1: Dict[str, Any],
-        record2: Dict[str, Any],
+        record1: Dict[str, str],
+        record2: Dict[str, str],
         label: Optional[str] = None,
     ) -> Optional[Instance]:
         """Tokenizes, indexes and embeds the two records and optionally adds the label
 
         Parameters
         ----------
-        record1 : Dict[str, Any]
+        record1
             First record
-        record2 : Dict[str, Any]
+        record2
             Second record
-        label : Optional[str]
+        label
             Classification label
 
         Returns

--- a/src/biome/text/modules/heads/classification/relation_classification.py
+++ b/src/biome/text/modules/heads/classification/relation_classification.py
@@ -78,9 +78,9 @@ class RelationClassification(ClassificationHead):
 
     def featurize(
         self,
-        text: Any,
+        text: Union[str, List[str], Dict[str, str]],
         entities: List[Dict],
-        label: Optional[Union[int, str, List[Union[int, str]]]] = None,
+        label: Optional[Union[str, List[str]]] = None,
     ) -> Optional[Instance]:
 
         instance = self.backbone.featurizer(

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -57,7 +57,9 @@ class TextClassification(ClassificationHead):
         )
 
     def featurize(
-        self, text: Any, label: Optional[Union[int, str, List[Union[int, str]]]] = None
+        self,
+        text: Union[str, List[str], Dict[str, str]],
+        label: Optional[Union[str, List[str]]] = None,
     ) -> Optional[Instance]:
         instance = self.backbone.featurizer(
             text,

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -677,19 +677,6 @@ class Pipeline:
         finally:
             self._model.to(prior_device if prior_device >= 0 else "cpu")
 
-    def serve(self, port: int = 9998):
-        """Launches a REST prediction service with the current model
-
-        Parameters
-        ----------
-        port: `int`
-            The port on which the prediction service will be running (default: 9998)
-        """
-        from ._helpers import _serve
-
-        self._model = self._model.eval()
-        return _serve(self, port)
-
     def set_head(self, type: Type[TaskHead], **kwargs):
         """Sets a new task head for the pipeline
 

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -73,8 +73,9 @@ class Pipeline:
     def _update_prediction_signatures(self):
         """Updates the `self.predict` signature to match the model inputs for interactive work-flows"""
         updated_parameters = [
-            Parameter(name=_input, kind=Parameter.POSITIONAL_OR_KEYWORD)
-            for _input in self.inputs
+            par
+            for name, par in inspect.signature(self.head.featurize).parameters.items()
+            if par.default == Parameter.empty
         ] + [
             par
             for name, par in inspect.signature(self.predict).parameters.items()
@@ -584,8 +585,18 @@ class Pipeline:
         predictions
             A dictionary or a list of dictionaries containing the predictions and additional information.
         """
+        # the signature of this method gets updated in the self.__init__
+        args_kwargs_names = [
+            f"`{name}`"
+            for name, par in inspect.signature(self.predict).parameters.items()
+            if par.default == inspect.Parameter.empty
+        ]
+
         if ((args or kwargs) and batch) or not (args or kwargs or batch):
-            raise ValueError("Please provide either 'arg/kwargs' OR a 'batch'")
+            raise ValueError(
+                f"Please provide either {' and '.join(args_kwargs_names)}, OR a `batch`"
+            )
+
         if args or kwargs:
             batch = [self._map_args_kwargs_to_input(*args, **kwargs)]
 


### PR DESCRIPTION
This PR removes the `Pipeline.serve` method, and improves the cli `biome serve` command by adding pydantic `BaseModel`s to the API, for validating the request body and improving the error messages.

- request body cannot be parsed:
```
There was an error parsing the body. 
Check the docs at '0.0.0.0:8888/docs' for an example of a valid request body.
```
- request body does not comply with the `BaseModel`, for example:
```
1 validation error for Request
body -> predict_input -> texttt
  extra fields not permitted (type=value_error.extra). 
Check the docs at '0.0.0.0:8888/docs' for an example of a valid request body.
```
- Screenshot of the docs:
![Screenshot from 2021-02-03 13-39-36](https://user-images.githubusercontent.com/15979778/106748295-53c25580-6625-11eb-8413-313777c54bd9.png)
