### PR TITLE
Feat: Optimizing the vocab creation

### DIFF
--- a/docs/docs/documentation/tutorials/1-Training_a_text_classifier.ipynb
+++ b/docs/docs/documentation/tutorials/1-Training_a_text_classifier.ipynb
@@ -457,7 +457,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vocab_config = VocabularyConfiguration(datasets=[train_ds], min_count={WordFeatures.namespace: 20})"
+    "vocab_config = VocabularyConfiguration(min_count={WordFeatures.namespace: 20})"
    ]
   },
   {

--- a/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb
+++ b/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb
@@ -540,8 +540,7 @@
     "The default behavior of *biome.text* is to add all tokens from the training data set to the pipeline's vocabulary. \n",
     "This is done automatically when training the pipeline for the first time.\n",
     "\n",
-    "Since we use pretrained word embeddings we will not only consider the training data, but also the validation data when creating the vocabulary. \n",
-    "In addition, we get rid of the rarest words by adding the `min_count` argument and set it to 2 for the word feature vocabulary.\n",
+    "For this tutorial we get rid of the rarest words by adding the `min_count` argument and set it to 2 for the word feature vocabulary.\n",
     "For a complete list of available arguments see the [VocabularyConfiguration API](https://www.recogn.ai/biome-text/master/api/biome/text/configuration.html#vocabularyconfiguration)."
    ]
   },
@@ -582,6 +581,8 @@
     "\n",
     ":::\n",
     "\n",
+    "Since we use pretrained word embeddings we will not only consider the training data, but also the validation data when creating the vocabulary by setting `include_valid_data_in_vocab=True`. \n",
+    "\n",
     "The training output will be saved in a folder specified by the `output` argument of the `train` method. \n",
     "It will contain the trained model weights and the metrics, as well as the vocabulary and a *log* folder for visualizing the training process with [tensorboard](https://www.tensorflow.org/tensorboard/).\n",
     "\n",
@@ -612,6 +613,7 @@
     "    validation=valid_ds,\n",
     "    test=test_ds,\n",
     "    vocab_config=vocab_config,\n",
+    "    include_valid_data_in_vocab=True,\n",
     ")"
    ]
   },

--- a/docs/docs/documentation/user-guides/2-configuration.md
+++ b/docs/docs/documentation/user-guides/2-configuration.md
@@ -240,6 +240,7 @@ However, when providing a learning rate scheduler it is advised to set the `pati
 
 The creation of the vocabulary is managed automatically by *biome.text* and for most use cases the default settings are perfectly fine.
 If you want to do something more specific with your vocabulary you can provide a [`VocabularyConfiguration`](../../api/biome/text/configuration.md#vocabularyconfiguration) object to the `Pipeline.train()` method.
+By default the `Pipeline.train()` method only takes into account your training data for the creation of the vocabulary, but you can also include the validation data by specifying `include_valid_data_in_vocab=True`.
 
 ### Limit vocab to pretrained word vectors
 
@@ -248,16 +249,11 @@ from biome.text import Dataset, VocabularyConfiguration
 train_ds = Dataset.from_dict({"text": ["test text"], "label": ["test_label"]})
 
 vocab_config = VocabularyConfiguration(
-    datasets=[train_ds],
     pretrained_files={"word": "path/to/pretrained_words.txt"},
     only_include_pretrained_words=True,
 )
 ```
-
 In this example we limit the vocabulary to words that are listed in a file with pretrained word vectors.
-
-A `VocabularyConfiguration` must always include a list of `Dataset`s from which the vocabulary is created.
-By default, this list only includes the training data provided to the `Pipeline.train()` method.
 
 The `pretrained_files` parameter is a mapping in form of a dictionary, in which the key indicates the namespace of the feature for which the pretrained file is valid.
 This parameter enables a few other parameters, such as the `only_include_pretrained_words` that allows you to only include words in the vocabulary that are present in your data **and** in the pretrained files.

--- a/src/biome/text/_helpers.py
+++ b/src/biome/text/_helpers.py
@@ -25,7 +25,7 @@ from torch.utils.data import IterableDataset
 from biome.text import Pipeline
 from biome.text import TrainerConfiguration
 from biome.text import helpers
-from biome.text.dataset import InstancesDataset
+from biome.text.dataset import InstanceDataset
 from biome.text.model import PipelineModel
 from biome.text.training_results import TrainingResults
 
@@ -64,9 +64,9 @@ class PipelineTrainer:
         pipeline: Pipeline,
         trainer_config: TrainerConfiguration,
         output_dir: str,
-        training: InstancesDataset,
-        validation: Optional[InstancesDataset] = None,
-        test: Optional[InstancesDataset] = None,
+        training: InstanceDataset,
+        validation: Optional[InstanceDataset] = None,
+        test: Optional[InstanceDataset] = None,
         batch_weight_key: str = "",
         epoch_callbacks: List["allennlp.training.EpochCallback"] = None,
     ):
@@ -270,7 +270,7 @@ class PipelineTrainer:
 
 
 def create_dataloader(
-    dataset: InstancesDataset,
+    dataset: InstanceDataset,
     batch_size: int,
     data_bucketing: bool = False,
     batches_per_epoch: Optional[int] = None,
@@ -313,7 +313,7 @@ def create_dataloader(
 def create_trainer_for_finding_lr(
     model: PipelineModel,
     trainer_config: TrainerConfiguration,
-    training_data: InstancesDataset,
+    training_data: InstanceDataset,
 ) -> GradientDescentTrainer:
     """Returns an AllenNLP Trainer used for the learning rate scan.
 

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -566,26 +566,29 @@ class TrainerConfiguration:
         return allennlp_trainer_config
 
 
+@dataclasses.dataclass
 class VocabularyConfiguration:
-    """Configures a `Vocabulary` before it gets created from the data
-
-    Use this to configure a Vocabulary using specific arguments from `allennlp.data.Vocabulary`
+    """Configurations for creating the vocabulary
 
     See [AllenNLP Vocabulary docs](https://docs.allennlp.org/master/api/data/vocabulary/#vocabulary])
 
     Parameters
     ----------
-    datasets
-        List of datasets from which to create the vocabulary
-    min_count
-        Minimum number of appearances of a token to be included in the vocabulary.
-        The key in the dictionary refers to the namespace of the input feature
+    include_validation_data
+        If True, include the validation data when creating the vocabulary. Default: False
     max_vocab_size
         If you want to cap the number of tokens in your vocabulary, you can do so with this
         parameter.  If you specify a single integer, every namespace will have its vocabulary fixed
         to be no larger than this.  If you specify a dictionary, then each namespace in the
         `counter` can have a separate maximum vocabulary size. Any missing key will have a value
         of `None`, which means no cap on the vocabulary size.
+    min_count
+        Minimum number of appearances of a token to be included in the vocabulary.
+        The key in the dictionary refers to the namespace of the input feature
+    min_pretrained_embeddings
+        Minimum number of lines to keep from pretrained_files, even for tokens not appearing in the sources.
+    only_include_pretrained_words
+        Only include tokens present in pretrained_files
     pretrained_files
         If provided, this map specifies the path to optional pretrained embedding files for each
         namespace. This can be used to either restrict the vocabulary to only words which appear
@@ -593,62 +596,18 @@ class VocabularyConfiguration:
         regardless of their count, depending on the value of `only_include_pretrained_words`.
         Words which appear in the pretrained embedding file but not in the data are NOT included
         in the Vocabulary.
-    only_include_pretrained_words
-        Only include tokens present in pretrained_files
     tokens_to_add
         A list of tokens to add to the corresponding namespace of the vocabulary,
         even if they are not present in the `datasets`
-    min_pretrained_embeddings
-        Minimum number of lines to keep from pretrained_files, even for tokens not appearing in the sources.
     """
 
-    def __init__(
-        self,
-        datasets: List[Dataset],
-        min_count: Dict[str, int] = None,
-        max_vocab_size: Union[int, Dict[str, int]] = None,
-        pretrained_files: Optional[Dict[str, str]] = None,
-        only_include_pretrained_words: bool = False,
-        tokens_to_add: Dict[str, List[str]] = None,
-        min_pretrained_embeddings: Dict[str, int] = None,
-    ):
-        self.datasets = datasets
-        self.pretrained_files = pretrained_files
-        self.min_count = min_count
-        self.max_vocab_size = max_vocab_size
-        self.only_include_pretrained_words = only_include_pretrained_words
-        self.tokens_to_add = tokens_to_add
-        self.min_pretrained_embeddings = min_pretrained_embeddings
-
-    def build_vocab(self, pipeline: "Pipeline", lazy: bool = False) -> Vocabulary:
-        """Build the configured vocabulary
-
-        Parameters
-        ----------
-        pipeline
-            The pipeline used to create the instances from which the vocabulary is built.
-        lazy
-            If true, instances are lazily loaded from disk, otherwise they are loaded into memory.
-
-        Returns
-        -------
-        vocab
-        """
-        vocab = Vocabulary.from_instances(
-            instances=(
-                instance
-                for dataset in self.datasets
-                for instance in dataset.to_instances(pipeline, lazy=lazy)
-            ),
-            max_vocab_size=self.max_vocab_size,
-            min_count=self.min_count,
-            pretrained_files=self.pretrained_files,
-            only_include_pretrained_words=self.only_include_pretrained_words,
-            min_pretrained_embeddings=self.min_pretrained_embeddings,
-            tokens_to_add=self.tokens_to_add,
-        )
-
-        return vocab
+    include_validation_data: bool = False
+    max_vocab_size: Union[int, Dict[str, int]] = None
+    min_count: Dict[str, int] = None
+    min_pretrained_embeddings: Dict[str, int] = None
+    only_include_pretrained_words: bool = False
+    pretrained_files: Optional[Dict[str, str]] = None
+    tokens_to_add: Dict[str, List[str]] = None
 
 
 @dataclasses.dataclass

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -16,8 +16,6 @@ from allennlp.data import TokenIndexer
 from allennlp.data import Vocabulary
 from allennlp.modules import TextFieldEmbedder
 
-from biome.text.dataset import Dataset
-
 from .features import CharFeatures
 from .features import TransformersFeatures
 from .features import WordFeatures
@@ -30,9 +28,6 @@ from .modules.heads.task_head import TaskHeadConfiguration
 from .modules.heads.token_classification import TokenClassification
 from .tokenizer import Tokenizer
 from .tokenizer import TransformersTokenizer
-
-if TYPE_CHECKING:
-    from .pipeline import Pipeline
 
 
 class FeaturesConfiguration(FromParams):
@@ -574,8 +569,6 @@ class VocabularyConfiguration:
 
     Parameters
     ----------
-    include_validation_data
-        If True, include the validation data when creating the vocabulary. Default: False
     max_vocab_size
         If you want to cap the number of tokens in your vocabulary, you can do so with this
         parameter.  If you specify a single integer, every namespace will have its vocabulary fixed
@@ -601,7 +594,6 @@ class VocabularyConfiguration:
         even if they are not present in the `datasets`
     """
 
-    include_validation_data: bool = False
     max_vocab_size: Union[int, Dict[str, int]] = None
     min_count: Dict[str, int] = None
     min_pretrained_embeddings: Dict[str, int] = None

--- a/src/biome/text/dataset.py
+++ b/src/biome/text/dataset.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
     from biome.text.pipeline import Pipeline
 
-InstancesDataset = Union[AllennlpDataset, AllennlpLazyDataset]
+InstanceDataset = Union[AllennlpDataset, AllennlpLazyDataset]
 
 
 class Dataset:
@@ -339,7 +339,7 @@ class Dataset:
 
     def to_instances(
         self, pipeline: "Pipeline", lazy: bool = False, use_cache: bool = True
-    ) -> InstancesDataset:
+    ) -> InstanceDataset:
         """Convert input to instances for the pipeline
 
         Parameters

--- a/src/biome/text/loggers.py
+++ b/src/biome/text/loggers.py
@@ -13,7 +13,7 @@ from mlflow.entities import Experiment
 from mlflow.tracking import MlflowClient
 from mlflow.utils import mlflow_tags
 
-from biome.text.dataset import InstancesDataset
+from biome.text.dataset import InstanceDataset
 from biome.text.training_results import TrainingResults
 
 # We do not require wandb
@@ -39,9 +39,9 @@ class BaseTrainLogger(EpochCallback):
         self,
         pipeline: "Pipeline",
         trainer_configuration: "TrainerConfiguration",
-        training: InstancesDataset,
-        validation: Optional[InstancesDataset] = None,
-        test: Optional[InstancesDataset] = None,
+        training: InstanceDataset,
+        validation: Optional[InstanceDataset] = None,
+        test: Optional[InstanceDataset] = None,
     ):
         """Init train logging
 
@@ -157,9 +157,9 @@ class MlflowLogger(BaseTrainLogger):
         self,
         pipeline: "Pipeline",
         trainer_configuration: "TrainerConfiguration",
-        training: InstancesDataset,
-        validation: Optional[InstancesDataset] = None,
-        test: Optional[InstancesDataset] = None,
+        training: InstanceDataset,
+        validation: Optional[InstanceDataset] = None,
+        test: Optional[InstanceDataset] = None,
     ):
         from pandas import json_normalize
 
@@ -232,9 +232,9 @@ class WandBLogger(BaseTrainLogger):
         self,
         pipeline: "Pipeline",
         trainer_configuration: "TrainerConfiguration",
-        training: InstancesDataset,
-        validation: Optional[InstancesDataset] = None,
-        test: Optional[InstancesDataset] = None,
+        training: InstanceDataset,
+        validation: Optional[InstanceDataset] = None,
+        test: Optional[InstanceDataset] = None,
     ):
         config = {
             "pipeline": pipeline.config.as_dict(),

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -16,7 +16,6 @@ from allennlp.nn.util import get_text_field_mask
 from captum.attr import IntegratedGradients
 
 from biome.text.backbone import ModelBackbone
-from biome.text.featurizer import FeaturizeError
 from biome.text.modules.configuration import ComponentConfiguration
 from biome.text.modules.configuration import FeedForwardConfiguration
 from biome.text.modules.configuration import Seq2VecEncoderConfiguration

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -38,7 +38,7 @@ from biome.text.configuration import PredictionConfiguration
 from biome.text.configuration import TrainerConfiguration
 from biome.text.configuration import VocabularyConfiguration
 from biome.text.dataset import Dataset
-from biome.text.dataset import InstancesDataset
+from biome.text.dataset import InstanceDataset
 from biome.text.errors import EmptyVocabError
 from biome.text.features import TransformersFeatures
 from biome.text.features import WordFeatures
@@ -281,7 +281,7 @@ class Pipeline:
         self,
         trainer_config: TrainerConfiguration,
         find_lr_config: FindLRConfiguration,
-        training_data: Union[Dataset, InstancesDataset],
+        training_data: Dataset,
         vocab_config: Optional[Union[VocabularyConfiguration, str]] = "default",
         lazy: bool = False,
     ):
@@ -354,10 +354,10 @@ class Pipeline:
     def train(
         self,
         output: str,
-        training: Union[Dataset, InstancesDataset],
+        training: Dataset,
         trainer: Optional[TrainerConfiguration] = None,
-        validation: Optional[Union[Dataset, InstancesDataset]] = None,
-        test: Optional[Union[Dataset, InstancesDataset]] = None,
+        validation: Optional[Dataset] = None,
+        test: Optional[Dataset] = None,
         vocab_config: Optional[Union[VocabularyConfiguration, str]] = "default",
         loggers: List[BaseTrainLogger] = None,
         lazy: bool = False,

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -24,7 +24,7 @@ from torch.utils.data import IterableDataset
 
 from biome.text.configuration import VocabularyConfiguration
 from biome.text.dataset import Dataset
-from biome.text.dataset import InstancesDataset
+from biome.text.dataset import InstanceDataset
 from biome.text.pipeline import Pipeline
 
 # We do not require wandb
@@ -488,7 +488,7 @@ class Trainer:
 
 
 def create_dataloader(
-    instance_dataset: InstancesDataset,
+    instance_dataset: InstanceDataset,
     batch_size: int = 16,
     data_bucketing: bool = False,
 ) -> PyTorchDataLoader:

--- a/tests/text/test_hpo.py
+++ b/tests/text/test_hpo.py
@@ -65,7 +65,7 @@ def test_tune_exp_save_dataset_and_vocab(
     dataset, pipeline_config, trainer_config, monkeypatch
 ):
     pl = Pipeline.from_config(pipeline_config)
-    vocab = VocabularyConfiguration(datasets=[dataset]).build_vocab(pipeline=pl)
+    vocab = pl.create_vocab([dataset.to_instances(pl)])
 
     my_exp = TuneExperiment(
         pipeline_config=pipeline_config,

--- a/tests/text/test_pipeline_vocab.py
+++ b/tests/text/test_pipeline_vocab.py
@@ -86,8 +86,9 @@ def test_specific_vocab_config(
 ):
     pipeline.train(
         output=str(tmp_path / "vocab_test_output"),
-        training=valid_dataset,
-        vocab_config=VocabularyConfiguration(datasets=[train_dataset, valid_dataset]),
+        training=train_dataset,
+        validation=valid_dataset,
+        include_valid_data_in_vocab=True,
     )
     assert pipeline.vocab.get_vocab_size(WordFeatures.namespace) == 16
     assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 19
@@ -121,7 +122,9 @@ def test_not_touching_vocab(
     assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 12
 
 
-def test_restore_vocab(pipeline, train_dataset, tmp_path, deactivate_pipeline_trainer):
+def test_restore_vocab(
+    pipeline, train_dataset, valid_dataset, tmp_path, deactivate_pipeline_trainer
+):
     output = tmp_path / "test_restore_vocab_output"
     pipeline.train(
         output=str(output),

--- a/tests/text/test_pretrained_word_vectors.py
+++ b/tests/text/test_pretrained_word_vectors.py
@@ -105,12 +105,14 @@ def test_extending_vocab_with_weights_file(
     )
 
 
-def test_raise_filenotfound_error(pipeline_config, deactivate_pipeline_trainer):
+def test_raise_filenotfound_error(
+    pipeline_config, deactivate_pipeline_trainer, dataset
+):
     Path(pipeline_config["features"]["word"]["weights_file"]).unlink()
     pipeline = Pipeline.from_config(pipeline_config)
 
     with pytest.raises(FileNotFoundError):
         pipeline.train(
             output="dummy",
-            training=cast(Dataset, None),
+            training=dataset,
         )

--- a/tests/text/test_trainer.py
+++ b/tests/text/test_trainer.py
@@ -117,9 +117,7 @@ def test_text_classification(tmp_path, pipeline_dict, train_valid_dataset):
         default_root_dir=str(tmp_path),
     )
 
-    vocab_config = VocabularyConfiguration(
-        datasets=[train_ds], max_vocab_size={"word": 50}
-    )
+    vocab_config = VocabularyConfiguration(max_vocab_size={"word": 50})
 
     trainer.fit(
         pipeline=pl,

--- a/tests/text_classification_integration_test.py
+++ b/tests/text_classification_integration_test.py
@@ -118,9 +118,7 @@ def test_text_classification(
     train_ds = train_valid_dataset[0]
     valid_ds = train_valid_dataset[1]
     trainer = TrainerConfiguration(**trainer_dict)
-    vocab_config = VocabularyConfiguration(
-        datasets=[train_ds], max_vocab_size={"word": 50}
-    )
+    vocab_config = VocabularyConfiguration(max_vocab_size={"word": 50})
 
     output = tmp_path / "output"
 


### PR DESCRIPTION
This PR closes #525 and optimizes the vocab creation.
Changes: The `VocabularyConfiguration` gets rid of its `datasets` parameter and is now a simple dataclass, the trainer gets a new argument: `include_valid_data_in_vocab`. In this way we can reuse the same InstanceDatasets for the vocab creation and the training.