### PR TITLE
Fix: Avoid huge memory overhead when using the Trainer

### DIFF
--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -134,7 +134,8 @@ class DocumentClassification(ClassificationHead):
         # TODO: An optimized implementation would be to calculate the attributions directly in the forward method
         #  and provide a practical switch, maybe: `with head.turn_attributions_on(): self.forward_on_instances()`
         #  In this way we would calculate the attributions batch wise and on on GPU if available.
-        output["embeddings"], output["mask"] = embeddings, mask
+        if not self.training:
+            output["embeddings"], output["mask"] = embeddings, mask
 
         return output
 

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -227,10 +227,11 @@ class RecordPairClassification(ClassificationHead):
         # TODO: An optimized implementation would be to calculate the attributions directly in the forward method
         #  and provide a practical switch, maybe: `with head.turn_attributions_on(): self.forward_on_instances()`
         #  In this way we would calculate the attributions batch wise and on on GPU if available.
-        output["field_encoded_record1"] = field_encoded_record1
-        output["record_mask_record1"] = record_mask_record1
-        output["field_encoded_record2"] = field_encoded_record2
-        output["record_mask_record2"] = record_mask_record2
+        if not self.training:
+            output["field_encoded_record1"] = field_encoded_record1
+            output["record_mask_record1"] = record_mask_record1
+            output["field_encoded_record2"] = field_encoded_record2
+            output["record_mask_record2"] = record_mask_record2
 
         return output
 

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -105,7 +105,8 @@ class TextClassification(ClassificationHead):
         # TODO: An optimized implementation would be to calculate the attributions directly in the forward method
         #  and provide a practical switch, maybe: `with head.turn_attributions_on(): self.forward_on_instances()`
         #  In this way we would calculate the attributions batch wise and on on GPU if available.
-        output["embeddings"], output["mask"] = embeddings, mask
+        if not self.training:
+            output["embeddings"], output["mask"] = embeddings, mask
 
         return output
 

--- a/tests/text/modules/heads/classification/test_document_classification.py
+++ b/tests/text/modules/heads/classification/test_document_classification.py
@@ -66,7 +66,8 @@ def test_make_task_prediction(pipeline):
 
 def test_compute_attributions(pipeline):
     instance = pipeline.head.featurize("test this sentence")
-    forward_output = pipeline._model.forward_on_instances([instance])
+    pipeline.model.eval()
+    forward_output = pipeline.model.forward_on_instances([instance])
 
     attributions = pipeline.head._compute_attributions(
         forward_output[0], instance, n_steps=1

--- a/tests/text/modules/heads/classification/test_record_pair_classification.py
+++ b/tests/text/modules/heads/classification/test_record_pair_classification.py
@@ -169,7 +169,8 @@ def test_attributions(pipeline_dict, training_dataset):
     instance = pipeline.head.featurize(
         training_dataset["record1"][0], training_dataset["record2"][0]
     )
-    forward_output = pipeline._model.forward_on_instances([instance])
+    pipeline.model.eval()
+    forward_output = pipeline.model.forward_on_instances([instance])
 
     attributions = pipeline.head._compute_attributions(forward_output[0], instance)
 

--- a/tests/text/modules/heads/classification/test_text_classification.py
+++ b/tests/text/modules/heads/classification/test_text_classification.py
@@ -40,7 +40,8 @@ def test_make_task_prediction(pipeline):
 
 def test_compute_attributions(pipeline):
     instance = pipeline.head.featurize("test this sentence")
-    forward_output = pipeline._model.forward_on_instances([instance])
+    pipeline.model.eval()
+    forward_output = pipeline.model.forward_on_instances([instance])
 
     attributions = pipeline.head._compute_attributions(
         forward_output[0], instance, n_steps=1


### PR DESCRIPTION
This PR fixes an issue when using most of the classification heads with the new PL Trainer. It seems PL somehow stores the output dicts for all steps, so it is important not to "pollute" this dict with unnecessary stuff during the training!