### PR TITLE
Docs: Deployment section in our 'User Guides'

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
     <br>
 <p>
 <p align="center">
-    <a href="https://travis-ci.com/recognai/biome-text">
-        <img alt="Build" src="https://travis-ci.org/recognai/biome-text.svg?branch=master">
+    <a href="https://github.com/recognai/biome-text/actions">
+        <img alt="CI" src="https://github.com/recognai/biome-text/workflows/CI/badge.svg?branch=master&event=push">
     </a>
     <a href="https://github.com/recognai/biome-text/blob/master/LICENSE.txt">
         <img alt="GitHub" src="https://img.shields.io/github/license/recognai/biome-text.svg?color=blue">
     </a>
-    <a href="https://www.recogn.ai/biome-text/index.html">
+    <a href="https://www.recogn.ai/biome-text/">
         <img alt="Documentation" src="https://img.shields.io/website/http/www.recogn.ai/biome-text/index.html.svg?down_color=red&down_message=offline&up_message=online">
     </a>
     <a href="https://github.com/recognai/biome-text/releases">
@@ -23,7 +23,7 @@
 </h3>
 
 ## Quick Links
-- [Documentation](https://www.recogn.ai/biome-text/documentation/)
+- [Documentation](https://www.recogn.ai/biome-text/)
 
 
 ## Features
@@ -69,9 +69,9 @@ docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elas
 
 ## Get started
 
-The best way to see how *biome.text* works is to go through our [first tutorial](https://www.recogn.ai/biome-text/documentation/tutorials/1-Training_a_text_classifier.html).
+The best way to see how *biome.text* works is to go through our [first tutorial](https://www.recogn.ai/biome-text/master/documentation/tutorials/1-Training_a_text_classifier.html).
 
-Please refer to our [documentation](https://www.recogn.ai/biome-text) for more tutorials, detailed user guides and how you can [contribute](https://www.recogn.ai/biome-text/documentation/community/contributing.html) to *biome.text*.
+Please refer to our [documentation](https://www.recogn.ai/biome-text) for more tutorials, detailed user guides and how you can [contribute](https://www.recogn.ai/biome-text/master/documentation/community/contributing.html) to *biome.text*.
 
 ## Licensing
 

--- a/docs/docs/documentation/tutorials/1-Training_a_text_classifier.ipynb
+++ b/docs/docs/documentation/tutorials/1-Training_a_text_classifier.ipynb
@@ -621,7 +621,7 @@
     "\n",
     "To check and understand the predictions of the model, we can use the *biome.text explore UI*.\n",
     "Just calling the [explore.create](https://www.recogn.ai/biome-text/master/api/biome/text/explore.html#create) method will open the UI in the output of our cell.\n",
-    "We will set the `explain` argument to true, which automatically visualizes the attribution of each token by means of [integrated gradients](https://arxiv.org/abs/1703.01365).\n"
+    "We will set the `attributions` argument to true, which automatically visualizes the attribution of each token to the prediction by means of [integrated gradients](https://arxiv.org/abs/1703.01365).\n"
    ]
   },
   {
@@ -648,7 +648,7 @@
    },
    "outputs": [],
    "source": [
-    "explore.create(pl_trained, valid_ds, explain=True)"
+    "explore.create(pl_trained, valid_ds, attributions=True)"
    ]
   },
   {

--- a/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
+++ b/docs/docs/documentation/tutorials/3-Hyperparameter_optimization_with_Ray_Tune.ipynb
@@ -488,7 +488,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "explore.create(pl_trained, valid_ds, explain=True)"
+    "explore.create(pl_trained, valid_ds, attributions=True)"
    ]
   },
   {

--- a/docs/docs/documentation/user-guides/3-deployment.md
+++ b/docs/docs/documentation/user-guides/3-deployment.md
@@ -8,7 +8,11 @@ or deploying it directly on Microsoft Azure ML or Amazon SageMaker.
 ## Built-in deployment via FastAPI
 ### Start the REST endpoint
 
-Once we have defined and trained a model, and endpoint with the API REST can be established using the command `biome serve [path to output/model.tar.gz] -p 9999`.
+Once we have defined and trained a model, and endpoint with the API REST can be established using the command
+
+```bash
+biome serve path/to/output/model.tar.gz
+```
 
 If everything is correct, the server process will begin by the application startup, and when it's done, we will receive the following message in the terminal:
 

--- a/docs/docs/documentation/user-guides/3-deployment.md
+++ b/docs/docs/documentation/user-guides/3-deployment.md
@@ -6,5 +6,36 @@ and take advantage of all its deployment tools like packaging the model as self-
 or deploying it directly on Microsoft Azure ML or Amazon SageMaker.
 
 ## Built-in deployment via FastAPI
+### Start the REST endpoint
+
+Once we have defined and trained a model, and endpoint with the API REST can be established using the command `biome serve [path to output/model.tar.gz] -p 9999`.
+
+If everything is correct, the server process will begin by the application startup, and when it's done, we will receive the following message in the terminal:
+
+```bash
+INFO:     Uvicorn running on http://0.0.0.0:9999 (Press CTRL+C to quit)
+```
+
+At this point, everything is up and running. We can access the documentation of the API in our browsers following this direction: `http://0.0.0.0:9999/docs`
+
+### Quick-tour of the API
+
+When the API docs are open, the defaults calls that we can make are shown to us. These calls are the ones provided by [FastAPI](https://fastapi.tiangolo.com/), like *config*, *status* and *predict*
+
+### Making predictions
+
+As we came from a trained model, we can make predictions right away. We can use the predict POST call, which is equivalent to the `Pipeline.predict()` made on Python.
+
+If we open the predict section and click on "*Try it out*", the API will offer us a text field to write out our message. The input text must be structured as a Python dictionary, so we can write:
+
+```python
+{
+	"text": "Hello",
+	"add_tokens": false,
+	"add_attributions": false
+}
+```
+
+If we press "*Execute*", we can see the POST call in Curl and the request URL at which we send the call. We can also see the server response, with the response call, the response body and headers, and a description of the call in case it can be useful (e.g. in an error response).
 
 ## Deployment via MLFlow Models

--- a/docs/docs/documentation/user-guides/3-deployment.md
+++ b/docs/docs/documentation/user-guides/3-deployment.md
@@ -1,45 +1,142 @@
 # Deployment
 
-*Biome.text* provides an easy to use built-in tool to deploy your model on a local machine as a REST API via [FastAPI](https://fastapi.tiangolo.com/).
-Additionally, you can easily export your pipeline to an [MLFlow Model](https://mlflow.org/docs/latest/models.html#mlflow-models)
-and take advantage of all its deployment tools like packaging the model as self-contained Docker image with a REST API endpoint,
-or deploying it directly on Microsoft Azure ML or Amazon SageMaker.
+*Biome.text* provides an easy to use built-in tool to deploy your model
+on a local machine as a REST API via [FastAPI](https://fastapi.tiangolo.com/).
+Additionally, you can easily export your pipeline to an
+[MLFlow Model](https://mlflow.org/docs/latest/models.html#mlflow-models)
+and take advantage of all its deployment tools, like packaging the model as self-contained Docker image
+with a REST API endpoint  or deploying it directly on Microsoft Azure ML or Amazon SageMaker.
 
 ## Built-in deployment via FastAPI
-### Start the REST endpoint
 
-Once we have defined and trained a model, and endpoint with the API REST can be established using the command
+The built-in tool uses [FastAPI](https://fastapi.tiangolo.com/) and an [Uvicorn](https://www.uvicorn.org/) server
+to expose the model as an API REST service.
+
+### Start the REST service
+
+For the REST service we need to save our pipeline as a `model.tar.gz` file on disk.
+This can be achieved by either training our pipeline with `Pipeline.train()`, in which case the `model.tar.gz` file is part
+of the training output, or by simply calling `Pipeline.save()` to serialize the pipeline in its current state.
+With the `model.tar.gz` file at hand we use the *biome.text* CLI to start the API REST service from the terminal:
 
 ```bash
 biome serve path/to/output/model.tar.gz
 ```
 
-If everything is correct, the server process will begin by the application startup, and when it's done, we will receive the following message in the terminal:
+If everything is correct, the Uvicorn server starts, and we should see following message in the terminal:
 
 ```bash
 INFO:     Uvicorn running on http://0.0.0.0:9999 (Press CTRL+C to quit)
 ```
 
-At this point, everything is up and running. We can access the documentation of the API in our browsers following this direction: `http://0.0.0.0:9999/docs`
+At this point, everything is up and running.
+We can access the documentation of the API in our browsers following this direction: `http://0.0.0.0:9999/docs`
 
 ### Quick-tour of the API
 
-When the API docs are open, the defaults calls that we can make are shown to us. These calls are the ones provided by [FastAPI](https://fastapi.tiangolo.com/), like *config*, *status* and *predict*
+The API docs provide an overview of the available endpoints of the REST service:
+  - the `/predict` endpoint allows POST requests and is equivalent to the `Pipeline.predict()` method
+  - the `/config` endpoint returns the pipeline configuration corresponding to `Pipeline.config`
+  - the `/_status` endpoint simply returns the status of the REST service
 
 ### Making predictions
 
-As we came from a trained model, we can make predictions right away. We can use the predict POST call, which is equivalent to the `Pipeline.predict()` made on Python.
+The best way to try out the `/predict` endpoint, is through the API docs.
+If we open the `/predict` section and click on "*Try it out*", the API will offer us a text field to provide our input.
+The text field already provides you with a valid data scheme, and you can simply change the values of the input parameters.
+For example, for a pipeline with a `TextClassification` head you could send following request body:
 
-If we open the predict section and click on "*Try it out*", the API will offer us a text field to write out our message. The input text must be structured as a Python dictionary, so we can write:
-
-```python
+```json
 {
-	"text": "Hello",
+	"text": "Hello, test this input",
 	"add_tokens": false,
-	"add_attributions": false
+	"add_attributions": true
 }
 ```
 
-If we press "*Execute*", we can see the POST call in Curl and the request URL at which we send the call. We can also see the server response, with the response call, the response body and headers, and a description of the call in case it can be useful (e.g. in an error response).
+If we press **Execute**, we can see the POST call with `Curl` and the request URL to which we sent the request body.
+We can also see the server response, with the response code, the response body and the response headers.
+The response body should include the prediction corresponding to your input,
+or a descriptive error message in case something went wrong.
+
 
 ## Deployment via MLFlow Models
+
+Let us go through a quick example to illustrate how to deploy your *biome.text* models via MLFlow Models.
+
+### Exporting the pipeline to MLFlow
+
+```python{4-9}
+from biome.text import Pipeline
+import mlflow, pandas
+
+pipeline = Pipeline.from_config({
+    "name": "to_mlflow_example",
+    "head": {"type": "TextClassification", "labels": ["a", "b"]},
+})
+
+model_uri = pipeline.to_mlflow()
+
+model = mlflow.pyfunc.load_model(model_uri)
+
+prediction: pandas.DataFrame = model.predict(pandas.DataFrame([{"text": "Test this text"}]))
+```
+
+First we need to export our pipeline as MLFlow model. In this example we use a basic untrained pipeline with a
+`TextClassification` head, but normally you would either load a pretrained pipeline via `Pipeline.from_pretrained()`
+or train the pipeline first before exporting it.
+To export the pipeline, you simply call `.to_mlflow()` that will log your pipeline as MLFlow model on a
+MLFlow Tracking Server.
+The tracking URI of the server, as well as the run name, and the experiment ID under which to log the model, are
+configurable parameters of the method.
+The returned string is the artifact URI of the MLFlow model that we can use to load or deploy our model with the
+MLFlow deployment tools.
+
+### Loading and deploying the MLFlow Model
+
+```python{11-13}
+from biome.text import Pipeline
+import mlflow, pandas
+
+pipeline = Pipeline.from_config({
+    "name": "to_mlflow_example",
+    "head": {"type": "TextClassification", "labels": ["a", "b"]},
+})
+
+model_uri = pipeline.to_mlflow()
+
+model = mlflow.pyfunc.load_model(model_uri)
+
+prediction: pandas.DataFrame = model.predict(pandas.DataFrame([{"text": "Test this text"}]))
+```
+
+To use the MLFlow model for inference, we feed our model URI to the `mlflow.pyfunc.load_model()` method and call
+`.predict()` on the loaded model.
+MLFlow models take as input a [pandas DataFrame](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html)
+and also return their predictions as a DataFrame.
+
+If we wanted to serve our MLFlow model as a local REST API, we could use the MLFlow CLI command
+[`mlflow models`](https://www.mlflow.org/docs/latest/cli.html#mlflow-models):
+
+```bash
+mlflow models serve -m <model_uri>
+```
+
+:::tip TIP
+
+Do not forget to set the `MLFLOW_TRACKING_URI` environment variable in case you use a
+different tracking server location than the default `./mlruns`.
+
+:::
+
+An example request for the served model would be:
+```bash
+curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
+    "columns": ["text"],
+    "data": ["test this input", "and this as well"]
+}'
+```
+
+For more details about how to exploit all MLFlow Model features,
+like deploying them on Microsoft Azure ML or Amazon SageMake, please refer to their
+[documentation](https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools).

--- a/docs/docs/documentation/user-guides/3-deployment.md
+++ b/docs/docs/documentation/user-guides/3-deployment.md
@@ -1,0 +1,10 @@
+# Deployment
+
+*Biome.text* provides an easy to use built-in tool to deploy your model on a local machine as a REST API via [FastAPI](https://fastapi.tiangolo.com/).
+Additionally, you can easily export your pipeline to an [MLFlow Model](https://mlflow.org/docs/latest/models.html#mlflow-models)
+and take advantage of all its deployment tools like packaging the model as self-contained Docker image with a REST API endpoint,
+or deploying it directly on Microsoft Azure ML or Amazon SageMaker.
+
+## Built-in deployment via FastAPI
+
+## Deployment via MLFlow Models

--- a/docs/docs/documentation/user-guides/3-deployment.md
+++ b/docs/docs/documentation/user-guides/3-deployment.md
@@ -7,6 +7,8 @@ Additionally, you can easily export your pipeline to an
 and take advantage of all its deployment tools, like packaging the model as self-contained Docker image
 with a REST API endpoint  or deploying it directly on Microsoft Azure ML or Amazon SageMaker.
 
+[[toc]]
+
 ## Built-in deployment via FastAPI
 
 The built-in tool uses [FastAPI](https://fastapi.tiangolo.com/) and an [Uvicorn](https://www.uvicorn.org/) server
@@ -138,5 +140,5 @@ curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
 ```
 
 For more details about how to exploit all MLFlow Model features,
-like deploying them on Microsoft Azure ML or Amazon SageMake, please refer to their
+like deploying them on Microsoft Azure ML or Amazon SageMaker, please refer to their
 [documentation](https://www.mlflow.org/docs/latest/models.html#built-in-deployment-tools).

--- a/src/biome/text/cli/serve.py
+++ b/src/biome/text/cli/serve.py
@@ -26,7 +26,7 @@ from biome.text import Pipeline
     "--port",
     "-p",
     type=int,
-    default=8888,
+    default=9999,
     show_default=True,
     help="Port on which to serve the REST API.",
 )

--- a/src/biome/text/cli/serve.py
+++ b/src/biome/text/cli/serve.py
@@ -110,19 +110,37 @@ def _serve(pipeline: Pipeline, port: int):
             else:
                 return PlainTextResponse(str(exc.detail), status_code=exc.status_code)
 
-        @app.post("/predict")
+        @app.post("/predict", tags=["Pipeline"])
         async def predict(predict_input: PredictInput):
+            """Returns a prediction given some input data
+
+            Parameters
+            ----------
+            - **args/kwargs:** See the Example Value for the Request body below.
+            If provided, the **batch** parameter will be ignored.
+            - **batch:** A list of dictionaries that represents a batch of inputs.
+            The dictionary keys must comply with the **args/kwargs**.
+            Predicting batches should typically be faster than repeated calls with **args/kwargs**.
+            - **add_tokens:** If true, adds a 'tokens' key in the prediction that contains the tokenized input.
+            - **add_attributions:** If true, adds a 'attributions' key that contains attributions of the input to the prediction.
+            - **attributions_kwargs:** This dict is directly passed on to the `TaskHead.compute_attributions()`.
+
+            Returns
+            -------
+            - **predictions:** A dictionary or a list of dictionaries containing the predictions and additional information.
+            """
             with http_error_handling():
                 return sanitize(
                     pipeline.predict(**predict_input.dict(skip_defaults=True))
                 )
 
-        @app.get("/_config")
+        @app.get("/config", tags=["Pipeline"])
         async def config():
+            """The configuration of the pipeline"""
             with http_error_handling():
                 return pipeline.config.as_dict()
 
-        @app.get("/_status")
+        @app.get("/_status", tags=["REST service"])
         async def status():
             with http_error_handling():
                 return {"ok": True}

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -775,7 +775,7 @@ class Pipeline:
         tracking_uri: Optional[str] = None,
         experiment_id: Optional[int] = None,
         run_name: str = "Log biome.text model",
-    ):
+    ) -> str:
         """Logs the pipeline as MLFlow Model to a MLFlow Tracking server
 
         Parameters
@@ -805,7 +805,7 @@ class Pipeline:
         ... })
         >>> model_uri = pipeline.to_mlflow()
         >>> model = mlflow.pyfunc.load_model(model_uri)
-        >>> preciction: pandas.DataFrame = model.predict(pandas.DataFrame([{"text": "Test this text"}]))
+        >>> prediction: pandas.DataFrame = model.predict(pandas.DataFrame([{"text": "Test this text"}]))
         """
         if tracking_uri:
             mlflow.set_tracking_uri(tracking_uri)


### PR DESCRIPTION
This PR adds a `Deployment` section to the *User Guides* of the documentation. Goal is to describe two deployment options:
- built-in tool via our CLI and FastAPI
- deployment via MLFlow models

There is still little content and It's still a draft, @ignacioct maybe we could work together on this branch.
@dvsrepo in case you want to follow the progress and comment: checking out this branch and running `make docs` should provide you a preview of the docs.