### PR TITLE
Fix: Make Algolia search work with our versioned docs

### DIFF
--- a/docs/docs/.vuepress/theme/components/AlgoliaSearchBox.vue
+++ b/docs/docs/.vuepress/theme/components/AlgoliaSearchBox.vue
@@ -54,13 +54,8 @@ export default {
             inputSelector: '#algolia-search-input',
             // #697 Make docsearch work well at i18n mode.
             algoliaOptions: Object.assign({
-              'facetFilters': [`lang:${lang}`].concat(algoliaOptions.facetFilters || [])
+              'facetFilters': [`lang:${lang}`, `version:${this.$site.base.split("/")[2]}`].concat(algoliaOptions.facetFilters || [])
             }, algoliaOptions),
-            handleSelected: (input, event, suggestion) => {
-              const { pathname, hash } = new URL(suggestion.url)
-              const routepath = pathname.replace(this.$site.base, '/')
-              this.$router.push(`${routepath}${hash}`)
-            }
           }
         ))
       })


### PR DESCRIPTION
Title says it all ... After merging this PR, the master version of our docs should work fine, i still have to rebuilt the two other versions manually.

I still have to figure out how to dynamically add new versions to our algolia config file, for now we have to push a PR for every new release we want to add to the search.