### PR TITLE
Apply max_sequence_length also to the TransformersTokenizer

### DIFF
--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -228,7 +228,8 @@ class TokenizerConfiguration(FromParams):
     end_tokens
         A list of token strings to the sequence after tokenized input text.
     use_transformers
-        If true, we will use a transformers tokenizer from HuggingFace and disregard all other parameters above.
+        If true, we will use a transformers tokenizer from HuggingFace and disregard all other parameters above
+        (except `max_sequence_length`!).
         If you specify any of the above parameters you want to set this to false.
         If None, we automatically choose the right value based on your feature and head configuration.
     transformers_kwargs

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -220,7 +220,9 @@ class TransformersTokenizer(Tokenizer):
         return list(map(self._tokenize, document))
 
     def _tokenize(self, text: str) -> List[Token]:
-        return self.pretrained_tokenizer.tokenize(text)
+        return self.pretrained_tokenizer.tokenize(
+            text[: self._config.max_sequence_length]
+        )
 
     @property
     def nlp(self) -> Language:

--- a/tests/text/test_pipeline_tokenizer.py
+++ b/tests/text/test_pipeline_tokenizer.py
@@ -25,6 +25,7 @@ def pipeline_dict(request) -> dict:
 
 
 def test_pipeline_transformers_tokenizer(pipeline_dict):
+    pipeline_dict["tokenizer"] = {"max_sequence_length": 1}
     pl = Pipeline.from_config(pipeline_dict)
 
     assert pl.config.tokenizer_config.transformers_kwargs == {
@@ -37,7 +38,12 @@ def test_pipeline_transformers_tokenizer(pipeline_dict):
     )
     assert type(pl.backbone.tokenizer) is TransformersTokenizer
 
-    prediction = pl.predict("Test this!")
+    # test max_sequence_length, only <s>, t, </s> should survive
+    assert (
+        len(pl.backbone.tokenizer.tokenize_text("this is a multi token text")[0]) == 3
+    )
+
+    assert pl.predict("Test this!")
 
 
 def test_pipeline_default_tokenizer(pipeline_dict):


### PR DESCRIPTION
This PR activates the `max_sequence_length` for the `TransformersTokenizer`. 