### PR TITLE
Bump up spacy to 3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
             "pandas",
             "pytorch-lightning~=1.3.0",
             "ray[tune]~=1.3.0",
-            "spacy~=2.3.0",
+            "spacy~=3.0.0",
             "torch",  # the version is defined by allennlp
             "transformers",  # the version is defined by allennlp
             "tqdm>=4.49.0",

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -209,9 +209,8 @@ class TokenizerConfiguration(FromParams):
 
     Parameters
     ----------
-    lang
-        The [spaCy model used](https://spacy.io/api/tokenizer) for tokenization is language dependent.
-        For optimal performance, specify the language of your input data (default: "en").
+    spacy_model
+        The [spaCy model](https://spacy.io/models) used for the tokenization. Default: "en_core_web_sm".
     max_sequence_length
         Maximum length in characters for input texts truncated with `[:max_sequence_length]` after `TextCleaning`.
     max_nr_of_sentences
@@ -241,7 +240,7 @@ class TokenizerConfiguration(FromParams):
     # note: It's important that it inherits from FromParas so that `Pipeline.from_pretrained()` works!
     def __init__(
         self,
-        lang: str = "en",
+        spacy_model: str = "en_core_web_sm",
         max_sequence_length: int = None,
         max_nr_of_sentences: int = None,
         text_cleaning: Optional[Dict[str, Any]] = None,
@@ -253,7 +252,7 @@ class TokenizerConfiguration(FromParams):
         use_transformers: Optional[bool] = None,
         transformers_kwargs: Optional[Dict] = None,
     ):
-        self.lang = lang
+        self.spacy_model = spacy_model
         self.max_sequence_length = max_sequence_length
         self.max_nr_of_sentences = max_nr_of_sentences
         self.segment_sentences = segment_sentences

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -53,8 +53,7 @@ class Tokenizer:
         if config.segment_sentences and not self.__nlp__.has_pipe(
             self.__SPACY_SENTENCIZER__
         ):
-            sentencizer = self.__nlp__.create_pipe(self.__SPACY_SENTENCIZER__)
-            self.__nlp__.add_pipe(sentencizer)
+            self.__nlp__.add_pipe(self.__SPACY_SENTENCIZER__)
 
         if config.text_cleaning is None:
             self.text_cleaning = TextCleaning()
@@ -130,7 +129,7 @@ class Tokenizer:
         if not self.config.segment_sentences:
             return list(map(self._tokenize, texts[: self.config.max_nr_of_sentences]))
         sentences = [
-            sentence.string.strip()
+            sentence.text.strip()
             for doc in self.__nlp__.pipe(texts)
             for sentence in doc.sents
         ]

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -39,7 +39,6 @@ class Tokenizer:
     __SPACY_SENTENCIZER__ = "sentencizer"
 
     def __init__(self, config: "TokenizerConfiguration"):
-        _fetch_spacy_model(config.lang)
         self._config = config
 
         self._end_tokens = config.end_tokens or []
@@ -49,7 +48,7 @@ class Tokenizer:
         self._start_tokens.reverse()
 
         self.__nlp__ = get_spacy_model(
-            self.config.lang, pos_tags=True, ner=False, parse=False
+            self.config.spacy_model, pos_tags=True, ner=False, parse=False
         )
         if config.segment_sentences and not self.__nlp__.has_pipe(
             self.__SPACY_SENTENCIZER__
@@ -227,16 +226,3 @@ class TransformersTokenizer(Tokenizer):
     @property
     def nlp(self) -> Language:
         raise NotImplementedError("For the TransformerTokenizer we have no spaCy nlp")
-
-
-def _fetch_spacy_model(lang: str):
-    # Allennlp get_spacy_model method works only for fully named models (en_core_web_sm) but no
-    # for already linked named (en, es)
-    # This is a workaround for mitigate those kind of errors. Just loading one more time, it's ok.
-    # See https://github.com/allenai/allennlp/issues/4201
-    import spacy
-
-    try:
-        spacy.load(lang, disable=["vectors", "textcat", "tagger" "parser" "ner"])
-    except OSError:
-        spacy.cli.download(lang)

--- a/tests/text/modules/heads/classification/test_record_pair_classification.py
+++ b/tests/text/modules/heads/classification/test_record_pair_classification.py
@@ -146,7 +146,9 @@ def pipeline_dict() -> Dict:
 @pytest.fixture
 def trainer_config() -> TrainerConfiguration:
     return TrainerConfiguration(
-        max_epochs=1, optimizer={"type": "adam", "amsgrad": True, "lr": 0.002}
+        max_epochs=1,
+        optimizer={"type": "adam", "amsgrad": True, "lr": 0.002},
+        gpus=0,
     )
 
 

--- a/tests/text/modules/heads/classification/test_relation_classifier.py
+++ b/tests/text/modules/heads/classification/test_relation_classifier.py
@@ -70,6 +70,7 @@ def trainer_config() -> TrainerConfiguration:
     return TrainerConfiguration(
         max_epochs=1,
         optimizer={"type": "adamw", "lr": 0.002},
+        gpus=0,
     )
 
 

--- a/tests/text/modules/heads/test_language_modelling.py
+++ b/tests/text/modules/heads/test_language_modelling.py
@@ -58,6 +58,7 @@ def trainer_config() -> TrainerConfiguration:
     return TrainerConfiguration(
         max_epochs=2,
         optimizer={"type": "adam", "amsgrad": True, "lr": 0.002},
+        gpus=0,
     )
 
 


### PR DESCRIPTION
Our dependency on spacy is more direct than i thought. It is difficult for us to keep supporting spacy2.0 if we want to be compatible with spacy3.0:
- `Span.string` -> `Span.text`
- `spacy.gold` -> `spacy.training`, and also the method names changed (`offsets_to_biluo_tags` ...)
- no need to call `create_pipe` first, a simple `add_pipe` is sufficient
- no more model shortcuts

I vote for bumping up the spacy version and requiring spacy3.0 as this PR does (AllenNLP's spacy dep is >=2.1.0, <3.1.0). @frascuchon what do you think?