### PR TITLE
Feat: Introducing LightningTrainerConfiguration

### DIFF
--- a/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb
+++ b/docs/docs/documentation/tutorials/2-Training_a_sequence_tagger_for_Slot_Filling.ipynb
@@ -541,6 +541,7 @@
     "This is done automatically when training the pipeline for the first time.\n",
     "\n",
     "For this tutorial we get rid of the rarest words by adding the `min_count` argument and set it to 2 for the word feature vocabulary.\n",
+    "Since we use pretrained word embeddings we will not only consider the training data, but also the validation data when creating the vocabulary by setting `include_valid_data=True`. \n",
     "For a complete list of available arguments see the [VocabularyConfiguration API](https://www.recogn.ai/biome-text/master/api/biome/text/configuration.html#vocabularyconfiguration)."
    ]
   },
@@ -550,10 +551,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vocab_config = VocabularyConfiguration(\n",
-    "    datasets=[train_ds, valid_ds],\n",
-    "    min_count={\"word\": 2},\n",
-    ")"
+    "vocab_config = VocabularyConfiguration(min_count={\"word\": 2}, include_valid_data=True)"
    ]
   },
   {
@@ -580,8 +578,6 @@
     "See the [TrainerConfiguration API](https://www.recogn.ai/biome-text/master/api/biome/text/configuration.html#trainerconfiguration) for a complete list of available configurations.\n",
     "\n",
     ":::\n",
-    "\n",
-    "Since we use pretrained word embeddings we will not only consider the training data, but also the validation data when creating the vocabulary by setting `include_valid_data_in_vocab=True`. \n",
     "\n",
     "The training output will be saved in a folder specified by the `output` argument of the `train` method. \n",
     "It will contain the trained model weights and the metrics, as well as the vocabulary and a *log* folder for visualizing the training process with [tensorboard](https://www.tensorflow.org/tensorboard/).\n",
@@ -613,7 +609,6 @@
     "    validation=valid_ds,\n",
     "    test=test_ds,\n",
     "    vocab_config=vocab_config,\n",
-    "    include_valid_data_in_vocab=True,\n",
     ")"
    ]
   },

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -1,8 +1,11 @@
 import copy
-import dataclasses
-from typing import TYPE_CHECKING
+import os
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
 from typing import Any
 from typing import Dict
+from typing import Iterable
 from typing import List
 from typing import Optional
 from typing import Type
@@ -15,6 +18,11 @@ from allennlp.common.checks import ConfigurationError
 from allennlp.data import TokenIndexer
 from allennlp.data import Vocabulary
 from allennlp.modules import TextFieldEmbedder
+from pytorch_lightning import Callback
+from pytorch_lightning.accelerators import Accelerator
+from pytorch_lightning.loggers import LightningLoggerBase
+from pytorch_lightning.plugins import Plugin
+from pytorch_lightning.profiler import BaseProfiler
 
 from .features import CharFeatures
 from .features import TransformersFeatures
@@ -436,7 +444,7 @@ class PipelineConfiguration(FromParams):
         return self.features.compile_embedder(vocab)
 
 
-@dataclasses.dataclass
+@dataclass
 class TrainerConfiguration:
     """Configures the training of a pipeline
 
@@ -509,9 +517,7 @@ class TrainerConfiguration:
         A value of None or -1 means all checkpoints will be kept.
     """
 
-    optimizer: Dict[str, Any] = dataclasses.field(
-        default_factory=lambda: {"type": "adam"}
-    )
+    optimizer: Dict[str, Any] = field(default_factory=lambda: {"type": "adam"})
     validation_metric: str = "-loss"
     patience: Optional[int] = 2
     num_epochs: int = 20
@@ -561,7 +567,7 @@ class TrainerConfiguration:
         return allennlp_trainer_config
 
 
-@dataclasses.dataclass
+@dataclass
 class VocabularyConfiguration:
     """Configurations for creating the vocabulary
 
@@ -569,6 +575,9 @@ class VocabularyConfiguration:
 
     Parameters
     ----------
+    include_valid_data
+        If passed to the `Trainer`, this argument allows you to take the validation data into account when creating
+        the vocabulary (apart from the training data). Default: False.
     max_vocab_size
         If you want to cap the number of tokens in your vocabulary, you can do so with this
         parameter.  If you specify a single integer, every namespace will have its vocabulary fixed
@@ -594,6 +603,7 @@ class VocabularyConfiguration:
         even if they are not present in the `datasets`
     """
 
+    include_valid_data: bool = False
     max_vocab_size: Union[int, Dict[str, int]] = None
     min_count: Dict[str, int] = None
     min_pretrained_embeddings: Dict[str, int] = None
@@ -602,7 +612,7 @@ class VocabularyConfiguration:
     tokens_to_add: Dict[str, List[str]] = None
 
 
-@dataclasses.dataclass
+@dataclass
 class FindLRConfiguration:
     """A configuration for finding the learning rate via `Pipeline.find_lr()`.
 
@@ -631,7 +641,7 @@ class FindLRConfiguration:
 
 
 # We need this to be hashable for the prediction cache -> frozen=True
-@dataclasses.dataclass(frozen=True)
+@dataclass(frozen=True)
 class PredictionConfiguration:
     """Contains configurations for a `Pipeline.prediction`
 
@@ -644,4 +654,297 @@ class PredictionConfiguration:
 
     add_tokens: bool = False
     add_attributions: bool = False
-    attributions_kwargs: Dict = dataclasses.field(default_factory=dict)
+    attributions_kwargs: Dict = field(default_factory=dict)
+
+
+@dataclass
+class LightningTrainerConfiguration:
+    """Configuration for our Lightning Trainer
+
+    The docs are mainly a copy from the
+    [Lightning Trainer API](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.trainer.html#pytorch_lightning.trainer.trainer.Trainer)
+    with some additional parameters added.
+
+    Parameters
+    ----------
+    accelerator
+        Previously known as distributed_backend (dp, ddp, ddp2, etc...).
+        Can also take in an accelerator object for custom hardware.
+
+    accumulate_grad_batches
+        Accumulates grads every k batches or as set up in the dict.
+
+    add_csv_logger
+        Adds a default CSV logger if `logger` is not False. Default: True
+
+    add_tensorboard_logger
+        Adds a default Tensorboard logger if `logger` is not False. Default: True
+
+    add_wandb_logger
+        Adds a default WandB logger if `logger` is not False and wandb is installed. Default: True
+
+    amp_backend
+        The mixed precision backend to use ("native" or "apex")
+
+    amp_level
+        The optimization level to use (O1, O2, etc...).
+
+    auto_lr_find
+        If set to True, will make trainer.tune() run a learning rate finder,
+        trying to optimize initial learning for faster convergence. trainer.tune() method will
+        set the suggested learning rate in self.lr or self.learning_rate in the LightningModule.
+        To use a different key set a string instead of True with the key name.
+
+    auto_scale_batch_size
+        If set to True, will `initially` run a batch size
+        finder trying to find the largest batch size that fits into memory.
+        The result will be stored in self.batch_size in the LightningModule.
+        Additionally, can be set to either `power` that estimates the batch size through
+        a power search or `binsearch` that estimates the batch size through a binary search.
+
+    auto_select_gpus
+        If enabled and `gpus` is an integer, pick available
+        gpus automatically. This is especially useful when
+        GPUs are configured to be in "exclusive mode", such
+        that only one process at a time can access them.
+
+    batch_size
+        Size of the batch.
+
+    benchmark
+        If true enables cudnn.benchmark.
+
+    callbacks
+        Add a callback or list of callbacks.
+
+    checkpoint_callback
+        If ``True``, enable checkpointing.
+        It will configure a default ModelCheckpoint callback if there is no user-defined ModelCheckpoint in
+        :paramref:`~pytorch_lightning.trainer.trainer.Trainer.callbacks`. Default: ``True``.
+
+    check_val_every_n_epoch
+        Check val every n train epochs.
+
+    data_bucketing
+        If enabled, try to apply data bucketing over training batches.
+
+    default_root_dir
+        Default path for logs and weights when no logger/ckpt_callback passed.
+        Can be remote file paths such as 's3://mybucket/path' or 'hdfs://path/'
+        Default: './training_logs'.
+
+    deterministic
+        If true enables cudnn.deterministic.
+
+    fast_dev_run
+        runs n if set to ``n`` (int) else 1 if set to ``True`` batch(es)
+        of train, val and test to find any bugs (ie: a sort of unit test).
+
+    flush_logs_every_n_steps
+        How often to flush logs to disk (defaults to every 100 steps).
+
+    gpus
+        number of gpus to train on (int) or which GPUs to train on (list or str) applied per node
+
+    gradient_clip_val
+        0 means don't clip.
+
+    limit_train_batches
+        How much of training dataset to check (floats = percent, int = num_batches)
+
+    limit_val_batches
+        How much of validation dataset to check (floats = percent, int = num_batches)
+
+    limit_test_batches
+        How much of test dataset to check (floats = percent, int = num_batches)
+
+    log_every_n_steps
+        How often to log within steps (defaults to every 50 steps).
+
+    log_gpu_memory
+        None, 'min_max', 'all'. Might slow performance
+
+    logger
+        Logger (or iterable collection of loggers) for experiment tracking.
+        If not False, we will add some loggers by default, see `add_[csv, tensorboard, wandb]_logger`.
+        Default: True
+
+    prepare_data_per_node
+        If True, each LOCAL_RANK=0 will call prepare data.
+        Otherwise only NODE_RANK=0, LOCAL_RANK=0 will prepare data
+
+    process_position
+        orders the progress bar when running multiple models on same machine.
+
+    progress_bar_refresh_rate
+        How often to refresh progress bar (in steps). Value ``0`` disables progress bar.
+        Ignored when a custom progress bar is passed to :paramref:`~Trainer.callbacks`. Default: None, means
+        a suitable value will be chosen based on the environment (terminal, Google COLAB, etc.).
+
+    profiler
+        To profile individual steps during training and assist in identifying bottlenecks. Passing bool
+        value is deprecated in v1.1 and will be removed in v1.3.
+
+    overfit_batches
+        Overfit a percent of training data (float) or a set number of batches (int). Default: 0.0
+
+    plugins
+        Plugins allow modification of core behavior like ddp and amp, and enable custom lightning plugins.
+
+    precision
+        Full precision (32), half precision (16). Can be used on CPU, GPU or TPUs.
+
+    max_epochs
+        Stop training once this number of epochs is reached. Disabled by default (None).
+        If both max_epochs and max_steps are not specified, defaults to ``max_epochs`` = 1000.
+
+    min_epochs
+        Force training for at least these many epochs. Disabled by default (None).
+        If both min_epochs and min_steps are not specified, defaults to ``min_epochs`` = 1.
+
+    max_steps
+        Stop training after this number of steps. Disabled by default (None).
+
+    min_steps
+        Force training for at least these number of steps. Disabled by default (None).
+
+    num_nodes
+        number of GPU nodes for distributed training.
+
+    num_processes
+        number of processes for distributed training with distributed_backend="ddp_cpu"
+
+    num_sanity_val_steps
+        Sanity check runs n validation batches before starting the training routine.
+        Set it to `-1` to run all batches in all validation dataloaders. Default: 2
+
+    optimizer
+        Configuration for an [AllenNLP/PyTorch optimizer](https://docs.allennlp.org/main/api/training/optimizers/)
+        that is constructed via the AllenNLP configuration framework.
+        Default: `{"type": "adam", "lr": 0.001}`
+
+    reload_dataloaders_every_epoch
+        Set to True to reload dataloaders every epoch.
+
+    replace_sampler_ddp
+        Explicitly enables or disables sampler replacement. If not specified this
+        will toggled automatically when DDP is used. By default it will add ``shuffle=True`` for
+        train sampler and ``shuffle=False`` for val/test sampler. If you want to customize it,
+        you can set ``replace_sampler_ddp=False`` and add your own distributed sampler.
+
+    resume_from_checkpoint
+        Path/URL of the checkpoint from which training is resumed. If there is
+        no checkpoint file at the path, start from scratch. If resuming from mid-epoch checkpoint,
+        training will start from the beginning of the next epoch.
+
+    sync_batchnorm
+        Synchronize batch norm layers between process groups/whole world.
+
+    terminate_on_nan
+        If set to True, will terminate training (by raising a `ValueError`) at the
+        end of each training batch, if any of the parameters or the loss are NaN or +/-inf.
+
+    tpu_cores
+        How many TPU cores to train on (1 or 8) / Single TPU to train on [1]
+
+    track_grad_norm
+        -1 no tracking. Otherwise tracks that p-norm. May be set to 'inf' infinity-norm.
+
+    truncated_bptt_steps
+        Truncated back prop breaks performs backprop every k steps of much longer
+        sequence.
+
+    val_check_interval
+        How often to check the validation set. Use float to check within a training epoch,
+        use int to check every n steps (batches).
+
+    weights_summary
+        Prints a summary of the weights when training begins.
+
+    weights_save_path
+        Where to save weights if specified. Will override default_root_dir
+        for checkpoints only. Use this if for whatever reason you need the checkpoints
+        stored in a different place than the logs written in `default_root_dir`.
+        Can be remote file paths such as `s3://mybucket/path` or 'hdfs://path/'
+        Defaults to `default_root_dir`.
+
+    move_metrics_to_cpu
+        Whether to force internal logged metrics to be moved to cpu.
+        This can save some gpu memory, but can make training slower. Use with attention.
+
+    multiple_trainloader_mode
+        How to loop over the datasets when there are multiple train loaders.
+        In 'max_size_cycle' mode, the trainer ends one epoch when the largest dataset is traversed,
+        and smaller datasets reload when running out of their data. In 'min_size' mode, all the datasets
+        reload when reaching the minimum length of datasets.
+
+    stochastic_weight_avg
+        Whether to use `Stochastic Weight Averaging (SWA)
+        <https://pytorch.org/blog/pytorch-1.6-now-includes-stochastic-weight-averaging/>_`
+    """
+
+    logger: Union[LightningLoggerBase, Iterable[LightningLoggerBase], bool] = True
+    checkpoint_callback: bool = True
+    callbacks: Optional[Union[List[Callback], Callback]] = None
+    default_root_dir: str = field(
+        default_factory=lambda: os.path.join(os.getcwd(), "training_logs")
+    )
+    gradient_clip_val: float = 0
+    process_position: int = 0
+    num_nodes: int = 1
+    num_processes: int = 1
+    gpus: Optional[Union[List[int], str, int]] = None
+    auto_select_gpus: bool = False
+    tpu_cores: Optional[Union[List[int], str, int]] = None
+    log_gpu_memory: Optional[str] = None
+    progress_bar_refresh_rate: Optional[int] = None
+    overfit_batches: Union[int, float] = 0.0
+    track_grad_norm: Union[int, float, str] = -1
+    check_val_every_n_epoch: int = 1
+    fast_dev_run: Union[int, bool] = False
+    accumulate_grad_batches: Union[int, Dict[int, int], List[list]] = 1
+    max_epochs: Optional[int] = None
+    min_epochs: Optional[int] = None
+    max_steps: Optional[int] = None
+    min_steps: Optional[int] = None
+    limit_train_batches: Union[int, float] = 1.0
+    limit_val_batches: Union[int, float] = 1.0
+    limit_test_batches: Union[int, float] = 1.0
+    limit_predict_batches: Union[int, float] = 1.0
+    val_check_interval: Union[int, float] = 1.0
+    flush_logs_every_n_steps: int = 100
+    log_every_n_steps: int = 50
+    accelerator: Optional[Union[str, Accelerator]] = None
+    sync_batchnorm: bool = False
+    precision: int = 32
+    weights_summary: Optional[str] = "top"
+    weights_save_path: Optional[str] = None
+    num_sanity_val_steps: int = 2
+    truncated_bptt_steps: Optional[int] = None
+    resume_from_checkpoint: Optional[Union[Path, str]] = None
+    profiler: Optional[Union[BaseProfiler, bool, str]] = None
+    benchmark: bool = False
+    deterministic: bool = False
+    reload_dataloaders_every_epoch: bool = False
+    auto_lr_find: Union[bool, str] = False
+    replace_sampler_ddp: bool = True
+    terminate_on_nan: bool = False
+    auto_scale_batch_size: Union[str, bool] = False
+    prepare_data_per_node: bool = True
+    plugins: Optional[Union[Plugin, str, list]] = None
+    amp_backend: str = "native"
+    amp_level: str = "O2"
+    distributed_backend: Optional[str] = None
+    automatic_optimization: Optional[bool] = None
+    move_metrics_to_cpu: bool = False
+    multiple_trainloader_mode: str = "max_size_cycle"
+    stochastic_weight_avg: bool = False
+    # non lightning trainer parameters
+    add_csv_logger: bool = True
+    add_tensorboard_logger: bool = True
+    add_wandb_logger: bool = True
+    batch_size: int = 16
+    data_bucketing: bool = False
+    optimizer: Dict[str, Any] = field(
+        default_factory=lambda: {"type": "adam", "lr": 0.001}
+    )

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -1,8 +1,6 @@
 import logging
 import os
-from pathlib import Path
-from typing import Dict
-from typing import Iterable
+from dataclasses import asdict
 from typing import List
 from typing import Optional
 from typing import Union
@@ -13,15 +11,13 @@ from allennlp.data import PyTorchDataLoader
 from allennlp.data.samplers import BucketBatchSampler
 from allennlp.training.optimizers import Optimizer
 from pytorch_lightning import Callback
-from pytorch_lightning.accelerators import Accelerator
 from pytorch_lightning.loggers import CSVLogger
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.loggers import WandbLogger
-from pytorch_lightning.plugins import Plugin
-from pytorch_lightning.profiler import BaseProfiler
 from torch.utils.data import IterableDataset
 
+from biome.text.configuration import LightningTrainerConfiguration
 from biome.text.configuration import VocabularyConfiguration
 from biome.text.dataset import Dataset
 from biome.text.dataset import InstanceDataset
@@ -45,332 +41,75 @@ class Trainer:
     """A class for training a `biome.text.Pipeline`.
 
     It is basically a light wrapper around the awesome Pytorch Lightning Trainer to facilitate the interaction
-    with our pipelines. The docs are mainly a copy from the
-    [Lightning Trainer API](https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.trainer.html#pytorch_lightning.trainer.trainer.Trainer)
-    with some additional parameters added.
+    with our pipelines.
 
     Parameters
     ----------
-    accelerator
-        Previously known as distributed_backend (dp, ddp, ddp2, etc...).
-        Can also take in an accelerator object for custom hardware.
-
-    accumulate_grad_batches
-        Accumulates grads every k batches or as set up in the dict.
-
-    add_csv_logger
-        Adds a default CSV logger if `logger` is not False. Default: True
-
-    add_tensorboard_logger
-        Adds a default Tensorboard logger if `logger` is not False. Default: True
-
-    add_wandb_logger
-        Adds a default WandB logger if `logger` is not False and wandb is installed. Default: True
-
-    amp_backend
-        The mixed precision backend to use ("native" or "apex")
-
-    amp_level
-        The optimization level to use (O1, O2, etc...).
-
-    auto_lr_find
-        If set to True, will make trainer.tune() run a learning rate finder,
-        trying to optimize initial learning for faster convergence. trainer.tune() method will
-        set the suggested learning rate in self.lr or self.learning_rate in the LightningModule.
-        To use a different key set a string instead of True with the key name.
-
-    auto_scale_batch_size
-        If set to True, will `initially` run a batch size
-        finder trying to find the largest batch size that fits into memory.
-        The result will be stored in self.batch_size in the LightningModule.
-        Additionally, can be set to either `power` that estimates the batch size through
-        a power search or `binsearch` that estimates the batch size through a binary search.
-
-    auto_select_gpus
-        If enabled and `gpus` is an integer, pick available
-        gpus automatically. This is especially useful when
-        GPUs are configured to be in "exclusive mode", such
-        that only one process at a time can access them.
-
-    batch_size
-        Size of the batch.
-
-    benchmark
-        If true enables cudnn.benchmark.
-
-    callbacks
-        Add a callback or list of callbacks.
-
-    checkpoint_callback
-        If ``True``, enable checkpointing.
-        It will configure a default ModelCheckpoint callback if there is no user-defined ModelCheckpoint in
-        :paramref:`~pytorch_lightning.trainer.trainer.Trainer.callbacks`. Default: ``True``.
-
-    check_val_every_n_epoch
-        Check val every n train epochs.
-
-    data_bucketing
-        If enabled, try to apply data bucketing over training batches.
-
-    default_root_dir
-        Default path for logs and weights when no logger/ckpt_callback passed.
-        Can be remote file paths such as 's3://mybucket/path' or 'hdfs://path/'
-        Default: './training_logs'.
-
-    deterministic
-        If true enables cudnn.deterministic.
-
-    fast_dev_run
-        runs n if set to ``n`` (int) else 1 if set to ``True`` batch(es)
-        of train, val and test to find any bugs (ie: a sort of unit test).
-
-    flush_logs_every_n_steps
-        How often to flush logs to disk (defaults to every 100 steps).
-
-    gpus
-        number of gpus to train on (int) or which GPUs to train on (list or str) applied per node
-
-    gradient_clip_val
-        0 means don't clip.
-
-    limit_train_batches
-        How much of training dataset to check (floats = percent, int = num_batches)
-
-    limit_val_batches
-        How much of validation dataset to check (floats = percent, int = num_batches)
-
-    limit_test_batches
-        How much of test dataset to check (floats = percent, int = num_batches)
-
-    log_every_n_steps
-        How often to log within steps (defaults to every 50 steps).
-
-    log_gpu_memory
-        None, 'min_max', 'all'. Might slow performance
-
-    logger
-        Logger (or iterable collection of loggers) for experiment tracking.
-        If not False, we will add some loggers by default, see `add_[csv, tensorboard, wandb]_logger`.
-        Default: True
-
-    prepare_data_per_node
-        If True, each LOCAL_RANK=0 will call prepare data.
-        Otherwise only NODE_RANK=0, LOCAL_RANK=0 will prepare data
-
-    process_position
-        orders the progress bar when running multiple models on same machine.
-
-    progress_bar_refresh_rate
-        How often to refresh progress bar (in steps). Value ``0`` disables progress bar.
-        Ignored when a custom progress bar is passed to :paramref:`~Trainer.callbacks`. Default: None, means
-        a suitable value will be chosen based on the environment (terminal, Google COLAB, etc.).
-
-    profiler
-        To profile individual steps during training and assist in identifying bottlenecks. Passing bool
-        value is deprecated in v1.1 and will be removed in v1.3.
-
-    overfit_batches
-        Overfit a percent of training data (float) or a set number of batches (int). Default: 0.0
-
-    plugins
-        Plugins allow modification of core behavior like ddp and amp, and enable custom lightning plugins.
-
-    precision
-        Full precision (32), half precision (16). Can be used on CPU, GPU or TPUs.
-
-    max_epochs
-        Stop training once this number of epochs is reached. Disabled by default (None).
-        If both max_epochs and max_steps are not specified, defaults to ``max_epochs`` = 1000.
-
-    min_epochs
-        Force training for at least these many epochs. Disabled by default (None).
-        If both min_epochs and min_steps are not specified, defaults to ``min_epochs`` = 1.
-
-    max_steps
-        Stop training after this number of steps. Disabled by default (None).
-
-    min_steps
-        Force training for at least these number of steps. Disabled by default (None).
-
-    num_nodes
-        number of GPU nodes for distributed training.
-
-    num_processes
-        number of processes for distributed training with distributed_backend="ddp_cpu"
-
-    num_sanity_val_steps
-        Sanity check runs n validation batches before starting the training routine.
-        Set it to `-1` to run all batches in all validation dataloaders. Default: 2
-
-    optimizer
-        Configuration for an [AllenNLP/PyTorch optimizer](https://docs.allennlp.org/main/api/training/optimizers/)
-        that is constructed via the AllenNLP configuration framework.
-        Default: `{"type": "adam", "lr": 0.001}`
-
-    reload_dataloaders_every_epoch
-        Set to True to reload dataloaders every epoch.
-
-    replace_sampler_ddp
-        Explicitly enables or disables sampler replacement. If not specified this
-        will toggled automatically when DDP is used. By default it will add ``shuffle=True`` for
-        train sampler and ``shuffle=False`` for val/test sampler. If you want to customize it,
-        you can set ``replace_sampler_ddp=False`` and add your own distributed sampler.
-
-    resume_from_checkpoint
-        Path/URL of the checkpoint from which training is resumed. If there is
-        no checkpoint file at the path, start from scratch. If resuming from mid-epoch checkpoint,
-        training will start from the beginning of the next epoch.
-
-    sync_batchnorm
-        Synchronize batch norm layers between process groups/whole world.
-
-    terminate_on_nan
-        If set to True, will terminate training (by raising a `ValueError`) at the
-        end of each training batch, if any of the parameters or the loss are NaN or +/-inf.
-
-    tpu_cores
-        How many TPU cores to train on (1 or 8) / Single TPU to train on [1]
-
-    track_grad_norm
-        -1 no tracking. Otherwise tracks that p-norm. May be set to 'inf' infinity-norm.
-
-    truncated_bptt_steps
-        Truncated back prop breaks performs backprop every k steps of much longer
-        sequence.
-
-    val_check_interval
-        How often to check the validation set. Use float to check within a training epoch,
-        use int to check every n steps (batches).
-
-    weights_summary
-        Prints a summary of the weights when training begins.
-
-    weights_save_path
-        Where to save weights if specified. Will override default_root_dir
-        for checkpoints only. Use this if for whatever reason you need the checkpoints
-        stored in a different place than the logs written in `default_root_dir`.
-        Can be remote file paths such as `s3://mybucket/path` or 'hdfs://path/'
-        Defaults to `default_root_dir`.
-
-    move_metrics_to_cpu
-        Whether to force internal logged metrics to be moved to cpu.
-        This can save some gpu memory, but can make training slower. Use with attention.
-
-    multiple_trainloader_mode
-        How to loop over the datasets when there are multiple train loaders.
-        In 'max_size_cycle' mode, the trainer ends one epoch when the largest dataset is traversed,
-        and smaller datasets reload when running out of their data. In 'min_size' mode, all the datasets
-        reload when reaching the minimum length of datasets.
-
-    stochastic_weight_avg
-        Whether to use `Stochastic Weight Averaging (SWA)
-        <https://pytorch.org/blog/pytorch-1.6-now-includes-stochastic-weight-averaging/>_`
+    pipeline
+        Pipeline to train
+    train_dataset
+        The training dataset
+    valid_dataset
+        The validation dataset. Default: `None`.
+    trainer_config
+        The configuration of the trainer. Default: `LightningTrainerConfiguration()`.
+    vocab_config
+        A `VocabularyConfiguration` to create/extend the pipeline's vocabulary.
+        If `"default"` (str), we will use the default configuration `VocabularyConfiguration()`.
+        If None, we will leave the pipeline's vocabulary untouched. Default: `"default"`.
+    lazy
+        If True, instances are lazily loaded from disk, otherwise they are loaded into memory. Default: False.
     """
 
     def __init__(
         self,
-        logger: Union[LightningLoggerBase, Iterable[LightningLoggerBase], bool] = True,
-        checkpoint_callback: bool = True,
-        callbacks: Optional[Union[List[Callback], Callback]] = None,
-        default_root_dir: Optional[str] = None,
-        gradient_clip_val: float = 0,
-        process_position: int = 0,
-        num_nodes: int = 1,
-        num_processes: int = 1,
-        gpus: Optional[Union[List[int], str, int]] = None,
-        auto_select_gpus: bool = False,
-        tpu_cores: Optional[Union[List[int], str, int]] = None,
-        log_gpu_memory: Optional[str] = None,
-        progress_bar_refresh_rate: Optional[int] = None,
-        overfit_batches: Union[int, float] = 0.0,
-        track_grad_norm: Union[int, float, str] = -1,
-        check_val_every_n_epoch: int = 1,
-        fast_dev_run: Union[int, bool] = False,
-        accumulate_grad_batches: Union[int, Dict[int, int], List[list]] = 1,
-        max_epochs: Optional[int] = None,
-        min_epochs: Optional[int] = None,
-        max_steps: Optional[int] = None,
-        min_steps: Optional[int] = None,
-        limit_train_batches: Union[int, float] = 1.0,
-        limit_val_batches: Union[int, float] = 1.0,
-        limit_test_batches: Union[int, float] = 1.0,
-        limit_predict_batches: Union[int, float] = 1.0,
-        val_check_interval: Union[int, float] = 1.0,
-        flush_logs_every_n_steps: int = 100,
-        log_every_n_steps: int = 50,
-        accelerator: Optional[Union[str, Accelerator]] = None,
-        sync_batchnorm: bool = False,
-        precision: int = 32,
-        weights_summary: Optional[str] = "top",
-        weights_save_path: Optional[str] = None,
-        num_sanity_val_steps: int = 2,
-        truncated_bptt_steps: Optional[int] = None,
-        resume_from_checkpoint: Optional[Union[Path, str]] = None,
-        profiler: Optional[Union[BaseProfiler, bool, str]] = None,
-        benchmark: bool = False,
-        deterministic: bool = False,
-        reload_dataloaders_every_epoch: bool = False,
-        auto_lr_find: Union[bool, str] = False,
-        replace_sampler_ddp: bool = True,
-        terminate_on_nan: bool = False,
-        auto_scale_batch_size: Union[str, bool] = False,
-        prepare_data_per_node: bool = True,
-        plugins: Optional[Union[Plugin, str, list]] = None,
-        amp_backend: str = "native",
-        amp_level: str = "O2",
-        distributed_backend: Optional[str] = None,
-        automatic_optimization: Optional[bool] = None,
-        move_metrics_to_cpu: bool = False,
-        multiple_trainloader_mode: str = "max_size_cycle",
-        stochastic_weight_avg: bool = False,
-        # non lightning trainer parameters,
-        add_csv_logger: bool = True,
-        add_tensorboard_logger: bool = True,
-        add_wandb_logger: bool = True,
-        batch_size: int = 16,
-        data_bucketing: bool = False,
-        optimizer: Optional[Dict] = None,
+        pipeline: Pipeline,
+        train_dataset: Dataset,
+        valid_dataset: Optional[Dataset] = None,
+        trainer_config: Optional[LightningTrainerConfiguration] = None,
+        vocab_config: Optional[Union[str, VocabularyConfiguration]] = "default",
+        lazy: bool = False,
     ):
-        default_root_dir = default_root_dir or os.path.join(
-            os.getcwd(), "training_logs"
+        self._pipeline = pipeline
+        self._train_dataset = train_dataset
+        self._valid_dataset = valid_dataset
+        # since we will make changes to the config, better to make a copy -> asdict returns a deep copy
+        self._trainer_config = (
+            LightningTrainerConfiguration(**asdict(trainer_config))
+            if trainer_config is not None
+            else LightningTrainerConfiguration()
         )
-        self._lightning_trainer_kwargs = {
-            key: value
-            for key, value in locals().items()
-            # filter non Lightening Trainer kwargs
-            if key
-            not in [
-                "self",
-                "add_csv_logger",
-                "add_tensorboard_logger",
-                "add_wandb_logger",
-                "batch_size",
-                "data_bucketing",
-                "optimizer",
-            ]
-        }
-        # these configurations will be logged to wandb
-        self._trainer_config = {
-            "batch_size": batch_size,
-            "data_bucketing": data_bucketing,
-            "optimizer": optimizer or {"type": "adam", "lr": 0.001},
-        }
-
-        self._add_csv_logger = add_csv_logger
-        self._add_tensorboard_logger = add_tensorboard_logger
-        self._add_wandb_logger = add_wandb_logger
+        self._vocab_config: Optional[VocabularyConfiguration] = (
+            VocabularyConfiguration() if vocab_config == "default" else vocab_config
+        )
+        self._lazy = lazy
 
         # the wandb logger holds a special place in our heart
         self._wandb_logger: Optional[WandbLogger] = None
 
-        if logger is not False:
-            self._lightning_trainer_kwargs["logger"] = self._add_default_loggers()
+        if self._trainer_config.logger is not False:
+            self._trainer_config.logger = self._add_default_loggers()
 
-        self.trainer = pl.Trainer(**self._lightning_trainer_kwargs)
+        non_lightning_kwargs = [
+            "add_csv_logger",
+            "add_tensorboard_logger",
+            "add_wandb_logger",
+            "batch_size",
+            "batch_size",
+            "data_bucketing",
+            "optimizer",
+        ]
+        self.trainer = pl.Trainer(
+            **{
+                key: value
+                for key, value in asdict(self._trainer_config).items()
+                if key not in non_lightning_kwargs
+            }
+        )
 
     def _add_default_loggers(self) -> List[LightningLoggerBase]:
         """Adds default loggers for the lightning trainer"""
-        loggers = self._lightning_trainer_kwargs["logger"]
+        loggers = self._trainer_config.logger
         if loggers is True:
             loggers = []
         elif isinstance(loggers, LightningLoggerBase):
@@ -379,25 +118,30 @@ class Trainer:
         def loggers_include(logger_type) -> bool:
             return any([isinstance(logger, logger_type) for logger in loggers])
 
-        if self._add_csv_logger and not loggers_include(CSVLogger):
+        if self._trainer_config.add_csv_logger and not loggers_include(CSVLogger):
             loggers.append(
                 CSVLogger(
-                    save_dir=self._lightning_trainer_kwargs["default_root_dir"]
-                    or os.getcwd(),
+                    save_dir=self._trainer_config.default_root_dir or os.getcwd(),
                     name="csv",
                 )
             )
-        if self._add_tensorboard_logger and not loggers_include(TensorBoardLogger):
+        if self._trainer_config.add_tensorboard_logger and not loggers_include(
+            TensorBoardLogger
+        ):
             loggers.append(
                 TensorBoardLogger(
-                    save_dir=self._lightning_trainer_kwargs["default_root_dir"]
-                    or os.getcwd(),
+                    save_dir=self._trainer_config.default_root_dir,
                     name="tensorboard",
                 )
             )
-        if self._add_wandb_logger and _HAS_WANDB and not loggers_include(WandbLogger):
-            save_dir = self._lightning_trainer_kwargs["default_root_dir"] or os.getcwd()
-            self._wandb_logger = WandbLogger(save_dir=save_dir, project="biome")
+        if (
+            self._trainer_config.add_wandb_logger
+            and _HAS_WANDB
+            and not loggers_include(WandbLogger)
+        ):
+            self._wandb_logger = WandbLogger(
+                save_dir=self._trainer_config.default_root_dir, project="biome"
+            )
             loggers.append(self._wandb_logger)
         elif loggers_include(WandbLogger):
             self._wandb_logger = [
@@ -411,75 +155,52 @@ class Trainer:
 
         return loggers
 
-    def fit(
-        self,
-        pipeline: Pipeline,
-        train_dataset: Dataset,
-        valid_dataset: Optional[Dataset] = None,
-        vocab_config: Optional[Union[str, VocabularyConfiguration]] = "default",
-        include_valid_data_in_vocab: bool = False,
-        lazy: bool = False,
-    ):
-        """Train the pipeline
-
-        Parameters
-        ----------
-        pipeline
-            Pipeline to train
-        train_dataset
-            The training dataset
-        valid_dataset
-            The validation dataset
-        vocab_config
-            A `VocabularyConfiguration` to create/extend the pipeline's vocabulary.
-            If 'default' (str), we will use the default configuration `VocabularyConfiguration()`.
-            If None, we will leave the pipeline's vocabulary untouched. Default: 'default'.
-        include_valid_data_in_vocab
-            If True, take the validation data into account when creating the vocabulary (apart from the training data).
-            Has no effect if `vocab_config` is None. Default: False.
-        lazy
-            If True, instances are lazily loaded from disk, otherwise they are loaded into memory. Default: False.
-        """
+    def fit(self):
+        """Train the pipeline"""
         # create instances
-        train_instances = train_dataset.to_instances(pipeline, lazy=lazy)
+        train_instances = self._train_dataset.to_instances(
+            self._pipeline, lazy=self._lazy
+        )
         valid_instances = (
             None
-            if valid_dataset is None
-            else valid_dataset.to_instances(pipeline, lazy=lazy)
+            if self._valid_dataset is None
+            else self._valid_dataset.to_instances(self._pipeline, lazy=self._lazy)
         )
 
         # create vocab
         vocab_config = (
-            VocabularyConfiguration() if vocab_config == "default" else vocab_config
+            VocabularyConfiguration()
+            if self._vocab_config == "default"
+            else self._vocab_config
         )
         if vocab_config is not None:
             vocab_datasets = [train_instances]
-            if valid_instances is not None and include_valid_data_in_vocab:
+            if valid_instances is not None and self._vocab_config.include_valid_data:
                 vocab_datasets += [valid_instances]
-            pipeline.create_vocab(vocab_datasets, config=vocab_config)
+            self._pipeline.create_vocab(vocab_datasets, config=vocab_config)
 
         # create dataloaders
         train_dataloader = create_dataloader(
             train_instances,
-            batch_size=self._trainer_config["batch_size"],
-            data_bucketing=self._trainer_config["data_bucketing"],
+            batch_size=self._trainer_config.batch_size,
+            data_bucketing=self._trainer_config.data_bucketing,
         )
         valid_dataloader = (
             create_dataloader(
-                valid_dataset.to_instances(pipeline, lazy=lazy),
-                batch_size=self._trainer_config["batch_size"],
-                data_bucketing=self._trainer_config["data_bucketing"],
+                self._valid_dataset.to_instances(self._pipeline, lazy=self._lazy),
+                batch_size=self._trainer_config.batch_size,
+                data_bucketing=self._trainer_config.data_bucketing,
             )
-            if valid_dataset is not None
+            if self._valid_dataset is not None
             else None
         )
 
         # create optimizer
-        pipeline.model.optimizer = Optimizer.from_params(
+        self._pipeline.model.optimizer = Optimizer.from_params(
             Params(
                 {
-                    "model_parameters": pipeline.model.named_parameters(),
-                    **self._trainer_config["optimizer"],
+                    "model_parameters": self._pipeline.model.named_parameters(),
+                    **self._trainer_config.optimizer,
                 }
             )
         )
@@ -487,13 +208,13 @@ class Trainer:
         # log config to wandb
         if self._wandb_logger is not None:
             config = {
-                "pipeline": pipeline.config.as_dict(),
-                "trainer": self._trainer_config,
+                "pipeline": self._pipeline.config.as_dict(),
+                "trainer": asdict(self._trainer_config),
             }
             self._wandb_logger.experiment.config.update(config)
 
         self.trainer.fit(
-            pipeline.model,
+            self._pipeline.model,
             train_dataloader=train_dataloader,
             val_dataloaders=valid_dataloader,
         )

--- a/tests/text/test_pipeline_vocab.py
+++ b/tests/text/test_pipeline_vocab.py
@@ -84,11 +84,13 @@ def test_default_vocab(
 def test_specific_vocab_config(
     pipeline, train_dataset, valid_dataset, deactivate_pipeline_trainer, tmp_path
 ):
+    vocab_config = VocabularyConfiguration(include_valid_data=True)
+
     pipeline.train(
         output=str(tmp_path / "vocab_test_output"),
         training=train_dataset,
         validation=valid_dataset,
-        include_valid_data_in_vocab=True,
+        vocab_config=vocab_config,
     )
     assert pipeline.vocab.get_vocab_size(WordFeatures.namespace) == 16
     assert pipeline.vocab.get_vocab_size(CharFeatures.namespace) == 19


### PR DESCRIPTION
This is a bit of a mess ...
The main change is the introduction of a `LightningTrainerConfiguration` dataclass (to be renamed when the old Trainer goes away). Until now it was (more similar to pure lightning):
```python
trainer = Trainer(**trainer_kwargs)
trainer.fit(pipeline, train_data)
```
Now it is: (more similar to hf transformers):
```python
trainer_config = TrainerConfiguration(**trainer_kwargs)
trainer = Trainer(pipeline, train_data, trainer_config)
trainer.fit()
```
I saw that i needed the pipeline and data to define sane defaults in the `Trainer` init, that is why i moved the trainer_kwargs to a proper dataclass. It is one line more, but i think it is worth it in order to have better defaults.

This PR also includes a minor change in the vocab config: i moved the `include_valid_data_in_vocab` parameter to the `VocabularyConfiguration` as `include_valid_data`. Conceptually it makes much more sense there.