### PR TITLE
Remove the vocab parameter from Pipeline.from_config

### DIFF
--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -78,15 +78,13 @@ class Pipeline:
         )
 
     @classmethod
-    def from_yaml(cls, path: str, vocab_path: Optional[str] = None) -> "Pipeline":
+    def from_yaml(cls, path: str) -> "Pipeline":
         """Creates a pipeline from a config yaml file
 
         Parameters
         ----------
         path
             The path to a YAML configuration file
-        vocab_path
-            If provided, the pipeline vocab will be loaded from this path
 
         Returns
         -------
@@ -95,13 +93,12 @@ class Pipeline:
         """
         pipeline_configuration = PipelineConfiguration.from_yaml(path)
 
-        return cls.from_config(pipeline_configuration, vocab_path=vocab_path)
+        return cls.from_config(pipeline_configuration)
 
     @classmethod
     def from_config(
         cls,
         config: Union[PipelineConfiguration, dict],
-        vocab_path: Optional[str] = None,
     ) -> "Pipeline":
         """Creates a pipeline from a `PipelineConfiguration` object or a configuration dictionary
 
@@ -109,8 +106,6 @@ class Pipeline:
         ----------
         config
             A `PipelineConfiguration` object or a configuration dict
-        vocab_path
-            If provided, the pipeline vocabulary will be loaded from this path
 
         Returns
         -------
@@ -120,10 +115,7 @@ class Pipeline:
         if isinstance(config, PipelineConfiguration):
             config = config.as_dict()
 
-        model = PipelineModel(
-            config=config,
-            vocab=Vocabulary.from_files(vocab_path) if vocab_path is not None else None,
-        )
+        model = PipelineModel(config=config)
 
         if not isinstance(model, PipelineModel):
             raise TypeError(f"Cannot load model. Wrong format of {model}")

--- a/tests/text/test_hpo.py
+++ b/tests/text/test_hpo.py
@@ -57,22 +57,15 @@ def test_tune_exp_save_dataset_and_vocab(
     dataset, pipeline_config, trainer_config, monkeypatch
 ):
     pl = Pipeline.from_config(pipeline_config)
-    vocab = pl.create_vocab([dataset.to_instances(pl)])
 
     my_exp = TuneExperiment(
         pipeline_config=pipeline_config,
         trainer_config=trainer_config,
         train_dataset=dataset,
         valid_dataset=dataset,
-        vocab=vocab,
     )
 
     config = my_exp.config
-    pl2 = Pipeline.from_config(config["pipeline_config"], config["vocab_path"])
-
-    pl._model.extend_vocabulary(vocab)
-    assert pl.backbone.vocab._index_to_token == pl2.backbone.vocab._index_to_token
-    assert pl.backbone.vocab._token_to_index == pl2.backbone.vocab._token_to_index
 
     assert dataset[:] == Dataset.load_from_disk(config["train_dataset_path"])[:]
     assert dataset[:] == Dataset.load_from_disk(config["valid_dataset_path"])[:]


### PR DESCRIPTION
I think we hardly used this argument, and i found a bug when using it with pretrained word vectors.
I will remove it for now, for the `TuneExperiment` class i will introduce a `vocab_config` parameter in a follow-up PR.