### PR TITLE
Feat: Remove `PredictionError`, return None instead

### DIFF
--- a/src/biome/text/featurizer.py
+++ b/src/biome/text/featurizer.py
@@ -83,7 +83,7 @@ class InputFeaturizer:
 
         if self._contains_empty_strings(record_tokens):
             raise FeaturizeError(
-                f"Empty tokens are produced for the provided input data: {data}"
+                f"None or empty tokens are produced for the provided input data: {data}"
             )
 
         return Instance({to_field: self._tokens_to_field(record_tokens, aggregate)})

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -384,12 +384,7 @@ class Pipeline:
         -------
         predictions
             A dictionary or a list of dictionaries containing the predictions and additional information.
-            If a prediction fails for a single input in the batch, its return value will be `None`.
-
-        Raises
-        ------
-        PredictionError
-            Failed to predict the single input or the whole batch
+            If a prediction fails, its return value will be `None`.
         """
         if args or kwargs:
             batch = [self._map_args_kwargs_to_input(*args, **kwargs)]
@@ -401,8 +396,6 @@ class Pipeline:
         )
 
         predictions = self._model.predict(batch, prediction_config)
-        if not any(predictions):
-            raise PredictionError(f"Failed to make predictions for {batch}")
 
         predictions_dict = [
             prediction.as_dict() if prediction is not None else None
@@ -652,11 +645,3 @@ class Pipeline:
     def _config_from_archive(archive: Archive) -> PipelineConfiguration:
         config = archive.config["model"]["config"]
         return PipelineConfiguration.from_params(config)
-
-
-class PredictionError(Exception):
-    """Exception for a failed prediction of a single input or a whole batch"""
-
-    # For now this is the only Error in this module. If you want to add further Errors
-    # define a base class as recommended in https://docs.python.org/3/tutorial/errors.html#user-defined-exceptions
-    pass

--- a/tests/text/test_pipeline_predict.py
+++ b/tests/text/test_pipeline_predict.py
@@ -2,7 +2,6 @@ import pytest
 
 from biome.text import Pipeline
 from biome.text.modules.heads.task_prediction import TextClassificationPrediction
-from biome.text.pipeline import PredictionError
 
 
 @pytest.fixture
@@ -15,12 +14,9 @@ def pipeline() -> Pipeline:
     )
 
 
-def test_raise_Prediction_error(pipeline):
-    with pytest.raises(PredictionError):
-        pipeline.predict("")
-
-    with pytest.raises(PredictionError):
-        pipeline.predict(batch=[{"text": ""}, {"text": ""}])
+def test_return_none_for_failed_prediction(pipeline):
+    assert pipeline.predict("") is None
+    assert pipeline.predict(batch=[{"text": ""}, {"text": ""}]) == [None, None]
 
 
 def test_batch_parameter_gets_ignored(pipeline):


### PR DESCRIPTION
We used to throw a PredictionError for single predictions or when the whole batch failed. We now simply return None and log a Warning.