### PR TITLE
Adds parameter for lr schedulers for the lightning trainer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,10 +39,13 @@ if __name__ == "__main__":
             "ipywidgets~=7.5.1",
             "lxml~=4.6.2",
             "mlflow~=1.13.1",
-            "pandas~=1.1.0",
+            "numpy",
+            "pandas",
             "pytorch-lightning==1.2.0",
             "ray[tune]~=1.2.0",
             "spacy~=2.3.0",
+            "torch",  # the version is defined by allennlp
+            "transformers",  # the version is defined by allennlp
             "tqdm>=4.49.0",
             "uvicorn~=0.11.0",
         ],

--- a/src/biome/text/__init__.py
+++ b/src/biome/text/__init__.py
@@ -35,6 +35,7 @@ try:
 except ModuleNotFoundError:
     pass
 
+from .configuration import LightningTrainerConfiguration
 from .configuration import PipelineConfiguration
 from .configuration import TrainerConfiguration
 from .configuration import VocabularyConfiguration

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -790,12 +790,14 @@ class LightningTrainerConfiguration:
         Force training for at least these number of steps. Disabled by default (None)
 
     monitor
-        Metric to monitor. Will be used to load the best weights after the training.
-        Has no effect if `checkpoint_callback` is False. Default: 'validation_loss'.
+        Metric to monitor. Will be used to load the best weights after the training (`checkpoint_callback` must be True)
+        or stop the training early (`add_early_stopping` must be True). Default: 'validation_loss'.
 
     monitor_mode
         Either 'min' or 'max'. If `save_top_k_checkpoints != 0`, the decision to overwrite the current save file is made
-        based on either the maximization or the minimization of the monitored metric. Default: 'min'.
+        based on either the maximization or the minimization of the monitored metric (`checkpoint_callback` must be
+        True). It also configures the default early stopping callback (`add_early_stopping` must be True).
+        Default: 'min'
 
     num_sanity_val_steps
         Sanity check runs n validation batches before starting the training routine.

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -680,6 +680,9 @@ class LightningTrainerConfiguration:
     add_csv_logger
         Adds a default CSV logger if `logger` is not False. Default: True
 
+    add_lr_monitor
+        Adds a default `LearningRateMonitor(logging_interval="step")` to the callbacks. Default: True
+
     add_tensorboard_logger
         Adds a default Tensorboard logger if `logger` is not False. Default: True
 
@@ -752,6 +755,26 @@ class LightningTrainerConfiguration:
         If not False, we will add some loggers by default, see `add_[csv, tensorboard, wandb]_logger`.
         Default: True
 
+    lr_decay
+        Either 'linear' or 'cosine'. After an optional warmup, decay the learning rate in the specified manner.
+        Default None
+
+        You can use more sophisticated schedulers by first instantiating the Trainer and then manually specifying a
+        scheduler, for example:
+        ```python
+        from torch.optim.lr_scheduler import ReduceLROnPlateau
+        pipeline = Pipeline.from_config(...)
+        trainer = Trainer(...)
+        pipeline.model.lr_scheduler = {
+            "scheduler": ReduceLROnPlateau(pipeline.model.optimizer, ...),
+            "monitor": "validation_loss",
+            "strict": True,
+        }
+        trainer.fit()
+        ```
+        See also https://pytorch-lightning.readthedocs.io/en/stable/common/optimizers.html#learning-rate-scheduling
+        If specifying a scheduler manually, `lr_decay` and `warmup_steps` will have no effect.
+
     max_epochs
         Stop training once this number of epochs is reached. Disabled by default (None).
         If both max_epochs and max_steps are not specified, defaults to ``max_epochs`` = 1000.
@@ -819,6 +842,11 @@ class LightningTrainerConfiguration:
         How often to check the validation set. Use float to check within a training epoch,
         use int to check every n steps (batches).
 
+    warmup_steps
+        Number of steps for the warmup phase. In this initial phase the learning rate will be increased linearly from
+        zero until the learning rate specified in the optimizer. See also `lr_decay` for more sophisticated schedulers.
+        Default: 0
+
     weights_save_path
         Where to save weights if specified. Will override default_root_dir
         for checkpoints only. Use this if for whatever reason you need the checkpoints
@@ -864,10 +892,12 @@ class LightningTrainerConfiguration:
     # non lightning trainer parameters
     add_early_stopping: bool = True
     add_csv_logger: bool = True
+    add_lr_monitor: bool = True
     add_tensorboard_logger: bool = True
     add_wandb_logger: bool = True
     batch_size: int = 16
     data_bucketing: bool = False
+    lr_decay: Optional[str] = None
     monitor: str = "validation_loss"
     monitor_mode: str = "min"
     optimizer: Dict[str, Any] = field(
@@ -875,6 +905,7 @@ class LightningTrainerConfiguration:
     )
     patience: int = 3
     save_top_k_checkpoints: int = 1
+    warmup_steps: int = 0
     extra_lightning_params: Dict[str, Any] = field(default_factory=dict)
 
     def as_dict(self) -> Dict:
@@ -886,15 +917,18 @@ class LightningTrainerConfiguration:
         non_lightning_params = [
             "add_early_stopping",
             "add_csv_logger",
+            "add_lr_monitor",
             "add_tensorboard_logger",
             "add_wandb_logger",
             "batch_size",
             "data_bucketing",
+            "lr_decay",
             "monitor",
             "monitor_mode",
             "optimizer",
             "patience",
             "save_top_k_checkpoints",
+            "warmup_steps",
             "extra_lightning_params",
         ]
 

--- a/src/biome/text/model.py
+++ b/src/biome/text/model.py
@@ -115,6 +115,9 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
         self.file_path: Optional[str] = None
 
         self.optimizer: Optional[torch.optim.Optimizer] = None
+        # The lr_scheduler dict follows the Lightning format:
+        # https://pytorch-lightning.readthedocs.io/en/stable/common/optimizers.html#learning-rate-scheduling
+        self.lr_scheduler: Optional[Dict] = None
 
     def _update_head_related_attributes(self):
         """Updates the inputs/outputs and default mapping attributes, calculated from model head"""
@@ -442,7 +445,9 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
             )
 
     def configure_optimizers(self):
-        return self.optimizer
+        if self.lr_scheduler is None:
+            return self.optimizer
+        return [self.optimizer], [self.lr_scheduler]
 
 
 allennlp.models.Model.register(PipelineModel.__name__, exist_ok=True)(PipelineModel)

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -125,12 +125,15 @@ class Trainer:
             self._trainer_config.warmup_steps is None
             and self._trainer_config.lr_decay is None
         ):
-            self._pipeline.model.lr_scheduler = self._add_lr_scheduler()
+            self._pipeline.model.lr_scheduler = self._create_lr_scheduler()
 
         self.trainer = pl.Trainer(**self._trainer_config.lightning_params)
 
     def _add_default_loggers(self) -> List[LightningLoggerBase]:
-        """Adds default loggers for the lightning trainer"""
+        """Adds optional default loggers and returns the extended list
+
+        Added loggers: CSV, TensorBoard, WandB
+        """
         loggers = self._trainer_config.logger
         if loggers is True:
             loggers = []
@@ -181,6 +184,10 @@ class Trainer:
         return loggers
 
     def _add_default_callbacks(self) -> List[Callback]:
+        """Adds optional default callbacks and returns the extended list
+
+        Added callbacks: ModelCheckpoint, EarlyStopping, LearningRateMonitor
+        """
         callbacks = self._trainer_config.callbacks or []
         if isinstance(callbacks, Callback):
             callbacks = [callbacks]
@@ -232,7 +239,11 @@ class Trainer:
 
         return callbacks
 
-    def _add_lr_scheduler(self) -> Dict:
+    def _create_lr_scheduler(self) -> Dict:
+        """Returns one of three default schedulers
+
+        Possibilities: constant/linear/cosine schedule with or without warmup
+        """
         steps_per_epoch = math.ceil(
             len(self._train_dataset) / self._trainer_config.batch_size
         )
@@ -277,6 +288,7 @@ class Trainer:
         self, output_dir: Optional[Union[str, Path]] = None, exist_ok: bool = False
     ):
         """Train the pipeline
+
         Parameters
         ----------
         output_dir

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -122,7 +122,7 @@ class Trainer:
 
         # create lr scheduler
         if not (
-            self._trainer_config.warmup_steps is None
+            self._trainer_config.warmup_steps == 0
             and self._trainer_config.lr_decay is None
         ):
             self._pipeline.model.lr_scheduler = self._create_lr_scheduler()

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -285,14 +285,14 @@ class Trainer:
         }
 
     def fit(
-        self, output_dir: Optional[Union[str, Path]] = None, exist_ok: bool = False
+        self, output_dir: Optional[Union[str, Path]] = "output", exist_ok: bool = False
     ):
         """Train the pipeline
 
         Parameters
         ----------
         output_dir
-            If specified, save the trained pipeline to this directory. Default: None.
+            If specified, save the trained pipeline to this directory. Default: 'output'.
         exist_ok
             If True, overwrite the content of `output_dir`. Default: False.
         """

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -1,8 +1,10 @@
 import logging
+import math
 import os
 from dataclasses import asdict
 from pathlib import Path
 from typing import TYPE_CHECKING
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Union
@@ -15,6 +17,7 @@ from allennlp.data.samplers import BucketBatchSampler
 from allennlp.training.optimizers import Optimizer
 from pytorch_lightning import Callback
 from pytorch_lightning.callbacks import EarlyStopping
+from pytorch_lightning.callbacks import LearningRateMonitor
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import CSVLogger
 from pytorch_lightning.loggers import LightningLoggerBase
@@ -22,6 +25,9 @@ from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.loggers import WandbLogger
 from pytorch_lightning.utilities.cloud_io import load as pl_load
 from torch.utils.data import IterableDataset
+from transformers.optimization import get_constant_schedule_with_warmup
+from transformers.optimization import get_cosine_schedule_with_warmup
+from transformers.optimization import get_linear_schedule_with_warmup
 
 from biome.text.configuration import LightningTrainerConfiguration
 from biome.text.configuration import VocabularyConfiguration
@@ -103,6 +109,23 @@ class Trainer:
             self._trainer_config.logger = self._add_default_loggers()
         if self._trainer_config.gpus is None and torch.cuda.is_available():
             self._trainer_config.gpus = 1
+
+        # create optimizer
+        self._pipeline.model.optimizer = Optimizer.from_params(
+            Params(
+                {
+                    "model_parameters": self._pipeline.model.named_parameters(),
+                    **self._trainer_config.optimizer,
+                }
+            )
+        )
+
+        # create lr scheduler
+        if not (
+            self._trainer_config.warmup_steps is None
+            and self._trainer_config.lr_decay is None
+        ):
+            self._pipeline.model.lr_scheduler = self._add_lr_scheduler()
 
         self.trainer = pl.Trainer(**self._trainer_config.lightning_params)
 
@@ -201,7 +224,54 @@ class Trainer:
                 )
             )
 
+        # lr monitor
+        if self._trainer_config.add_lr_monitor and not get_callbacks_of_type(
+            LearningRateMonitor
+        ):
+            callbacks.append(LearningRateMonitor(logging_interval="step"))
+
         return callbacks
+
+    def _add_lr_scheduler(self) -> Dict:
+        steps_per_epoch = math.ceil(
+            len(self._train_dataset) / self._trainer_config.batch_size
+        )
+        try:
+            training_steps = min(
+                self._trainer_config.max_steps,
+                self._trainer_config.max_epochs * steps_per_epoch,
+            )
+        # One or both of the max_* is None:
+        except TypeError:
+            training_steps = (
+                self._trainer_config.max_steps
+                or self._trainer_config.max_epochs * steps_per_epoch
+                or 1000 * steps_per_epoch  # default of the lightning trainer
+            )
+
+        if self._trainer_config.lr_decay == "linear":
+            scheduler = get_linear_schedule_with_warmup(
+                optimizer=self._pipeline.model.optimizer,
+                num_warmup_steps=self._trainer_config.warmup_steps,
+                num_training_steps=training_steps,
+            )
+        elif self._trainer_config.lr_decay == "cosine":
+            scheduler = get_cosine_schedule_with_warmup(
+                optimizer=self._pipeline.model.optimizer,
+                num_warmup_steps=self._trainer_config.warmup_steps,
+                num_training_steps=training_steps,
+            )
+        else:
+            scheduler = get_constant_schedule_with_warmup(
+                optimizer=self._pipeline.model.optimizer,
+                num_warmup_steps=self._trainer_config.warmup_steps,
+            )
+
+        return {
+            "scheduler": scheduler,
+            "interval": "step",
+            "name": "learning_rate",
+        }
 
     def fit(
         self, output_dir: Optional[Union[str, Path]] = None, exist_ok: bool = False
@@ -257,16 +327,6 @@ class Trainer:
             )
             if self._valid_dataset is not None
             else None
-        )
-
-        # create optimizer
-        self._pipeline.model.optimizer = Optimizer.from_params(
-            Params(
-                {
-                    "model_parameters": self._pipeline.model.named_parameters(),
-                    **self._trainer_config.optimizer,
-                }
-            )
         )
 
         # log config to wandb

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -349,6 +349,7 @@ class Trainer:
             }
             self._wandb_logger.experiment.config.update(config)
 
+        # training
         try:
             self.trainer.fit(
                 self._pipeline.model,

--- a/tests/text/test_trainer.py
+++ b/tests/text/test_trainer.py
@@ -97,11 +97,9 @@ def pipeline_dict() -> dict:
 def test_text_classification(tmp_path, pipeline_dict, train_valid_dataset):
     """Apart from a well specified training, this also tests the vocab creation!"""
 
-    random.seed(42)
-    np.random.seed(422)
-    torch.manual_seed(4222)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(4222)
+    random.seed(43)
+    np.random.seed(43)
+    torch.manual_seed(43)
 
     pl = Pipeline.from_config(pipeline_dict)
     train_ds = train_valid_dataset[0]
@@ -133,7 +131,7 @@ def test_text_classification(tmp_path, pipeline_dict, train_valid_dataset):
 
     evaluation = pl.evaluate(valid_ds)
 
-    assert evaluation["loss"] == pytest.approx(0.8217981046438217, abs=0.003)
+    assert evaluation["loss"] == pytest.approx(0.9922929322719574, abs=0.003)
 
     Pipeline.from_pretrained(str(tmp_path / "output" / "model.tar.gz"))
 


### PR DESCRIPTION
This PR adds two parameters to the lightning trainer #543 (`warmup_steps` and `lr_decay`) to configure three types of learning rate schedulers: constant/linear/cosine scheduler with or without warmup. These are taken from the transformers library.

We cannot use the allennlp ones easily in lightning since they do not follow the pytorch scheduler API (to be fair there is not much of such an API ...). But you can still use all the pytorch schedulers manually, a small example is in the doc strings. Have to think about how we could improve this a bit.

