### PR TITLE
Feat: Add min/max sentence length parameters

### DIFF
--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -212,13 +212,24 @@ class TokenizerConfiguration(FromParams):
     spacy_model
         The [spaCy model](https://spacy.io/models) used for the tokenization. Default: "en_core_web_sm".
     max_sequence_length
-        Maximum length in characters for input texts truncated with `[:max_sequence_length]` after `TextCleaning`.
-    max_nr_of_sentences
-        Maximum number of sentences to keep when using `segment_sentences` truncated with `[:max_sequence_length]`.
+        Truncate the input after the text cleaning via `[:max_sequence_length]`. If the input is a list or a dict,
+        this limit is applied to each element or dict value, respectively.
+        Default: None
     text_cleaning
         A `TextCleaning` configuration with pre-processing rules for cleaning up and transforming raw input text.
     segment_sentences
-        Whether to segment input texts into sentences.
+        Whether to segment input texts into sentences. The segmentation into sentences happens
+        after the truncation with `[:max_sequence_length]`. Default: None.
+    min_sentence_length
+        When setting `segment_sentences` to True, this defines the minimum length of the sentence,
+        for the sentence to be included. Default: 0.
+    max_sentence_length
+        When setting `segment_sentences` to True, this defines the maximum length of the sentence,
+        for the sentence to be included. Default: 1e5.
+    max_nr_of_sentences
+        Maximum number of sentences to keep when using `segment_sentences` (after the min/max_sentence_length filter).
+        When `segment_sentences` is set to False and the input is a list of strings, this defines the maximum number of
+        elements of the list to keep. Default: None.
     use_spacy_tokens
         If True, the tokenized token list contains spacy tokens instead of allennlp tokens
     remove_space_tokens
@@ -227,12 +238,6 @@ class TokenizerConfiguration(FromParams):
         A list of token strings to the sequence before tokenized input text.
     end_tokens
         A list of token strings to the sequence after tokenized input text.
-    min_sentence_length
-        When setting `segment_sentences` to True, this defines the minimum length of the sentence to be included.
-        Default: 0.
-    max_sentence_length
-        When setting `segment_sentences` to True, this defines the maximum length of the sentence to be included.
-        Default: 1e5.
     use_transformers
         If true, we will use a transformers tokenizer from HuggingFace and disregard all other parameters above
         (except `max_sequence_length`!).
@@ -248,29 +253,29 @@ class TokenizerConfiguration(FromParams):
         self,
         spacy_model: str = "en_core_web_sm",
         max_sequence_length: int = None,
-        max_nr_of_sentences: int = None,
         text_cleaning: Optional[Dict[str, Any]] = None,
         segment_sentences: bool = False,
+        min_sentence_length: int = 0,
+        max_sentence_length: int = 100000,
+        max_nr_of_sentences: int = None,
         use_spacy_tokens: bool = False,
         remove_space_tokens: bool = True,
         start_tokens: Optional[List[str]] = None,
         end_tokens: Optional[List[str]] = None,
-        min_sentence_length: int = 0,
-        max_sentence_length: int = 100000,
         use_transformers: Optional[bool] = None,
         transformers_kwargs: Optional[Dict] = None,
     ):
         self.spacy_model = spacy_model
         self.max_sequence_length = max_sequence_length
-        self.max_nr_of_sentences = max_nr_of_sentences
-        self.segment_sentences = segment_sentences
         self.text_cleaning = text_cleaning
+        self.segment_sentences = segment_sentences
+        self.min_sentence_length = min_sentence_length
+        self.max_sentence_length = max_sentence_length
+        self.max_nr_of_sentences = max_nr_of_sentences
         self.start_tokens = start_tokens
         self.end_tokens = end_tokens
         self.use_spacy_tokens = use_spacy_tokens
         self.remove_space_tokens = remove_space_tokens
-        self.min_sentence_length = min_sentence_length
-        self.max_sentence_length = max_sentence_length
         self.use_transformers = use_transformers
         self.transformers_kwargs = transformers_kwargs or {}
 

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import os
+import warnings
 from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import fields
@@ -212,14 +213,16 @@ class TokenizerConfiguration(FromParams):
     spacy_model
         The [spaCy model](https://spacy.io/models) used for the tokenization. Default: "en_core_web_sm".
     max_sequence_length
-        Truncate the input after the text cleaning via `[:max_sequence_length]`. If the input is a list or a dict,
-        this limit is applied to each element or dict value, respectively.
+        DEPRECATED, use `truncate_input` instead.
+    truncate_input
+        Char index at which to truncate the input after the text cleaning via `[:truncate_input]`.
+        If the input is a list or a dict, this truncation is applied to each element or dict value, respectively.
         Default: None
     text_cleaning
         A `TextCleaning` configuration with pre-processing rules for cleaning up and transforming raw input text.
     segment_sentences
         Whether to segment input texts into sentences. The segmentation into sentences happens
-        after the truncation with `[:max_sequence_length]`. Default: None.
+        after the truncation with `truncate_input`. Default: None.
     min_sentence_length
         When setting `segment_sentences` to True, this defines the minimum length of the sentence,
         for the sentence to be included. Default: 0.
@@ -230,6 +233,9 @@ class TokenizerConfiguration(FromParams):
         Maximum number of sentences to keep when using `segment_sentences` (after the min/max_sentence_length filter).
         When `segment_sentences` is set to False and the input is a list of strings, this defines the maximum number of
         elements of the list to keep. Default: None.
+    truncate_sentence
+        Char index at which to truncate each sentence via `[:truncate_sentence]`, if `segment_sentences` is set to True.
+        Applied after the `min/max_sentence_length` filter. Default: None.
     use_spacy_tokens
         If True, the tokenized token list contains spacy tokens instead of allennlp tokens
     remove_space_tokens
@@ -240,7 +246,7 @@ class TokenizerConfiguration(FromParams):
         A list of token strings to the sequence after tokenized input text.
     use_transformers
         If true, we will use a transformers tokenizer from HuggingFace and disregard all other parameters above
-        (except `max_sequence_length`!).
+        (except `truncate_input`!).
         If you specify any of the above parameters you want to set this to false.
         If None, we automatically choose the right value based on your feature and head configuration.
     transformers_kwargs
@@ -253,11 +259,13 @@ class TokenizerConfiguration(FromParams):
         self,
         spacy_model: str = "en_core_web_sm",
         max_sequence_length: int = None,
+        truncate_input: int = None,
         text_cleaning: Optional[Dict[str, Any]] = None,
         segment_sentences: bool = False,
         min_sentence_length: int = 0,
         max_sentence_length: int = 100000,
         max_nr_of_sentences: int = None,
+        truncate_sentence: int = None,
         use_spacy_tokens: bool = False,
         remove_space_tokens: bool = True,
         start_tokens: Optional[List[str]] = None,
@@ -265,13 +273,23 @@ class TokenizerConfiguration(FromParams):
         use_transformers: Optional[bool] = None,
         transformers_kwargs: Optional[Dict] = None,
     ):
+        if max_sequence_length is not None:
+            warnings.warn(
+                "'max_sequence_length' is deprecated and will be removed in future versions. "
+                "Use `truncate_input` instead.",
+                category=FutureWarning,
+            )
+            self.truncate_input = max_sequence_length
+        else:
+            self.truncate_input = truncate_input
+
         self.spacy_model = spacy_model
-        self.max_sequence_length = max_sequence_length
         self.text_cleaning = text_cleaning
         self.segment_sentences = segment_sentences
         self.min_sentence_length = min_sentence_length
         self.max_sentence_length = max_sentence_length
         self.max_nr_of_sentences = max_nr_of_sentences
+        self.truncate_sentence = truncate_sentence
         self.start_tokens = start_tokens
         self.end_tokens = end_tokens
         self.use_spacy_tokens = use_spacy_tokens

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -227,6 +227,12 @@ class TokenizerConfiguration(FromParams):
         A list of token strings to the sequence before tokenized input text.
     end_tokens
         A list of token strings to the sequence after tokenized input text.
+    min_sentence_length
+        When setting `segment_sentences` to True, this defines the minimum length of the sentence to be included.
+        Default: 0.
+    max_sentence_length
+        When setting `segment_sentences` to True, this defines the maximum length of the sentence to be included.
+        Default: 1e5.
     use_transformers
         If true, we will use a transformers tokenizer from HuggingFace and disregard all other parameters above
         (except `max_sequence_length`!).
@@ -249,6 +255,8 @@ class TokenizerConfiguration(FromParams):
         remove_space_tokens: bool = True,
         start_tokens: Optional[List[str]] = None,
         end_tokens: Optional[List[str]] = None,
+        min_sentence_length: int = 0,
+        max_sentence_length: int = 1e5,
         use_transformers: Optional[bool] = None,
         transformers_kwargs: Optional[Dict] = None,
     ):
@@ -261,6 +269,8 @@ class TokenizerConfiguration(FromParams):
         self.end_tokens = end_tokens
         self.use_spacy_tokens = use_spacy_tokens
         self.remove_space_tokens = remove_space_tokens
+        self.min_sentence_length = min_sentence_length
+        self.max_sentence_length = max_sentence_length
         self.use_transformers = use_transformers
         self.transformers_kwargs = transformers_kwargs or {}
 

--- a/src/biome/text/configuration.py
+++ b/src/biome/text/configuration.py
@@ -256,7 +256,7 @@ class TokenizerConfiguration(FromParams):
         start_tokens: Optional[List[str]] = None,
         end_tokens: Optional[List[str]] = None,
         min_sentence_length: int = 0,
-        max_sentence_length: int = 1e5,
+        max_sentence_length: int = 100000,
         use_transformers: Optional[bool] = None,
         transformers_kwargs: Optional[Dict] = None,
     ):

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -132,9 +132,11 @@ class Tokenizer:
             sentence.text.strip()
             for doc in self.__nlp__.pipe(texts)
             for sentence in doc.sents
-            if self.config.min_sentence_length
-            < len(sentence)
-            < self.config.max_sentence_length
+            if (
+                self.config.min_sentence_length
+                < len(sentence.text.strip())
+                < self.config.max_sentence_length
+            )
         ]
         return list(map(self._tokenize, sentences[: self.config.max_nr_of_sentences]))
 

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -126,13 +126,12 @@ class Tokenizer:
         tokens: `List[List[Token]]`
         """
         texts = [
-            self.text_cleaning(text)[: self.config.max_sequence_length]
-            for text in document
+            self.text_cleaning(text)[: self.config.truncate_input] for text in document
         ]
         if not self.config.segment_sentences:
             return list(map(self._tokenize, texts[: self.config.max_nr_of_sentences]))
         sentences = [
-            sentence.text.strip()
+            sentence.text.strip()[: self.config.truncate_sentence]
             for doc in self.__nlp__.pipe(texts)
             for sentence in doc.sents
             if (
@@ -226,9 +225,7 @@ class TransformersTokenizer(Tokenizer):
         return list(map(self._tokenize, document))
 
     def _tokenize(self, text: str) -> List[Token]:
-        return self.pretrained_tokenizer.tokenize(
-            text[: self._config.max_sequence_length]
-        )
+        return self.pretrained_tokenizer.tokenize(text[: self._config.truncate_input])
 
     @property
     def nlp(self) -> Language:

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -132,6 +132,9 @@ class Tokenizer:
             sentence.text.strip()
             for doc in self.__nlp__.pipe(texts)
             for sentence in doc.sents
+            if self.config.min_sentence_length
+            < len(sentence)
+            < self.config.max_sentence_length
         ]
         return list(map(self._tokenize, sentences[: self.config.max_nr_of_sentences]))
 

--- a/src/biome/text/tokenizer.py
+++ b/src/biome/text/tokenizer.py
@@ -105,7 +105,7 @@ class Tokenizer:
         tokens: `List[Token]`
 
         """
-        tokens = self.nlp(text[: self.config.max_sequence_length])
+        tokens = list(self.nlp(text))
         if self.config.remove_space_tokens:
             tokens = [token for token in tokens if not token.is_space]
 
@@ -125,7 +125,10 @@ class Tokenizer:
         -------
         tokens: `List[List[Token]]`
         """
-        texts = [self.text_cleaning(text) for text in document]
+        texts = [
+            self.text_cleaning(text)[: self.config.max_sequence_length]
+            for text in document
+        ]
         if not self.config.segment_sentences:
             return list(map(self._tokenize, texts[: self.config.max_nr_of_sentences]))
         sentences = [

--- a/tests/text/test_dataset.py
+++ b/tests/text/test_dataset.py
@@ -197,7 +197,7 @@ class TestInstanceCaching:
         if self.uses_cached_instances(default_pipeline_config):
             pytest.fail("Incompatible pipelines did reuse the cached instances!")
 
-        default_pipeline_config["tokenizer"] = {"max_sequence_length": 10}
+        default_pipeline_config["tokenizer"] = {"truncate_input": 10}
         if self.uses_cached_instances(default_pipeline_config):
             pytest.fail("Incompatible pipelines did reuse the cached instances!")
 

--- a/tests/text/test_pipeline_tokenizer.py
+++ b/tests/text/test_pipeline_tokenizer.py
@@ -25,7 +25,7 @@ def pipeline_dict(request) -> dict:
 
 
 def test_pipeline_transformers_tokenizer(pipeline_dict):
-    pipeline_dict["tokenizer"] = {"max_sequence_length": 1}
+    pipeline_dict["tokenizer"] = {"truncate_input": 1}
     pl = Pipeline.from_config(pipeline_dict)
 
     assert pl.config.tokenizer_config.transformers_kwargs == {

--- a/tests/text/test_tokenizer.py
+++ b/tests/text/test_tokenizer.py
@@ -36,7 +36,7 @@ def test_text_cleaning_with_sentence_segmentation():
 def test_text_cleaning_with_sentence_segmentation_and_max_sequence():
     tokenizer = Tokenizer(
         TokenizerConfiguration(
-            max_sequence_length=8,
+            truncate_sentence=8,
             text_cleaning={"rules": ["html_to_text", "strip_spaces"]},
             segment_sentences=True,
         )

--- a/tests/text/test_tokenizer.py
+++ b/tests/text/test_tokenizer.py
@@ -90,3 +90,15 @@ def test_set_sentence_segmentation_with_max_number_of_sentences():
         ]
     )
     assert len(tokenized) == 2
+
+
+def test_min_max_sentence_length():
+    tokenizer = Tokenizer(
+        TokenizerConfiguration(
+            segment_sentences=True, min_sentence_length=10, max_sentence_length=15
+        )
+    )
+    tokenized = tokenizer.tokenize_text("short. A very long sentence. This is fine")
+
+    assert len(tokenized) == 1
+    assert len(tokenized[0]) == 3


### PR DESCRIPTION
This PR adds two new parameters to the `TokenizerConfiguration`:
- `min_sentence_length`
- `max_sentence_length`

These will only be used when setting `segment_sentences` to True.