### PR TITLE
Feature: Make metrics compatible with "inter-epoch" validations

### DIFF
--- a/src/biome/text/model.py
+++ b/src/biome/text/model.py
@@ -377,19 +377,36 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
 
     def training_step(self, batch, batch_idx) -> Dict:
         output = self(**batch)
-        self.log("loss", output["loss"], on_step=True, prog_bar=False, on_epoch=False)
+        self.log(
+            "training_loss",
+            output["loss"],
+            on_step=True,
+            prog_bar=False,
+            on_epoch=False,
+        )
 
         metrics = self.get_metrics()
         for key, val in metrics.items():
-            pbar = False if key.startswith("_") else True
-            self.log(key, val, on_step=True, prog_bar=pbar, on_epoch=False)
+            self.log(
+                ("training" if key.startswith("_") else "training_") + key,
+                val,
+                on_step=True,
+                prog_bar=not key.startswith("_"),
+                on_epoch=False,
+            )
 
         return output
 
     def training_epoch_end(self, outputs: List[Any]) -> None:
         metrics = self.get_metrics(reset=True)
         for key, val in metrics.items():
-            self.log(key, val, on_step=False, prog_bar=False, on_epoch=True)
+            self.log(
+                ("training" if key.startswith("_") else "training_") + key,
+                val,
+                on_step=False,
+                prog_bar=False,
+                on_epoch=True,
+            )
 
     def validation_step(self, batch, batch_idx) -> Dict:
         output = self(**batch)
@@ -409,12 +426,11 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
 
         metrics = self.get_metrics(reset=True)
         for key, val in metrics.items():
-            pbar = False if key.startswith("_") else True
             self.log(
-                ("validation_" if pbar else "validation") + key,
+                ("validation" if key.startswith("_") else "validation_") + key,
                 val,
                 on_step=False,
-                prog_bar=pbar,
+                prog_bar=not key.startswith("_"),
                 on_epoch=True,
             )
 

--- a/src/biome/text/model.py
+++ b/src/biome/text/model.py
@@ -400,7 +400,7 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
     def validation_epoch_end(self, outputs: List[Any]) -> None:
         averaged_epoch_loss = sum([output["loss"] for output in outputs]) / len(outputs)
         self.log(
-            "valid_loss",
+            "validation_loss",
             averaged_epoch_loss,
             on_step=False,
             prog_bar=True,
@@ -411,7 +411,7 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
         for key, val in metrics.items():
             pbar = False if key.startswith("_") else True
             self.log(
-                ("valid_" if pbar else "valid") + key,
+                ("validation_" if pbar else "validation") + key,
                 val,
                 on_step=False,
                 prog_bar=pbar,

--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -224,7 +224,6 @@ class ClassificationHead(TaskHead):
         -------
         A dictionary with all metric names and values.
         """
-        print("is_train", self.training)
         metrics, final_metrics = self._metrics.get_dict(is_train=self.training), {}
         if "accuracy" in metrics.keys():
             final_metrics.update({"accuracy": metrics["accuracy"].get_metric(reset)})

--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -17,7 +17,6 @@ from allennlp.nn.util import get_text_field_mask
 from captum.attr import IntegratedGradients
 
 from biome.text.backbone import ModelBackbone
-from biome.text.featurizer import FeaturizeError
 from biome.text.modules.configuration import ComponentConfiguration
 from biome.text.modules.configuration import FeedForwardConfiguration
 from biome.text.modules.configuration import Seq2SeqEncoderConfiguration
@@ -48,9 +47,7 @@ class DocumentClassification(ClassificationHead):
         multilabel: bool = False,
     ) -> None:
 
-        super(DocumentClassification, self).__init__(
-            backbone, labels=labels, multilabel=multilabel
-        )
+        super().__init__(backbone, labels=labels, multilabel=multilabel)
 
         self.backbone.encoder = TimeDistributedEncoder(backbone.encoder)
 

--- a/src/biome/text/modules/heads/classification/record_classification.py
+++ b/src/biome/text/modules/heads/classification/record_classification.py
@@ -7,7 +7,6 @@ import numpy
 from allennlp.data import Instance
 
 from biome.text.backbone import ModelBackbone
-from biome.text.featurizer import FeaturizeError
 from biome.text.modules.configuration import ComponentConfiguration
 from biome.text.modules.configuration import FeedForwardConfiguration
 from biome.text.modules.configuration import Seq2SeqEncoderConfiguration
@@ -36,7 +35,7 @@ class RecordClassification(DocumentClassification):
         multilabel: Optional[bool] = False,
     ) -> None:
 
-        super(RecordClassification, self).__init__(
+        super().__init__(
             backbone,
             labels=labels,
             tokens_pooler=tokens_pooler,

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -18,7 +18,6 @@ from allennlp.nn import util
 from captum.attr import IntegratedGradients
 
 from biome.text.backbone import ModelBackbone
-from biome.text.featurizer import FeaturizeError
 from biome.text.modules.configuration import BiMpmMatchingConfiguration
 from biome.text.modules.configuration import ComponentConfiguration
 from biome.text.modules.configuration import FeedForwardConfiguration
@@ -83,7 +82,7 @@ class RecordPairClassification(ClassificationHead):
         dropout: float = 0.1,
         initializer: InitializerApplicator = InitializerApplicator(),
     ):
-        super(RecordPairClassification, self).__init__(backbone, labels)
+        super().__init__(backbone, labels)
 
         # This is needed for the TrainerConfig to choose the right 'sorting_keys'
         self.backbone.encoder = TimeDistributedEncoder(self.backbone.encoder)

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -43,7 +43,7 @@ class TextClassification(ClassificationHead):
         multilabel: bool = False,
     ) -> None:
 
-        super(TextClassification, self).__init__(backbone, labels, multilabel)
+        super().__init__(backbone, labels, multilabel)
 
         self.pooler = (
             pooler.input_dim(self.backbone.encoder.get_output_dim()).compile()

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -31,6 +31,7 @@ from biome.text.helpers import offsets_from_tags
 from biome.text.helpers import spacy_to_allennlp_token
 from biome.text.helpers import span_labels_to_tag_labels
 from biome.text.helpers import tags_from_offsets
+from biome.text.metrics import Metrics
 from biome.text.modules.configuration import ComponentConfiguration
 from biome.text.modules.configuration import FeedForwardConfiguration
 from biome.text.modules.heads.task_head import TaskHead
@@ -69,7 +70,7 @@ class TokenClassification(TaskHead):
         dropout: Optional[float] = 0.0,
         feedforward: Optional[FeedForwardConfiguration] = None,
     ) -> None:
-        super(TokenClassification, self).__init__(backbone)
+        super().__init__(backbone)
 
         if label_encoding not in ["BIOUL", "BIO"]:
             raise WrongValueError(
@@ -113,19 +114,25 @@ class TokenClassification(TaskHead):
             self.num_labels, constraints, include_start_end_transitions=True
         )
 
-        self.metrics = {"accuracy": CategoricalAccuracy()}
-        if self.top_k > 1:
-            self.metrics.update(
-                {f"accuracy_{self.top_k}": CategoricalAccuracy(top_k=self.top_k)}
-            )
-        self.f1_metric = SpanBasedF1Measure(
-            self.backbone.vocab,
-            tag_namespace=vocabulary.LABELS_NAMESPACE,
-            label_encoding=self._label_encoding,
+        metrics = dict(
+            accuracy={"type": "categorical_accuracy"},
+            f1={
+                "type": "span_f1",
+                "vocabulary": self.backbone.vocab,
+                "tag_namespace": vocabulary.LABELS_NAMESPACE,
+                "label_encoding": self._label_encoding,
+            },
         )
-
-        self.__all_metrics = [self.f1_metric]
-        self.__all_metrics.extend(self.metrics.values())
+        if self.top_k > 1:
+            metrics.update(
+                {
+                    f"accuracy_{self.top_k}": {
+                        "type": "categorical_accuracy",
+                        "top_k": self.top_k,
+                    }
+                }
+            )
+        self._metrics = Metrics(**metrics)
 
     @property
     def span_labels(self) -> List[str]:
@@ -233,7 +240,7 @@ class TokenClassification(TaskHead):
 
         if tags is not None:
             output["loss"] = self._loss(logits, tags, mask)
-            for metric in self.__all_metrics:
+            for metric in self._metrics.get_dict(is_train=self.training).values():
                 metric(class_probabilities, tags, mask)
 
         return output
@@ -286,12 +293,15 @@ class TokenClassification(TaskHead):
         ]
 
     def get_metrics(self, reset: bool = False) -> Dict[str, float]:
-        metrics = {
-            metric_name: metric.get_metric(reset)
-            for metric_name, metric in self.metrics.items()
-            if metric_name != "f1"
-        }
-        metrics.update(self.f1_metric.get_metric(reset=reset))
+        metrics: Dict[str, float] = {}
+        for name, metric in self._metrics.get_dict(is_train=self.training).items():
+            metric_value = metric.get_metric(reset=reset)
+            try:
+                metrics.update(metric_value)
+            # AllenNLP's CategoricalAccuracy does not comply with AllenNLP's Metric API
+            except TypeError:
+                metrics[name] = metric_value
+
         return metrics
 
 

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -394,6 +394,11 @@ def create_dataloader(
     ----------
     instance_dataset
         The dataset of instances for the DataLoader
+    batch_size
+        Batch size
+    data_bucketing
+        If True, tries to sort batches with respect to the maximum input lengths per batch.
+        Not supported for lazily loaded data!
 
     Returns
     -------

--- a/tests/text/test_metrics.py
+++ b/tests/text/test_metrics.py
@@ -1,0 +1,24 @@
+from allennlp.data import Vocabulary
+
+from biome.text.metrics import Metrics
+
+
+def test_metrics():
+    metrics = Metrics(
+        accuracy={"type": "categorical_accuracy"},
+        f1={
+            "type": "span_f1",
+            "vocabulary": Vocabulary.empty(),
+        },
+    )
+
+    # Check that training and validation metrics are different instances
+    assert (
+        metrics.get_dict()["accuracy"]
+        is not metrics.get_dict(is_train=False)["accuracy"]
+    )
+    # Check if we share the same vocab
+    assert (
+        metrics.get_dict()["f1"]._label_vocabulary
+        is metrics.get_dict(is_train=False)["f1"]._label_vocabulary
+    )


### PR DESCRIPTION
This PR adds the possibility of computing the validation metrics during an epoch. Before this was not possible because we only defined one set of metrics that was used to calculate the training and the validation metrics. For this i introduced a "helper" `Metrics` class that takes care of instantiating two identical sets of the metrics.

I also deleted our custom `MultiLabelF1Measure` to use the AllenNLP implementation, which gives us micro-, macro-averaged and per label metrics for free.

Includes also some minor bugfixes and tests.

Closes #526 