### PR TITLE
Feat: Add default logger to our lightning trainer

### DIFF
--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -144,13 +144,13 @@ class Dataset:
 
         Parameters
         ----------
-        client:
+        client
             The elasticsearch client instance
-        index:
+        index
             The index, index pattern or alias to fetch documents
-        query:
+        query
             The es query body
-        fields:
+        fields
             Select fields to extract as ds features
 
         Returns

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,13 +3,10 @@ from pathlib import Path
 
 import pytest
 
-from biome.text import loggers
-
 
 def pytest_configure(config):
-    # In case you have wandb installed, there is an issue with tests:
-    # https://github.com/wandb/client/issues/1138
-    loggers._HAS_WANDB = False
+    # It's really hard to do testing with wandb enabled ...
+    os.environ["WANDB_MODE"] = "disabled"
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import pytest
@@ -38,3 +39,11 @@ def configurations_path() -> Path:
         / "user-guides"
         / "2-configuration.md"
     )
+
+
+@pytest.fixture
+def change_to_tmp_working_dir(tmp_path) -> Path:
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    yield tmp_path
+    os.chdir(cwd)

--- a/tests/text/test_trainer.py
+++ b/tests/text/test_trainer.py
@@ -22,14 +22,6 @@ from biome.text.configuration import WordFeatures
 
 
 @pytest.fixture
-def change_to_tmp_working_dir(tmp_path) -> Path:
-    cwd = os.getcwd()
-    os.chdir(tmp_path)
-    yield tmp_path
-    os.chdir(cwd)
-
-
-@pytest.fixture
 def train_valid_dataset(resources_data_path) -> Tuple[Dataset, Dataset]:
     """Returns both training and validation datasets"""
 
@@ -182,9 +174,7 @@ def test_default_root_dir(change_to_tmp_working_dir):
         ),
     ],
 )
-def test_add_default_loggers(input_kwargs, expected_loggers, tmp_path, monkeypatch):
-    monkeypatch.setenv("WANDB_MODE", "disabled")
-
+def test_add_default_loggers(input_kwargs, expected_loggers, tmp_path):
     trainer = Trainer(**input_kwargs, default_root_dir=str(tmp_path))
     if input_kwargs.get("logger") is not False:
         assert isinstance(trainer.trainer.logger, LoggerCollection)

--- a/tests/text/test_trainer.py
+++ b/tests/text/test_trainer.py
@@ -1,9 +1,17 @@
+import os
 import random
+import tempfile
+from pathlib import Path
 from typing import Tuple
 
 import numpy as np
 import pytest
 import torch
+from pytorch_lightning.loggers import CSVLogger
+from pytorch_lightning.loggers import LoggerCollection
+from pytorch_lightning.loggers import MLFlowLogger
+from pytorch_lightning.loggers import TensorBoardLogger
+from pytorch_lightning.loggers import WandbLogger
 
 from biome.text import Dataset
 from biome.text import Pipeline
@@ -11,6 +19,14 @@ from biome.text import Trainer
 from biome.text import VocabularyConfiguration
 from biome.text.configuration import CharFeatures
 from biome.text.configuration import WordFeatures
+
+
+@pytest.fixture
+def change_to_tmp_working_dir(tmp_path) -> Path:
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    yield tmp_path
+    os.chdir(cwd)
 
 
 @pytest.fixture
@@ -106,6 +122,7 @@ def test_text_classification(tmp_path, pipeline_dict, train_valid_dataset):
         batch_size=64,
         optimizer={"type": "adam", "lr": 0.01},
         max_epochs=5,
+        default_root_dir=str(tmp_path),
     )
 
     vocab_config = VocabularyConfiguration(
@@ -127,3 +144,69 @@ def test_text_classification(tmp_path, pipeline_dict, train_valid_dataset):
     evaluation = pl.evaluate(valid_ds)
 
     assert evaluation["loss"] == pytest.approx(0.8217981046438217, abs=0.003)
+
+
+def test_default_root_dir(change_to_tmp_working_dir):
+    trainer = Trainer()
+    assert trainer.trainer.default_root_dir == str(
+        change_to_tmp_working_dir / "training_logs"
+    )
+
+
+@pytest.mark.parametrize(
+    "input_kwargs,expected_loggers",
+    [
+        ({}, ["csv", "tensorboard", "wandb"]),
+        ({"logger": False}, []),
+        (
+            {
+                "logger": MLFlowLogger(
+                    tracking_uri=os.path.join(tempfile.gettempdir(), "mlruns")
+                ),
+                "add_wandb_logger": False,
+            },
+            ["csv", "tensorboard", "mlflow"],
+        ),
+        (
+            {
+                "logger": [
+                    MLFlowLogger(
+                        tracking_uri=os.path.join(tempfile.gettempdir(), "mlruns")
+                    ),
+                    CSVLogger(save_dir=tempfile.gettempdir()),
+                ],
+                "add_wandb_logger": False,
+                "add_tensorboard_logger": False,
+            },
+            ["csv", "mlflow"],
+        ),
+    ],
+)
+def test_add_default_loggers(input_kwargs, expected_loggers, tmp_path, monkeypatch):
+    monkeypatch.setenv("WANDB_MODE", "disabled")
+
+    trainer = Trainer(**input_kwargs, default_root_dir=str(tmp_path))
+    if input_kwargs.get("logger") is not False:
+        assert isinstance(trainer.trainer.logger, LoggerCollection)
+        assert len(trainer.trainer.logger.experiment) == len(expected_loggers)
+    else:
+        assert trainer._lightning_trainer_kwargs["logger"] is False
+
+    def loggers_include(logger_type) -> bool:
+        return any(
+            [
+                isinstance(logger, logger_type)
+                for logger in trainer._lightning_trainer_kwargs["logger"]
+            ]
+        )
+
+    for logger in expected_loggers:
+        if logger == "csv":
+            assert loggers_include(CSVLogger)
+        if logger == "tensorboard":
+            assert loggers_include(TensorBoardLogger)
+        if logger == "wandb":
+            assert loggers_include(WandbLogger)
+            assert (tmp_path / "wandb").is_dir()
+        if logger == "mlflow":
+            assert loggers_include(MLFlowLogger)


### PR DESCRIPTION
This PR adds three default loggers to our lightning trainer: CSV, TensorBoard, WandB. All of them can be disabled via `add_[csv, tensorboard, wandb]_logger` in the `Trainer` arguments.