### PR TITLE
Fix: Use token.idx_end if available

### DIFF
--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -184,9 +184,7 @@ class DocumentClassification(ClassificationHead):
                 Attribution(
                     text=token.text,
                     start=token.idx,
-                    end=token.idx + len(token.text)
-                    if isinstance(token.idx, int)
-                    else None,
+                    end=self._get_token_end(token),
                     field=self.forward_arg_name,
                     attribution=attribution,
                 )

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -146,7 +146,7 @@ class TextClassification(ClassificationHead):
             Attribution(
                 text=token.text,
                 start=token.idx,
-                end=token.idx + len(token.text) if isinstance(token.idx, int) else None,
+                end=self._get_token_end(token),
                 field=self.forward_arg_name,
                 attribution=attribution,
             )


### PR DESCRIPTION
This PR fixes an issue when using a transformer tokenizer and activating the `add_tokens`/`add_attributions` options in the `Pipeline.predict` method. The `end` key was taking into account the special chars added by the tokenizer, now it does not and refers correctly to the char index of the input.