### PR TITLE
Make `PipelineModel` a LightningModule

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
             "lxml~=4.6.2",
             "mlflow~=1.13.1",
             "pandas~=1.1.0",
+            "pytorch-lightning~=1.1.8",
             "ray[tune]~=1.0.0",
             "spacy~=2.3.0",
             "tqdm>=4.49.0",

--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -3,9 +3,11 @@ import json
 import logging
 import os
 import pickle
+import re
 import warnings
 from functools import lru_cache
 from logging.handlers import RotatingFileHandler
+from os import PathLike
 from pathlib import Path
 from typing import Any
 from typing import Dict
@@ -15,13 +17,18 @@ from typing import Optional
 from typing import Type
 from typing import Union
 
-import allennlp
+import numpy
+import pytorch_lightning as pl
 import torch
 from allennlp.common import Params
+from allennlp.common import Registrable
+from allennlp.common.checks import ConfigurationError
+from allennlp.common.params import remove_keys_from_params
 from allennlp.common.util import sanitize
+from allennlp.data import Batch
 from allennlp.data import Instance
 from allennlp.data import Vocabulary
-from allennlp.models.archival import CONFIG_NAME
+from allennlp.nn import util
 
 from . import vocabulary
 from .backbone import ModelBackbone
@@ -31,6 +38,8 @@ from .featurizer import FeaturizeError
 from .helpers import split_signature_params_by_predicate
 from .modules.heads import TaskHead
 from .modules.heads import TaskPrediction
+
+_DEFAULT_WEIGHTS = "best.th"
 
 
 class _HashDict(dict):
@@ -53,7 +62,7 @@ class _HashList(list):
         return pickle.dumps(self).__hash__()
 
 
-class PipelineModel(allennlp.models.Model):
+class PipelineModel(pl.LightningModule, Registrable):
     """
     This class represents pipeline model implementation for connect biome.text concepts with
     allennlp implementation details
@@ -88,9 +97,10 @@ class PipelineModel(allennlp.models.Model):
     _LOGGER = logging.getLogger(__name__)
 
     def __init__(self, name: str, head: TaskHead):
-        super().__init__(vocab=head.backbone.vocab)
+        super().__init__()
 
         self.name = name
+        self.vocab = head.backbone.vocab
         self._head = None
         self.set_head(head)
 
@@ -111,7 +121,6 @@ class PipelineModel(allennlp.models.Model):
         cls: Type["PipelineModel"],
         params: Params,
         vocab: Optional[Vocabulary] = None,
-        **extras,
     ) -> "PipelineModel":
         """
         Load the model implementation from params. We build manually each component from config sections.
@@ -124,8 +133,6 @@ class PipelineModel(allennlp.models.Model):
             The config key in these params is used to build the model components
         vocab
             The vocabulary for the model
-        **extras
-            Necessary for AllenNLP from_params machinery
 
         Returns
         -------
@@ -371,5 +378,217 @@ class PipelineModel(allennlp.models.Model):
 
         return predictions
 
+    # copied from allennlp.Model
 
-allennlp.models.Model.register(PipelineModel.__name__, exist_ok=True)(PipelineModel)
+    def extend_embedder_vocab(
+        self, embedding_sources_mapping: Dict[str, str] = None
+    ) -> None:
+        """
+        Iterates through all embedding modules in the model and assures it can embed
+        with the extended vocab. This is required in fine-tuning or transfer learning
+        scenarios where model was trained with original vocabulary but during
+        fine-tuning/transfer-learning, it will have it work with extended vocabulary
+        (original + new-data vocabulary).
+
+        # Parameters
+
+        embedding_sources_mapping : `Dict[str, str]`, optional (default = `None`)
+            Mapping from model_path to pretrained-file path of the embedding
+            modules. If pretrained-file used at time of embedding initialization
+            isn't available now, user should pass this mapping. Model path is
+            path traversing the model attributes upto this embedding module.
+            Eg. "_text_field_embedder.token_embedder_tokens".
+        """
+        # self.named_modules() gives all sub-modules (including nested children)
+        # The path nesting is already separated by ".": eg. parent_module_name.child_module_name
+        embedding_sources_mapping = embedding_sources_mapping or {}
+        for model_path, module in self.named_modules():
+            if hasattr(module, "extend_vocab"):
+                pretrained_file = embedding_sources_mapping.get(model_path)
+                module.extend_vocab(
+                    self.vocab,
+                    extension_pretrained_file=pretrained_file,
+                    model_path=model_path,
+                )
+
+    def get_regularization_penalty(self) -> Optional[torch.Tensor]:
+        """
+        The AllenNLP trainer needs this method
+        """
+        return None
+
+    @classmethod
+    def load(
+        cls,
+        config: Params,
+        serialization_dir: Union[str, PathLike],
+        weights_file: Optional[Union[str, PathLike]] = None,
+        cuda_device: int = -1,
+    ) -> "PipelineModel":
+        """
+        Instantiates an already-trained model, based on the experiment
+        configuration and some optional overrides.
+        """
+        weights_file = weights_file or os.path.join(serialization_dir, _DEFAULT_WEIGHTS)
+
+        # Load vocabulary from file
+        vocab_dir = os.path.join(serialization_dir, "vocabulary")
+        # If the config specifies a vocabulary subclass, we need to use it.
+        vocab_params = config.get("vocabulary", Params({}))
+        vocab_choice = vocab_params.pop_choice(
+            "type", Vocabulary.list_available(), True
+        )
+        vocab_class, _ = Vocabulary.resolve_class_name(vocab_choice)
+        vocab = vocab_class.from_files(
+            vocab_dir, vocab_params.get("padding_token"), vocab_params.get("oov_token")
+        )
+
+        model_params = config.get("model")
+
+        # The experiment config tells us how to _train_ a model, including where to get pre-trained
+        # embeddings/weights from. We're now _loading_ the model, so those weights will already be
+        # stored in our model. We don't need any pretrained weight file or initializers anymore,
+        # and we don't want the code to look for it, so we remove it from the parameters here.
+        remove_keys_from_params(model_params)
+        model = PipelineModel.from_params(vocab=vocab, params=model_params)
+
+        # Force model to cpu or gpu, as appropriate, to make sure that the embeddings are
+        # in sync with the weights
+        if cuda_device >= 0:
+            model.cuda(cuda_device)
+        else:
+            model.cpu()
+
+        # If vocab+embedding extension was done, the model initialized from from_params
+        # and one defined by state dict in weights_file might not have same embedding shapes.
+        # Eg. when model embedder module was transferred along with vocab extension, the
+        # initialized embedding weight shape would be smaller than one in the state_dict.
+        # So calling model embedding extension is required before load_state_dict.
+        # If vocab and model embeddings are in sync, following would be just a no-op.
+        model.extend_embedder_vocab()
+
+        # Load state dict. We pass `strict=False` so PyTorch doesn't raise a RuntimeError
+        # if the state dict is missing keys because we handle this case below.
+        model_state = torch.load(
+            weights_file, map_location=util.device_mapping(cuda_device)
+        )
+        missing_keys, unexpected_keys = model.load_state_dict(model_state, strict=False)
+
+        # Modules might define a class variable called `authorized_missing_keys`,
+        # a list of regex patterns, that tells us to ignore missing keys that match
+        # any of the patterns.
+        # We sometimes need this in order to load older models with newer versions of AllenNLP.
+
+        def filter_out_authorized_missing_keys(module, prefix=""):
+            nonlocal missing_keys
+            for pat in getattr(module.__class__, "authorized_missing_keys", None) or []:
+                missing_keys = [
+                    k
+                    for k in missing_keys
+                    if k.startswith(prefix) and re.search(pat[len(prefix) :], k) is None
+                ]
+            for name, child in module._modules.items():
+                if child is not None:
+                    filter_out_authorized_missing_keys(child, prefix + name + ".")
+
+        filter_out_authorized_missing_keys(model)
+
+        if unexpected_keys or missing_keys:
+            raise RuntimeError(
+                f"Error loading state dict for {model.__class__.__name__}\n\t"
+                f"Missing keys: {missing_keys}\n\t"
+                f"Unexpected keys: {unexpected_keys}"
+            )
+
+        return model
+
+    def forward_on_instances(
+        self, instances: List[Instance]
+    ) -> List[Dict[str, numpy.ndarray]]:
+        """
+        Takes a list of `Instances`, converts that text into arrays using this model's `Vocabulary`,
+        passes those arrays through `self.forward()` and `self.make_output_human_readable()` (which
+        by default does nothing) and returns the result.  Before returning the result, we convert
+        any `torch.Tensors` into numpy arrays and separate the batched output into a list of
+        individual dicts per instance. Note that typically this will be faster on a GPU (and
+        conditionally, on a CPU) than repeated calls to `forward_on_instance`.
+
+        # Parameters
+
+        instances : `List[Instance]`, required
+            The instances to run the model on.
+
+        # Returns
+
+        A list of the models output for each instance.
+        """
+        batch_size = len(instances)
+        with torch.no_grad():
+            cuda_device = self._get_prediction_device()
+            dataset = Batch(instances)
+            dataset.index_instances(self.vocab)
+            model_input = util.move_to_device(dataset.as_tensor_dict(), cuda_device)
+            outputs = self(**model_input)
+
+            instance_separated_output: List[Dict[str, numpy.ndarray]] = [
+                {} for _ in dataset.instances
+            ]
+            for name, output in list(outputs.items()):
+                if isinstance(output, torch.Tensor):
+                    # NOTE(markn): This is a hack because 0-dim pytorch tensors are not iterable.
+                    # This occurs with batch size 1, because we still want to include the loss in that case.
+                    if output.dim() == 0:
+                        output = output.unsqueeze(0)
+
+                    if output.size(0) != batch_size:
+                        self._maybe_warn_for_unseparable_batches(name)
+                        continue
+                    output = output.detach().cpu().numpy()
+                elif len(output) != batch_size:
+                    self._maybe_warn_for_unseparable_batches(name)
+                    continue
+                for instance_output, batch_element in zip(
+                    instance_separated_output, output
+                ):
+                    instance_output[name] = batch_element
+            return instance_separated_output
+
+    def _get_prediction_device(self) -> int:
+        """
+        This method checks the device of the model parameters to determine the cuda_device
+        this model should be run on for predictions.  If there are no parameters, it returns -1.
+
+        # Returns
+
+        The cuda device this model should run on for predictions.
+        """
+        devices = {util.get_device_of(param) for param in self.parameters()}
+
+        if len(devices) > 1:
+            devices_string = ", ".join(str(x) for x in devices)
+            raise ConfigurationError(
+                f"Parameters have mismatching cuda_devices: {devices_string}"
+            )
+        elif len(devices) == 1:
+            return devices.pop()
+        else:
+            return -1
+
+    def _maybe_warn_for_unseparable_batches(self, output_key: str):
+        """
+        This method warns once if a user implements a model which returns a dictionary with
+        values which we are unable to split back up into elements of the batch. This is controlled
+        by a class attribute `_warn_for_unseperable_batches` because it would be extremely verbose
+        otherwise.
+        """
+        if output_key not in self._warn_for_unseparable_batches:
+            self._LOGGER.warning(
+                f"Encountered the {output_key} key in the model's return dictionary which "
+                "couldn't be split by the batch size. Key will be ignored."
+            )
+            # We only want to warn once for this key,
+            # so we set this to false so we don't warn again.
+            self._warn_for_unseparable_batches.add(output_key)
+
+
+PipelineModel.register(PipelineModel.__name__, exist_ok=True)(PipelineModel)

--- a/src/biome/text/_model.py
+++ b/src/biome/text/_model.py
@@ -14,6 +14,7 @@ from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Optional
+from typing import Set
 from typing import Type
 from typing import Union
 
@@ -104,6 +105,8 @@ class PipelineModel(pl.LightningModule, Registrable):
         self.set_head(head)
 
         self.file_path: Optional[str] = None
+
+        self._warn_for_unseparable_batches: Set[str] = set()
 
     def _update_head_related_attributes(self):
         """Updates the inputs/outputs and default mapping attributes, calculated from model head"""
@@ -410,9 +413,18 @@ class PipelineModel(pl.LightningModule, Registrable):
     def get_regularization_penalty(self) -> Optional[torch.Tensor]:
         """Needed by the AllenNLP trainer.
 
-        We have not implemented gegularization in our PipelineModel at the moment, so this method does nothing.
+        We have not implemented regularization in our PipelineModel at the moment, so this method does nothing.
         """
         pass
+
+    def make_output_human_readable(
+        self, output_dict: Dict[str, torch.Tensor]
+    ) -> Dict[str, torch.Tensor]:
+        """Needed by the AllenNLP evaluate method.
+
+        This can go away once we have an evaluate using the Lightning Trainer.
+        """
+        return output_dict
 
     @classmethod
     def load(

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -15,19 +15,20 @@ from typing import Optional
 from typing import Tuple
 from typing import Type
 from typing import Union
-from typing import cast
 
 import mlflow
 import numpy
 import torch
 from allennlp.commands.find_learning_rate import search_learning_rate
 from allennlp.common import Params
+from allennlp.common.file_utils import cached_path
 from allennlp.common.file_utils import is_url_or_existing_file
 from allennlp.data import AllennlpLazyDataset
 from allennlp.data import Vocabulary
-from allennlp.models import load_archive
-from allennlp.models.archival import Archive
+from allennlp.models.archival import CONFIG_NAME
 from allennlp.models.archival import archive_model
+from allennlp.models.archival import extracted_archive
+from allennlp.models.archival import get_weights_path
 from allennlp.training.util import evaluate
 
 from biome.text import vocabulary
@@ -53,6 +54,8 @@ from biome.text.training_results import TrainingResults
 logging.getLogger("allennlp").setLevel(logging.ERROR)
 logging.getLogger("elasticsearch").setLevel(logging.ERROR)
 
+_LOGGER = logging.getLogger(__name__)
+
 
 class Pipeline:
     """Manages NLP models configuration and actions.
@@ -61,8 +64,6 @@ class Pipeline:
 
     Use instantiated Pipelines for training from scratch, fine-tuning, predicting, serving, or exploring predictions.
     """
-
-    _LOGGER = logging.getLogger(__name__)
 
     def __init__(self, model: PipelineModel, config: PipelineConfiguration):
         self._model = model
@@ -155,18 +156,8 @@ class Pipeline:
         pipeline
             A pretrained pipeline
         """
-        archive = load_archive(
-            path,
-            # Necessary for AllenNLP>=1.2.0 that requires a dataset_reader config key
-            # We choose the "interleaving" type since it is the most light weight one.
-            overrides={"dataset_reader": {"type": "interleaving", "readers": {}}},
-        )
-        model = cls._model_from_archive(archive)
+        model, config = _load_model_and_config_from_archive(path)
         model.file_path = str(path)
-        config = cls._config_from_archive(archive)
-
-        if not isinstance(model, PipelineModel):
-            raise TypeError(f"Cannot load model. Wrong format of {model}")
 
         return cls(model, config)
 
@@ -217,7 +208,7 @@ class Pipeline:
         At training time, this number can change when freezing/unfreezing certain parameter groups.
         """
         if vocabulary.is_empty(self.vocab, self.config.features.configured_namespaces):
-            self._LOGGER.warning(
+            _LOGGER.warning(
                 "At least one vocabulary of your features is still empty! "
                 "The number of trainable parameters usually depends on the size of your vocabulary."
             )
@@ -227,7 +218,7 @@ class Pipeline:
     def num_parameters(self) -> int:
         """Number of parameters present in the model."""
         if vocabulary.is_empty(self.vocab, self.config.features.configured_namespaces):
-            self._LOGGER.warning(
+            _LOGGER.warning(
                 "At least one vocabulary of your features is still empty! "
                 "The number of trainable parameters usually depends on the size of your vocabulary."
             )
@@ -853,17 +844,6 @@ class Pipeline:
                     model.vocab
                 )
 
-    @staticmethod
-    def _model_from_archive(archive: Archive) -> PipelineModel:
-        if not isinstance(archive.model, PipelineModel):
-            raise ValueError(f"Wrong pipeline model: {archive.model}")
-        return cast(PipelineModel, archive.model)
-
-    @staticmethod
-    def _config_from_archive(archive: Archive) -> PipelineConfiguration:
-        config = archive.config["model"]["config"]
-        return PipelineConfiguration.from_params(config)
-
     # deprecated methods:
 
     def create_vocabulary(self, config: VocabularyConfiguration) -> None:
@@ -899,6 +879,72 @@ class Pipeline:
         raise DeprecationWarning(
             "Use `self.predict(batch=..., add_attributions=True)` instead. This method will be removed in the future."
         )
+
+
+def _load_model_and_config_from_archive(
+    archive_file: Union[str, Path],
+    cuda_device: int = -1,
+    overrides: Union[str, Dict[str, Any]] = "",
+    weights_file: str = None,
+) -> Tuple[PipelineModel, PipelineConfiguration]:
+    """
+    Instantiates a PipelineConfiguration and a PipelineModel from an archived `tar.gz` file.
+
+    Parameters
+    ----------
+    archive_file
+        The archive file to load the pipeline from.
+    cuda_device
+        If `cuda_device` is >= 0, the pipeline model will be loaded onto the
+        corresponding GPU. Otherwise it will be loaded onto the CPU.
+    overrides
+        JSON overrides to apply to the unarchived `Params` object.
+    weights_file
+        The weights file to use.  If unspecified, weights.th in the archive_file will be used.
+
+    Returns
+    -------
+    pipeline_model, pipeline_config
+    """
+    # redirect to the cache, if necessary
+    resolved_archive_file = cached_path(archive_file)
+
+    if resolved_archive_file == archive_file:
+        _LOGGER.info(f"loading archive file {archive_file}")
+    else:
+        _LOGGER.info(
+            f"loading archive file {archive_file} from cache at {resolved_archive_file}"
+        )
+
+    tempdir = None
+    try:
+        if os.path.isdir(resolved_archive_file):
+            serialization_dir = resolved_archive_file
+        else:
+            with extracted_archive(resolved_archive_file, cleanup=False) as tempdir:
+                serialization_dir = tempdir
+
+        if weights_file:
+            weights_path = weights_file
+        else:
+            weights_path = get_weights_path(serialization_dir)
+
+        # Load config
+        config = Params.from_file(
+            os.path.join(serialization_dir, CONFIG_NAME), overrides
+        )
+
+        pipeline_model = PipelineModel.load(
+            config.duplicate(), serialization_dir, weights_path, cuda_device
+        )
+
+        pipeline_config = PipelineConfiguration.from_params(config["model"]["config"])
+    finally:
+        if tempdir is not None:
+            _LOGGER.info(f"removing temporary unarchived model dir at {tempdir}")
+            shutil.rmtree(tempdir, ignore_errors=True)
+
+    return pipeline_model, pipeline_config
 
 
 class PredictionError(Exception):


### PR DESCRIPTION
This PR makes the `PipelineModel` inherit from a `pl.LightningModule` and removes the inheritance from a `allennlp.Model`. This is the first step to allow our pipeline to be trained with the Lightning `Trainer`.

In order not to break any existing flow (that is using AllenNLP's trainer, evaluation and model serialization), i had to do two things:
- copy over a few methods from the `allennlp.Model`, mainly `extend_embedder_vocab`, `forward_on_instances` and `load`. I already customized them a bit, but they can surely be optimized or even merged with some of our existing methods, especially because now we have complete control over the whole prediction flow. I will leave this for future PRs.
- customize the method to load a pipeline from a `model.tar.gz`.

In a follow-up PR i will introduce the first version of our "Lightning" trainer.

