### PR TITLE
Save a `trainer_config.yaml` in the training output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ if __name__ == "__main__":
             "tqdm>=4.49.0",
             "fastapi>=0.63.0",
             "uvicorn>=0.13.0",
+            "pyyaml",
         ],
         extras_require={
             "dev": [

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -28,6 +28,7 @@ from biome.text.features import TransformersFeatures
 from biome.text.features import WordFeatures
 from biome.text.featurizer import InputFeaturizer
 from biome.text.helpers import sanitize_for_params
+from biome.text.helpers import sanitize_for_yaml
 from biome.text.helpers import save_dict_as_yaml
 from biome.text.modules.encoders import Encoder
 from biome.text.modules.heads.classification.relation_classification import (
@@ -927,6 +928,18 @@ class TrainerConfiguration:
     def as_dict(self) -> Dict:
         """Returns the dataclass as dict without a deepcopy, in contrast to `dataclasses.asdict`"""
         return {fld.name: getattr(self, fld.name) for fld in fields(self)}
+
+    def to_yaml(self, path: Union[str, Path]):
+        """Saves the configuration as a yaml file"""
+        if isinstance(path, str):
+            path = Path(path)
+        with path.open("w") as yml_file:
+            yaml.dump(
+                sanitize_for_yaml(self.as_dict()),
+                yml_file,
+                default_flow_style=False,
+                allow_unicode=True,
+            )
 
     @property
     def lightning_params(self) -> Dict[str, Any]:

--- a/src/biome/text/helpers.py
+++ b/src/biome/text/helpers.py
@@ -240,6 +240,23 @@ def sanitize_for_params(x: Any) -> Any:
     return x
 
 
+def sanitize_for_yaml(value: Any):
+    """Sanitizes the value for a simple yaml output, that is classes only built-in types"""
+    if isinstance(value, list):
+        return [sanitize_for_yaml(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(sanitize_for_yaml(v) for v in value)
+    if isinstance(value, dict):
+        return {k: sanitize_for_yaml(v) for k, v in value.items()}
+    try:
+        yaml.dump(value)
+    # we try a string representation
+    except Exception:
+        return str(value)
+    else:
+        return value
+
+
 def span_labels_to_tag_labels(
     labels: List[str], label_encoding: str = "BIO"
 ) -> List[str]:

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -390,6 +390,7 @@ class Trainer:
                 self._pipeline.save(output_dir)
                 with (output_dir / "metrics.json").open("w") as file:
                     json.dump(sanitize(self.trainer.logged_metrics), file)
+                self._trainer_config.to_yaml(output_dir / "trainer_config.yaml")
             if self._wandb_logger is not None:
                 self._wandb_logger.experiment.finish()
 

--- a/tests/text/test_features_transformers.py
+++ b/tests/text/test_features_transformers.py
@@ -58,7 +58,7 @@ def pipeline_dict() -> dict:
 
 
 @pytest.fixture
-def trainer_config() -> TrainerConfiguration:
+def trainer_config(tmp_path) -> TrainerConfiguration:
     return TrainerConfiguration(
         batch_size=16,
         max_epochs=1,
@@ -67,6 +67,7 @@ def trainer_config() -> TrainerConfiguration:
             "lr": 0.0001,
         },
         gpus=0,
+        default_root_dir=str(tmp_path),
     )
 
 


### PR DESCRIPTION
With this PR, a `trainer_config.yaml` is saved together with the `model.tar.gz` and `metrics.json` file in the training output.