### PR TITLE
Add dropout to the TextClassification head

### DIFF
--- a/tests/text/modules/heads/classification/test_text_classification.py
+++ b/tests/text/modules/heads/classification/test_text_classification.py
@@ -13,7 +13,7 @@ def pipeline() -> Pipeline:
     return Pipeline.from_config(
         {
             "name": "test_text_classification",
-            "head": {"type": "TextClassification", "labels": labels},
+            "head": {"type": "TextClassification", "labels": labels, "dropout": 0.1},
         }
     )
 


### PR DESCRIPTION
Adds a `dropout` parameter to the `TextClassification` head allowing to introduce a dropout after the backbone and after the pooler.