### PR TITLE
Batch predictions can contain None 

### DIFF
--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -80,9 +80,7 @@ class ClassificationHead(TaskHead):
             field = LabelField(label, label_namespace=vocabulary.LABELS_NAMESPACE)
         if not field:
             # We have label info but we cannot build the label field --> discard the instance
-            self._LOGGER.warning(
-                f"Cannot create a label field for {label}, discarding instance."
-            )
+            self._LOGGER.warning(f"Cannot create label field for `label={label}`!")
             return None
 
         instance.add_field(to_field, field)

--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -17,6 +17,7 @@ from allennlp.training.metrics import FBetaMeasure
 from biome.text import helpers
 from biome.text import vocabulary
 from biome.text.backbone import ModelBackbone
+from biome.text.featurizer import FeaturizeError
 from biome.text.metrics import MultiLabelF1Measure
 from biome.text.modules.heads.task_head import TaskHead
 from biome.text.modules.heads.task_head import TaskName
@@ -61,12 +62,34 @@ class ClassificationHead(TaskHead):
         instance: Instance,
         label: Union[List[str], List[int], str, int],
         to_field: str = "label",
-    ) -> Optional[Instance]:
-        """Includes the label field for classification into the instance data
+    ) -> Instance:
+        """Adds the label field for classification into the instance data
 
         Helper function for the child's `self.featurize` method.
+
+        Parameters
+        ----------
+        instance
+            Add a label field to this instance
+        label
+            The label data
+        to_field
+            Name space of the field
+
+        Returns
+        -------
+        instance
+            If `label` is not None, return `instance` with the a label field added.
+            Otherwise return just the given `instance`.
+
+        Raises
+        ------
+        FeaturizeError
+            If the label is an empty string or does not match the type:
+            - (str, int) for single label
+            - (list, np.array) for multi label
         """
-        # "if not label:" fails for ndarrays this is why we explicitly check None
+        # "if not label:" fails for ndarrays, this is why we explicitly check for None
         if label is None:
             return instance
 
@@ -80,10 +103,10 @@ class ClassificationHead(TaskHead):
             field = LabelField(label, label_namespace=vocabulary.LABELS_NAMESPACE)
         if not field:
             # We have label info but we cannot build the label field --> discard the instance
-            self._LOGGER.warning(f"Cannot create label field for `label={label}`!")
-            return None
+            raise FeaturizeError(f"Cannot create label field for `label={label}`!")
 
         instance.add_field(to_field, field)
+
         return instance
 
     def _make_forward_output(
@@ -224,7 +247,7 @@ class ClassificationHead(TaskHead):
     def forward(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:
         raise NotImplementedError
 
-    def featurize(self, *args, **kwargs) -> Optional[Instance]:
+    def featurize(self, *args, **kwargs) -> Instance:
         raise NotImplementedError
 
     def _make_task_prediction(

--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -91,14 +91,10 @@ class DocumentClassification(ClassificationHead):
         self,
         text: Union[List[str], Dict[str, str]],
         label: Optional[Union[str, List[str]]] = None,
-    ) -> Optional[Instance]:
-        try:
-            instance = self.backbone.featurizer(
-                text, to_field=self.forward_arg_name, exclude_record_keys=True
-            )
-        except FeaturizeError as error:
-            self._LOGGER.exception(error)
-            return None
+    ) -> Instance:
+        instance = self.backbone.featurizer(
+            text, to_field=self.forward_arg_name, exclude_record_keys=True
+        )
 
         return self._add_label(instance, label, to_field=self.label_name)
 

--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -94,6 +94,20 @@ class DocumentClassification(ClassificationHead):
         instance = self.backbone.featurizer(
             text, to_field=self.forward_arg_name, exclude_record_keys=True
         )
+
+        if not any(
+            [
+                cast(TextField, text_field).tokens
+                for text_field in cast(
+                    ListField, instance[self.forward_arg_name]
+                ).field_list
+            ]
+        ):
+            self._LOGGER.warning(
+                f"Only empty TextFields for `{self.forward_arg_name}={text}`!"
+            )
+            return None
+
         return self._add_label(instance, label, to_field=self.label_name)
 
     def forward(

--- a/src/biome/text/modules/heads/classification/record_classification.py
+++ b/src/biome/text/modules/heads/classification/record_classification.py
@@ -54,14 +54,10 @@ class RecordClassification(DocumentClassification):
 
     def featurize(
         self, label: Optional[Union[str, List[str]]] = None, **inputs
-    ) -> Optional[Instance]:
+    ) -> Instance:
 
         record = {input_key: inputs[input_key] for input_key in self._inputs}
-        try:
-            instance = self.backbone.featurizer(record, to_field=self.forward_arg_name)
-        except FeaturizeError as error:
-            self._LOGGER.exception(error)
-            return None
+        instance = self.backbone.featurizer(record, to_field=self.forward_arg_name)
 
         return self._add_label(instance, label)
 

--- a/src/biome/text/modules/heads/classification/record_classification.py
+++ b/src/biome/text/modules/heads/classification/record_classification.py
@@ -2,9 +2,12 @@ from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
+from typing import cast
 
 import numpy
 from allennlp.data import Instance
+from allennlp.data.fields import ListField
+from allennlp.data.fields import TextField
 
 from biome.text.backbone import ModelBackbone
 from biome.text.modules.configuration import ComponentConfiguration
@@ -55,10 +58,22 @@ class RecordClassification(DocumentClassification):
         self, label: Optional[Union[str, List[str]]] = None, **inputs
     ) -> Optional[Instance]:
 
-        instance = self.backbone.featurizer(
-            {input_key: inputs[input_key] for input_key in self._inputs},
-            to_field=self.forward_arg_name,
-        )
+        record = {input_key: inputs[input_key] for input_key in self._inputs}
+        instance = self.backbone.featurizer(record, to_field=self.forward_arg_name)
+
+        if not any(
+            [
+                cast(TextField, text_field).tokens
+                for text_field in cast(
+                    ListField, instance[self.forward_arg_name]
+                ).field_list
+            ]
+        ):
+            self._LOGGER.warning(
+                f"Only empty TextFields for `{self.forward_arg_name}={record}`!"
+            )
+            return None
+
         return self._add_label(instance, label)
 
     def _make_task_prediction(

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -134,7 +134,7 @@ class RecordPairClassification(ClassificationHead):
         record1: Dict[str, str],
         record2: Dict[str, str],
         label: Optional[str] = None,
-    ) -> Optional[Instance]:
+    ) -> Instance:
         """Tokenizes, indexes and embeds the two records and optionally adds the label
 
         Parameters
@@ -150,17 +150,17 @@ class RecordPairClassification(ClassificationHead):
         -------
         instance
             AllenNLP instance containing the two records plus optionally a label
+
+        Raises
+        ------
+        FeaturizeError
         """
-        try:
-            record1_instance = self.backbone.featurizer(
-                record1, to_field="record", aggregate=False
-            )
-            record2_instance = self.backbone.featurizer(
-                record2, to_field="record", aggregate=False
-            )
-        except FeaturizeError as error:
-            self._LOGGER.exception(error)
-            return None
+        record1_instance = self.backbone.featurizer(
+            record1, to_field="record", aggregate=False
+        )
+        record2_instance = self.backbone.featurizer(
+            record2, to_field="record", aggregate=False
+        )
 
         instance = Instance(
             {
@@ -168,9 +168,8 @@ class RecordPairClassification(ClassificationHead):
                 self._RECORD2_ARG_NAME_IN_FORWARD: record2_instance.get("record"),
             }
         )
-        instance = self._add_label(instance, label)
 
-        return instance
+        return self._add_label(instance, label)
 
     def forward(
         self,  # type: ignore

--- a/src/biome/text/modules/heads/classification/relation_classification.py
+++ b/src/biome/text/modules/heads/classification/relation_classification.py
@@ -34,7 +34,7 @@ class RelationClassification(ClassificationHead):
 
     _TEXT_ARG_NAME_IN_FORWARD = "text"
     _LABEL_ARG_NAME_IN_FORWARD = "label"
-    __LOGGER = logging.getLogger(__name__)
+    _LOGGER = logging.getLogger(__name__)
 
     def __init__(
         self,
@@ -90,11 +90,17 @@ class RelationClassification(ClassificationHead):
             exclude_record_keys=True,
         )
 
+        if not cast(TextField, instance[self._TEXT_ARG_NAME_IN_FORWARD]).tokens:
+            self._LOGGER.warning(
+                f"Empty TextField for `{self._TEXT_ARG_NAME_IN_FORWARD}={text}`!"
+            )
+            return None
+
         doc = self.backbone.tokenizer.nlp(text)
         entity_tags = tags_from_offsets(doc, entities, self._label_encoding)
 
         if "-" in entity_tags:
-            self.__LOGGER.warning(
+            self._LOGGER.warning(
                 f"Could not align spans with tokens for following example: '{text}' {entities}"
             )
             return None

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -63,17 +63,13 @@ class TextClassification(ClassificationHead):
         self,
         text: Union[str, List[str], Dict[str, str]],
         label: Optional[Union[str, List[str]]] = None,
-    ) -> Optional[Instance]:
-        try:
-            instance = self.backbone.featurizer(
-                text,
-                to_field=self.forward_arg_name,
-                aggregate=True,
-                exclude_record_keys=True,
-            )
-        except FeaturizeError as error:
-            self._LOGGER.exception(error)
-            return None
+    ) -> Instance:
+        instance = self.backbone.featurizer(
+            text,
+            to_field=self.forward_arg_name,
+            aggregate=True,
+            exclude_record_keys=True,
+        )
 
         return self._add_label(instance, label, to_field=self.label_name)
 

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 from typing import Dict
 from typing import List
@@ -30,6 +31,7 @@ class TextClassification(ClassificationHead):
 
     label_name = "label"
     forward_arg_name = "text"
+    _LOGGER = logging.getLogger(__name__)
 
     def __init__(
         self,
@@ -67,6 +69,12 @@ class TextClassification(ClassificationHead):
             aggregate=True,
             exclude_record_keys=True,
         )
+        if not cast(TextField, instance[self.forward_arg_name]).tokens:
+            self._LOGGER.warning(
+                f"Empty TextField for `{self.forward_arg_name}={text}`!"
+            )
+            return None
+
         return self._add_label(instance, label, to_field=self.label_name)
 
     def forward(  # type: ignore

--- a/src/biome/text/modules/heads/language_modelling.py
+++ b/src/biome/text/modules/heads/language_modelling.py
@@ -85,11 +85,7 @@ class LanguageModelling(TaskHead):
             )
 
     def featurize(self, text: str) -> Optional[Instance]:
-        try:
-            instance = self.backbone.featurizer(text, to_field="text", aggregate=True)
-        except FeaturizeError as error:
-            self._LOGGER.exception(error)
-            return None
+        instance = self.backbone.featurizer(text, to_field="text", aggregate=True)
 
         return instance
 

--- a/src/biome/text/modules/heads/language_modelling.py
+++ b/src/biome/text/modules/heads/language_modelling.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 from typing import Dict
 from typing import Optional
@@ -19,6 +20,7 @@ from biome.text import vocabulary
 from biome.text.backbone import ModelBackbone
 from biome.text.modules.configuration import ComponentConfiguration
 
+from ...featurizer import FeaturizeError
 from .task_head import TaskHead
 from .task_head import TaskName
 from .task_prediction import LanguageModellingPrediction
@@ -31,6 +33,7 @@ class LanguageModelling(TaskHead):
     """
 
     task_name = TaskName.language_modelling
+    _LOGGER = logging.getLogger(__name__)
 
     def __init__(
         self,
@@ -82,9 +85,10 @@ class LanguageModelling(TaskHead):
             )
 
     def featurize(self, text: str) -> Optional[Instance]:
-        instance = self.backbone.featurizer(text, to_field="text", aggregate=True)
-        if not cast(TextField, instance["text"]).tokens:
-            self._LOGGER.warning(f"Empty TextField for `text={text}`!")
+        try:
+            instance = self.backbone.featurizer(text, to_field="text", aggregate=True)
+        except FeaturizeError as error:
+            self._LOGGER.exception(error)
             return None
 
         return instance

--- a/src/biome/text/modules/heads/task_head.py
+++ b/src/biome/text/modules/heads/task_head.py
@@ -98,8 +98,17 @@ class TaskHead(torch.nn.Module, Registrable):
         """Metrics dictionary for training task"""
         raise NotImplementedError
 
-    def featurize(self, *args, **kwargs) -> Optional[Instance]:
-        """Converts incoming data into an Allennlp `Instance`, used for pyTorch tensors generation"""
+    def featurize(self, *args, **kwargs) -> Instance:
+        """Converts incoming data into an Allennlp `Instance`, used for pyTorch tensors generation
+
+        Returns
+        -------
+        instance
+
+        Raises
+        ------
+        FeaturizeError
+        """
         raise NotImplementedError
 
     def make_task_prediction(

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -570,11 +570,10 @@ class Pipeline:
         ----------
         *args/**kwargs
             These are dynamically updated and correspond to the pipeline's `self.inputs`.
-            You can provide either args/kwargs OR a batch.
+            If provided, the `batch` parameter will be ignored.
         batch
             A list of dictionaries that represents a batch of inputs. The dictionary keys must comply with the
-            `self.inputs` attribute. You can provide either args/kwargs OR a batch. Predicting batches should
-            typically be faster than repeated calls with args/kwargs.
+            `self.inputs` attribute. Predicting batches should typically be faster than repeated calls with args/kwargs.
         add_tokens
             If true, adds a 'tokens' key in the prediction that contains the tokenized input.
         add_attributions
@@ -587,18 +586,6 @@ class Pipeline:
         predictions
             A dictionary or a list of dictionaries containing the predictions and additional information.
         """
-        # the signature of this method gets updated in the self.__init__
-        args_kwargs_names = [
-            f"`{name}`"
-            for name, par in inspect.signature(self.predict).parameters.items()
-            if par.default == inspect.Parameter.empty
-        ]
-
-        if ((args or kwargs) and batch) or not (args or kwargs or batch):
-            raise ValueError(
-                f"Please provide either {' and '.join(args_kwargs_names)}, OR a `batch`"
-            )
-
         if args or kwargs:
             batch = [self._map_args_kwargs_to_input(*args, **kwargs)]
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,3 @@
 import logging
 
 logging.basicConfig(level=logging.INFO)
-test_logger = logging.getLogger(__name__)

--- a/tests/text/modules/heads/test_token_classification.py
+++ b/tests/text/modules/heads/test_token_classification.py
@@ -8,7 +8,6 @@ from biome.text import Pipeline
 from biome.text import TrainerConfiguration
 from biome.text import vocabulary
 from biome.text.modules.heads.task_prediction import Entity
-from biome.text.modules.heads.task_prediction import Token
 from biome.text.modules.heads.task_prediction import TokenClassificationPrediction
 
 

--- a/tests/text/test_model_predict.py
+++ b/tests/text/test_model_predict.py
@@ -4,6 +4,7 @@ from biome.text import Pipeline
 from biome.text._model import PipelineModel
 from biome.text.configuration import PredictionConfiguration
 from biome.text.errors import WrongInputError
+from biome.text.featurizer import FeaturizeError
 from biome.text.modules.heads.task_prediction import TaskPrediction
 
 
@@ -62,18 +63,15 @@ def test_return_type(model, monkeypatch):
 
 
 def test_text_to_instance(model, caplog):
-    instance = model.text_to_instance(wrong_kwarg="wrong argument")
-    assert instance is None
+    with pytest.raises(TypeError):
+        model.text_to_instance(wrong_kwarg="wrong argument")
+
+    with pytest.raises(TypeError):
+        model.text_to_instance(label="missing required argument")
+
+    model.text_to_instance(text="")
     assert caplog.record_tuples[0] == (
         "biome.text._model",
-        40,
-        "featurize() got an unexpected keyword argument 'wrong_kwarg'",
-    )
-
-    instance = model.text_to_instance(label="missing required argument")
-    assert instance is None
-    assert caplog.record_tuples[1] == (
-        "biome.text._model",
-        40,
-        "featurize() missing 1 required positional argument: 'text'",
+        30,
+        "The provided input data contains empty strings/tokens: ",
     )

--- a/tests/text/test_model_predict.py
+++ b/tests/text/test_model_predict.py
@@ -4,7 +4,6 @@ from biome.text import Pipeline
 from biome.text._model import PipelineModel
 from biome.text.configuration import PredictionConfiguration
 from biome.text.errors import WrongInputError
-from biome.text.errors import WrongValueError
 from biome.text.modules.heads.task_prediction import TaskPrediction
 
 
@@ -25,16 +24,28 @@ def test_training_mode_warning(model):
     assert model.training is False
 
 
-def test_value_error(model, monkeypatch):
+def test_forward_pass_error(model, monkeypatch, caplog):
     def mock_text_to_instance(**kwargs):
-        return None
+        return "mock instance"
+
+    def mock_forward_on_instances(*args, **kwargs):
+        raise Exception("mock Exception")
 
     monkeypatch.setattr(model, "text_to_instance", mock_text_to_instance)
+    monkeypatch.setattr(model, "forward_on_instances", mock_forward_on_instances)
 
-    with pytest.raises(WrongValueError):
-        model.predict(
-            [{"text": "Some value that breaks the featurize"}], PredictionConfiguration
-        )
+    predictions = model.predict(
+        [{"text": "Some value that breaks the forward pass"}], PredictionConfiguration
+    )
+
+    assert predictions == [None]
+    assert len(caplog.record_tuples) == 2
+    assert caplog.record_tuples[0] == ("biome.text._model", 40, "mock Exception")
+    assert caplog.record_tuples[1] == (
+        "biome.text._model",
+        30,
+        "Failed to make a forward pass for '[{'text': 'Some value that breaks the forward pass'}]'",
+    )
 
 
 def test_return_type(model, monkeypatch):
@@ -50,8 +61,19 @@ def test_return_type(model, monkeypatch):
     assert all([isinstance(pred, TaskPrediction) for pred in predictions])
 
 
-def test_text_to_instance(model):
-    with pytest.raises(WrongInputError):
-        model.text_to_instance(wrong_kwarg="wrong argument")
-    with pytest.raises(WrongInputError):
-        model.text_to_instance(label="missing required argument")
+def test_text_to_instance(model, caplog):
+    instance = model.text_to_instance(wrong_kwarg="wrong argument")
+    assert instance is None
+    assert caplog.record_tuples[0] == (
+        "biome.text._model",
+        40,
+        "featurize() got an unexpected keyword argument 'wrong_kwarg'",
+    )
+
+    instance = model.text_to_instance(label="missing required argument")
+    assert instance is None
+    assert caplog.record_tuples[1] == (
+        "biome.text._model",
+        40,
+        "featurize() missing 1 required positional argument: 'text'",
+    )

--- a/tests/text/test_pipeline_predict.py
+++ b/tests/text/test_pipeline_predict.py
@@ -20,7 +20,7 @@ def test_raise_Prediction_error(pipeline):
         pipeline.predict("")
 
     with pytest.raises(PredictionError):
-        pipeline.predict(batch=[{"not": ""}, {"happening": ""}])
+        pipeline.predict(batch=[{"text": ""}, {"text": ""}])
 
 
 def test_batch_parameter_gets_ignored(pipeline):

--- a/tests/text/test_pipeline_predict.py
+++ b/tests/text/test_pipeline_predict.py
@@ -46,7 +46,10 @@ def test_map_args_kwargs_to_input():
 def test_return_single_or_list(pipeline, monkeypatch):
     def mock_predict(batch, prediction_config):
         return [
-            TextClassificationPrediction(labels=["a"], probabilities=[1]) for _ in batch
+            TextClassificationPrediction(labels=["a"], probabilities=[1])
+            if i % 2 == 0
+            else None
+            for i, _ in enumerate(batch)
         ]
 
     monkeypatch.setattr(pipeline._model, "predict", mock_predict)
@@ -57,5 +60,8 @@ def test_return_single_or_list(pipeline, monkeypatch):
     assert isinstance(batch_prediction, list) and len(batch_prediction) == 1
     assert isinstance(batch_prediction[0], dict)
 
-    batch_prediction = pipeline.predict(batch=[{"text": "test"}, {"text": "test"}])
+    batch_prediction = pipeline.predict(
+        batch=[{"text": "test"}, {"text": "no instance for this input"}]
+    )
     assert isinstance(batch_prediction, list) and len(batch_prediction) == 2
+    assert isinstance(batch_prediction[0], dict) and batch_prediction[1] is None

--- a/tests/text/test_pipeline_predict.py
+++ b/tests/text/test_pipeline_predict.py
@@ -2,6 +2,7 @@ import pytest
 
 from biome.text import Pipeline
 from biome.text.modules.heads.task_prediction import TextClassificationPrediction
+from biome.text.pipeline import PredictionError
 
 
 @pytest.fixture
@@ -14,13 +15,22 @@ def pipeline() -> Pipeline:
     )
 
 
-def test_raise_value_error(pipeline):
-    with pytest.raises(ValueError):
-        pipeline.predict()
-    with pytest.raises(ValueError):
-        pipeline.predict("test", batch=[{"text": "test"}])
-    with pytest.raises(ValueError):
-        pipeline.predict(text="test", batch=[{"text": "test"}])
+def test_raise_Prediction_error(pipeline):
+    with pytest.raises(PredictionError):
+        pipeline.predict("")
+
+    with pytest.raises(PredictionError):
+        pipeline.predict(batch=[{"not": ""}, {"happening": ""}])
+
+
+def test_batch_parameter_gets_ignored(pipeline):
+    prediction = pipeline.predict("testtt", batch=[{"text": "test"}], add_tokens=True)
+    assert prediction["tokens"][0]["text"] == "testtt"
+
+    prediction = pipeline.predict(
+        text="testtt", batch=[{"text": "test"}], add_tokens=True
+    )
+    assert prediction["tokens"][0]["text"] == "testtt"
 
 
 def test_map_args_kwargs_to_input():


### PR DESCRIPTION
With this PR the `Pipeline.predict` output can contain None. This is the case if for the provided input we cannot generate an instance, or the forward output cannot be converted into a `TaskPrediction` (less likely).

I added checks to the `TaskHead.featurize`s, that looks for empty TextFields, and if found the returned instance will be None. This indirectly catches empty string inputs, but be aware of tokenizers that add special tokens ... maybe i could add an explicit check for empty strings in the provided input.

Anyways, if you already know that for certain inputs the model will fail, i think it is more efficient to avoid sending this input to the model in the first place. @frascuchon let me know if you want me to add an explicit check for empty inputs in the heads.