### PR TITLE
Refactor/upgrade fastapi deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 default: help
 
 dev: ## install package in development mode
-	@pip install --upgrade -e .[dev,serve]
+	@pip install --upgrade -e .[dev]
 	@pre-commit install
 
 check: ## applies a code pylint with autopep8 reformating

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 default: help
 
 dev: ## install package in development mode
-	@pip install --upgrade -e .[dev]
+	@pip install --upgrade -e .[dev,serve]
 	@pre-commit install
 
 check: ## applies a code pylint with autopep8 reformating

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ if __name__ == "__main__":
             "click~=7.1.0",
             "datasets~=1.2.1",
             "elasticsearch>=6.8.0,<7.5.0",
-            "fastapi~=0.55.0",
             "flask~=1.1.2",
             "flask-cors~=3.0.8",
             "flatdict~=4.0.0",
@@ -47,7 +46,6 @@ if __name__ == "__main__":
             "torch",  # the version is defined by allennlp
             "transformers",  # the version is defined by allennlp
             "tqdm>=4.49.0",
-            "uvicorn~=0.11.0",
         ],
         extras_require={
             "dev": [
@@ -63,6 +61,10 @@ if __name__ == "__main__":
                 # development
                 "pre-commit~=2.9.0",
                 "GitPython",
+            ],
+            "serve": [
+                "fastapi~=0.63.0",
+                "uvicorn~=0.13.0",
             ],
         },
         package_data={

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,8 @@ if __name__ == "__main__":
             "torch",  # the version is defined by allennlp
             "transformers",  # the version is defined by allennlp
             "tqdm>=4.49.0",
+            "fastapi>=0.63.0",
+            "uvicorn>=0.13.0",
         ],
         extras_require={
             "dev": [
@@ -61,10 +63,6 @@ if __name__ == "__main__":
                 # development
                 "pre-commit~=2.9.0",
                 "GitPython",
-            ],
-            "serve": [
-                "fastapi~=0.63.0",
-                "uvicorn~=0.13.0",
             ],
         },
         package_data={

--- a/src/biome/text/cli/serve.py
+++ b/src/biome/text/cli/serve.py
@@ -1,10 +1,5 @@
 import inspect
-from typing import Any
-from typing import Callable
-from typing import Dict
 from typing import List
-from typing import Optional
-from typing import Tuple
 
 import click
 import uvicorn
@@ -14,6 +9,7 @@ from fastapi import FastAPI
 from fastapi import HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import PlainTextResponse
+from pydantic import BaseConfig
 from pydantic import create_model
 from starlette.exceptions import HTTPException as StarletteHTTPException
 
@@ -75,7 +71,7 @@ def _serve(pipeline: Pipeline, port: int = 9999, host: str = "0.0.0.0"):
         if par.default != inspect.Parameter.empty and name != "batch"
     }
 
-    class Config:
+    class Config(BaseConfig):
         extra = "forbid"
 
     ModelInput = create_model("ModelInput", **model_parameters, __config__=Config)


### PR DESCRIPTION
Upgrade fastapi and uvicorn deps for pipeline serve. `fastapi` and `uvicorn` deps are required from a minimal version.

```python
"fastapi>=0.63.0"
```