### PR TITLE
Activate warnings

### DIFF
--- a/src/biome/text/__init__.py
+++ b/src/biome/text/__init__.py
@@ -1,6 +1,4 @@
 import logging
-import warnings
-from warnings import warn_explicit
 
 import pkg_resources
 
@@ -43,5 +41,4 @@ from .dataset import Dataset
 from .pipeline import Pipeline
 from .trainer import Trainer
 
-warnings.showwarning = warn_explicit
 logging.basicConfig()

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -681,7 +681,8 @@ class LightningTrainerConfiguration:
         Adds a default CSV logger if `logger` is not False. Default: True
 
     add_lr_monitor
-        Adds a default `LearningRateMonitor(logging_interval="step")` to the callbacks. Default: True
+        Adds a default `LearningRateMonitor(logging_interval="step")` to the callbacks.
+        By default (None), we will set this to true if you use either `warmup_steps` and/or `lr_decay`.
 
     add_tensorboard_logger
         Adds a default Tensorboard logger if `logger` is not False. Default: True
@@ -894,7 +895,7 @@ class LightningTrainerConfiguration:
     # non lightning trainer parameters
     add_early_stopping: bool = True
     add_csv_logger: bool = True
-    add_lr_monitor: bool = True
+    add_lr_monitor: Optional[bool] = None
     add_tensorboard_logger: bool = True
     add_wandb_logger: bool = True
     batch_size: int = 16

--- a/src/biome/text/features.py
+++ b/src/biome/text/features.py
@@ -127,6 +127,13 @@ class CharFeatures(Features):
     @property
     def config(self) -> Dict:
         """Returns the config in AllenNLP format"""
+        if self.encoder["type"] == "cnn":
+            min_padding_length = max(self.encoder.get("ngram_filter_sizes", [5]))
+        elif self.encoder["type"] in ["gru", "lstm"]:
+            min_padding_length = 1
+        else:
+            min_padding_length = 0
+
         config = {
             "indexer": {
                 "type": "characters",
@@ -134,8 +141,8 @@ class CharFeatures(Features):
                 "character_tokenizer": {
                     "lowercase_characters": self.lowercase_characters
                 },
+                "min_padding_length": min_padding_length,
             },
-            #         "character_tokenizer": {"lowercase_characters": True},
             "embedder": {
                 "type": "character_encoding",
                 "embedding": {

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import multiprocessing
 import os
 from dataclasses import asdict
 from pathlib import Path
@@ -416,4 +417,5 @@ def create_dataloader(
         )
         if data_bucketing
         else None,
+        num_workers=multiprocessing.cpu_count(),
     )

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -233,6 +233,11 @@ class Trainer:
             )
 
         # lr monitor
+        if self._trainer_config.add_lr_monitor is None and (
+            self._trainer_config.warmup_steps != 0
+            or self._trainer_config.lr_decay is not None
+        ):
+            self._trainer_config.add_lr_monitor = True
         if self._trainer_config.add_lr_monitor and not get_callbacks_of_type(
             LearningRateMonitor
         ):


### PR DESCRIPTION
At some point we deactivated all warnings, i think to avoid too many warnings from allennlp. Here i reactivate them again, since we are moving away from the allennlp trainer and i think they can be useful to spot some potential issues with the usage of third party libraries. When we encounter a frequent warning we should try to fix it or specifically deactivate that warning somehow.

This PR also includes some fixes that avoid warnings and their potential issues.