### PR TITLE
Feat/log best metrics for the new trainer

### DIFF
--- a/src/biome/text/model.py
+++ b/src/biome/text/model.py
@@ -461,6 +461,7 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
             logged_metrics[metric_name] = val
 
         # log best metrics
+        logged_metrics["epoch"] = self.current_epoch
         if self.best_metrics is None:
             self.best_metrics = logged_metrics
         elif (

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import math
 import multiprocessing
@@ -13,6 +14,7 @@ from typing import Union
 import pytorch_lightning as pl
 import torch
 from allennlp.common import Params
+from allennlp.common.util import sanitize
 from allennlp.data import PyTorchDataLoader
 from allennlp.data.samplers import BucketBatchSampler
 from allennlp.training.optimizers import Optimizer
@@ -341,7 +343,7 @@ class Trainer:
         try:
             output_dir = Path(output_dir)
         except TypeError:
-            pass
+            output_dir = None
         else:
             output_dir.mkdir(exist_ok=exist_ok)
 
@@ -381,6 +383,8 @@ class Trainer:
                 self._load_best_weights()
             if output_dir:
                 self._pipeline.save(output_dir)
+                with (output_dir / "metrics.json").open("w") as file:
+                    json.dump(sanitize(self.trainer.logged_metrics), file)
             if self._wandb_logger is not None:
                 self._wandb_logger.experiment.finish()
 

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -160,10 +160,8 @@ class Trainer:
             self._pipeline.model.lr_scheduler = self._create_lr_scheduler()
 
         # set monitor and mode for best validation metrics
-        self._pipeline.model.monitor_and_mode = (
-            self._trainer_config.monitor,
-            self._trainer_config.monitor_mode,
-        )
+        self._pipeline.model.monitor = self._trainer_config.monitor
+        self._pipeline.model.monitor_mode = self._trainer_config.monitor_mode
 
         self.trainer = pl.Trainer(**self._trainer_config.lightning_params)
 

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -159,6 +159,12 @@ class Trainer:
         ):
             self._pipeline.model.lr_scheduler = self._create_lr_scheduler()
 
+        # set monitor and mode for best validation metrics
+        self._pipeline.model.monitor_and_mode = (
+            self._trainer_config.monitor,
+            self._trainer_config.monitor_mode,
+        )
+
         self.trainer = pl.Trainer(**self._trainer_config.lightning_params)
 
     def _add_default_loggers(self) -> List[LightningLoggerBase]:


### PR DESCRIPTION
This PR belongs to #543 and adds the logging of `best_metrics` to the new trainer. This is the same behavior we have in the allennlp trainer.