### PR TITLE
refactor(inference): default fallback prediction

### DIFF
--- a/src/biome/text/model.py
+++ b/src/biome/text/model.py
@@ -356,7 +356,7 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
         self,
         batch: List[Dict[str, Union[str, List[str], Dict[str, str]]]],
         prediction_config: PredictionConfiguration,
-    ) -> List[Optional[TaskPrediction]]:
+    ) -> List[TaskPrediction]:
         """Returns predictions given some input data based on the current state of the model
 
         The keys of the input dicts in the batch must coincide with the `self.inputs` attribute.
@@ -369,12 +369,15 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
             The dictionary keys must comply with the `self.inputs` attribute.
         prediction_config
             Contains configurations for the prediction
+
+        Returns
+        -------
+        List of task predictions
         """
         if self.training:
             self.eval()
 
         instances = [self.text_to_instance(**input_dict) for input_dict in batch]
-        fallback_prediction = self.head.fallback_prediction()
         # Filter out None instances, that is when the head could not create an instance out of the input
         none_indices, not_none_instances = [], []
         for i, instance in enumerate(instances):
@@ -383,8 +386,10 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
             else:
                 not_none_instances.append(instance)
 
+        if not not_none_instances:
+            return [self.head.empty_prediction] * len(batch)
+
         try:
-            # TODO(dcfidalgo): better handling when no instances at all
             forward_outputs = self.forward_on_instances(not_none_instances)
         except Exception as error:
             input_examples = [
@@ -394,7 +399,7 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
             self._LOGGER.warning(
                 f"Failed to make a forward pass for '{input_examples}'"
             )
-            return [fallback_prediction] * len(batch)
+            return [self.head.empty_prediction] * len(batch)
 
         predictions = []
         for forward_output, instance in zip(forward_outputs, not_none_instances):
@@ -409,11 +414,11 @@ class PipelineModel(allennlp.models.Model, pl.LightningModule):
                 self._LOGGER.warning(
                     f"Failed to make a task prediction for '{forward_output, instance}'"
                 )
-                predictions.append(fallback_prediction)
+                predictions.append(self.head.empty_prediction)
 
         # Add None for the none instances
         for index in none_indices:
-            predictions.insert(index, fallback_prediction)
+            predictions.insert(index, self.head.empty_prediction)
 
         # Log predictions if the prediction logger was initialized
         if hasattr(self, "_prediction_logger"):

--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -132,9 +132,6 @@ class ClassificationHead(TaskHead):
 
         return instance
 
-    def fallback_prediction(self) -> TaskPrediction:
-        return TextClassificationPrediction(labels=[], probabilities=[])
-
     def _make_forward_output(
         self, logits: torch.Tensor, label: Optional[torch.IntTensor]
     ) -> Dict[str, Any]:

--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -21,6 +21,7 @@ from biome.text.modules.heads.task_head import TaskHead
 from biome.text.modules.heads.task_head import TaskName
 from biome.text.modules.heads.task_prediction import Attribution
 from biome.text.modules.heads.task_prediction import TaskPrediction
+from biome.text.modules.heads.task_prediction import TextClassificationPrediction
 
 
 class ClassificationHead(TaskHead):
@@ -130,6 +131,9 @@ class ClassificationHead(TaskHead):
         instance.add_field(to_field, field)
 
         return instance
+
+    def fallback_prediction(self) -> TaskPrediction:
+        return TextClassificationPrediction(labels=[], probabilities=[])
 
     def _make_forward_output(
         self, logits: torch.Tensor, label: Optional[torch.IntTensor]

--- a/src/biome/text/modules/heads/classification/classification.py
+++ b/src/biome/text/modules/heads/classification/classification.py
@@ -21,7 +21,6 @@ from biome.text.modules.heads.task_head import TaskHead
 from biome.text.modules.heads.task_head import TaskName
 from biome.text.modules.heads.task_prediction import Attribution
 from biome.text.modules.heads.task_prediction import TaskPrediction
-from biome.text.modules.heads.task_prediction import TextClassificationPrediction
 
 
 class ClassificationHead(TaskHead):

--- a/src/biome/text/modules/heads/classification/doc_classification.py
+++ b/src/biome/text/modules/heads/classification/doc_classification.py
@@ -78,6 +78,10 @@ class DocumentClassification(ClassificationHead):
             label_weights=label_weights,
         )
 
+        self._empty_prediction = DocumentClassificationPrediction(
+            labels=[], probabilities=[]
+        )
+
         self.backbone.encoder = TimeDistributedEncoder(backbone.encoder)
 
         # layers

--- a/src/biome/text/modules/heads/classification/record_classification.py
+++ b/src/biome/text/modules/heads/classification/record_classification.py
@@ -67,6 +67,10 @@ class RecordClassification(DocumentClassification):
             label_weights=label_weights,
         )
 
+        self._empty_prediction = RecordClassificationPrediction(
+            labels=[], probabilities=[]
+        )
+
         self._inputs = record_keys
 
     def inputs(self) -> Optional[List[str]]:

--- a/src/biome/text/modules/heads/classification/record_pair_classification.py
+++ b/src/biome/text/modules/heads/classification/record_pair_classification.py
@@ -89,6 +89,10 @@ class RecordPairClassification(ClassificationHead):
     ):
         super().__init__(backbone, labels, label_weights=label_weights)
 
+        self._empty_prediction = RecordPairClassificationPrediction(
+            labels=[], probabilities=[]
+        )
+
         # This is needed for the TrainerConfig to choose the right 'sorting_keys'
         self.backbone.encoder = TimeDistributedEncoder(self.backbone.encoder)
 

--- a/src/biome/text/modules/heads/classification/relation_classification.py
+++ b/src/biome/text/modules/heads/classification/relation_classification.py
@@ -78,6 +78,10 @@ class RelationClassification(ClassificationHead):
             label_weights=label_weights,
         )
 
+        self._empty_prediction = RelationClassificationPrediction(
+            labels=[], probabilities=[]
+        )
+
         self._label_encoding = entity_encoding
         self._entity_tags_namespace = "entities"
 
@@ -167,9 +171,6 @@ class RelationClassification(ClassificationHead):
         logits = self._classification_layer(embedded_text)
 
         return self._make_forward_output(logits=logits, label=label)
-
-    def fallback_prediction(self) -> TaskPrediction:
-        return RelationClassificationPrediction(labels=[], probabilities=[])
 
     def _make_task_prediction(
         self,

--- a/src/biome/text/modules/heads/classification/relation_classification.py
+++ b/src/biome/text/modules/heads/classification/relation_classification.py
@@ -26,6 +26,7 @@ from biome.text.modules.heads.classification.classification import Classificatio
 
 # from biome.text.modules.encoders.multi_head_self_attention_encoder import MultiheadSelfAttentionEncoder
 from biome.text.modules.heads.task_prediction import RelationClassificationPrediction
+from biome.text.modules.heads.task_prediction import TaskPrediction
 
 
 class RelationClassification(ClassificationHead):
@@ -166,6 +167,9 @@ class RelationClassification(ClassificationHead):
         logits = self._classification_layer(embedded_text)
 
         return self._make_forward_output(logits=logits, label=label)
+
+    def fallback_prediction(self) -> TaskPrediction:
+        return RelationClassificationPrediction(labels=[], probabilities=[])
 
     def _make_task_prediction(
         self,

--- a/src/biome/text/modules/heads/classification/relation_classification.py
+++ b/src/biome/text/modules/heads/classification/relation_classification.py
@@ -26,7 +26,6 @@ from biome.text.modules.heads.classification.classification import Classificatio
 
 # from biome.text.modules.encoders.multi_head_self_attention_encoder import MultiheadSelfAttentionEncoder
 from biome.text.modules.heads.task_prediction import RelationClassificationPrediction
-from biome.text.modules.heads.task_prediction import TaskPrediction
 
 
 class RelationClassification(ClassificationHead):

--- a/src/biome/text/modules/heads/classification/text_classification.py
+++ b/src/biome/text/modules/heads/classification/text_classification.py
@@ -64,6 +64,10 @@ class TextClassification(ClassificationHead):
 
         super().__init__(backbone, labels, multilabel, label_weights=label_weights)
 
+        self._empty_prediction = TextClassificationPrediction(
+            labels=[], probabilities=[]
+        )
+
         self.pooler = (
             pooler.input_dim(self.backbone.encoder.get_output_dim()).compile()
             if pooler

--- a/src/biome/text/modules/heads/language_modelling.py
+++ b/src/biome/text/modules/heads/language_modelling.py
@@ -39,6 +39,10 @@ class LanguageModelling(TaskHead):
     ) -> None:
         super(LanguageModelling, self).__init__(backbone)
 
+        self._empty_prediction = LanguageModellingPrediction(
+            lm_embeddings=numpy.array([]), mask=numpy.array([])
+        )
+
         self.bidirectional = bidirectional
 
         if not backbone.featurizer.has_word_features:
@@ -187,11 +191,6 @@ class LanguageModelling(TaskHead):
         ).view(-1, self._forward_dim)
 
         return self._loss(non_masked_embeddings, non_masked_targets)
-
-    def fallback_prediction(self) -> LanguageModellingPrediction:
-        return LanguageModellingPrediction(
-            lm_embeddings=numpy.array([]), mask=numpy.array([])
-        )
 
     def _make_task_prediction(
         self,

--- a/src/biome/text/modules/heads/language_modelling.py
+++ b/src/biome/text/modules/heads/language_modelling.py
@@ -188,6 +188,11 @@ class LanguageModelling(TaskHead):
 
         return self._loss(non_masked_embeddings, non_masked_targets)
 
+    def fallback_prediction(self) -> LanguageModellingPrediction:
+        return LanguageModellingPrediction(
+            lm_embeddings=numpy.array([]), mask=numpy.array([])
+        )
+
     def _make_task_prediction(
         self,
         single_forward_output: Dict[str, numpy.ndarray],

--- a/src/biome/text/modules/heads/task_head.py
+++ b/src/biome/text/modules/heads/task_head.py
@@ -98,6 +98,10 @@ class TaskHead(torch.nn.Module, Registrable):
         """Metrics dictionary for training task"""
         raise NotImplementedError
 
+    def fallback_prediction(self):
+        """The fallback task prediction output when an  unexpected error occurs at inference"""
+        return None  # This implements be de actual behaviour
+
     def featurize(self, *args, **kwargs) -> Instance:
         """Converts incoming data into an Allennlp `Instance`, used for pyTorch tensors generation
 

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -71,6 +71,10 @@ class TokenClassification(TaskHead):
     ) -> None:
         super().__init__(backbone)
 
+        self._empty_prediction = TokenClassificationPrediction(
+            tags=[[]], entities=[[]], scores=[]
+        )
+
         if label_encoding not in ["BIOUL", "BIO"]:
             raise WrongValueError(
                 f"Label encoding {label_encoding} not supported. Allowed values are {['BIOUL', 'BIO']}"
@@ -128,9 +132,6 @@ class TokenClassification(TaskHead):
     @property
     def span_labels(self) -> List[str]:
         return self._span_labels
-
-    def fallback_prediction(self) -> TaskPrediction:
-        return TokenClassificationPrediction(tags=[[]], entities=[[]], scores=[])
 
     def _loss(self, logits: torch.Tensor, labels: torch.Tensor, mask: torch.Tensor):
         """loss is calculated as -log_likelihood from crf"""

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -35,6 +35,7 @@ from biome.text.modules.configuration import FeedForwardConfiguration
 from biome.text.modules.heads.task_head import TaskHead
 from biome.text.modules.heads.task_head import TaskName
 from biome.text.modules.heads.task_prediction import Entity
+from biome.text.modules.heads.task_prediction import TaskPrediction
 from biome.text.modules.heads.task_prediction import TokenClassificationPrediction
 
 
@@ -127,6 +128,9 @@ class TokenClassification(TaskHead):
     @property
     def span_labels(self) -> List[str]:
         return self._span_labels
+
+    def fallback_prediction(self) -> TaskPrediction:
+        return TokenClassificationPrediction(tags=[[]], entities=[[]], scores=[])
 
     def _loss(self, logits: torch.Tensor, labels: torch.Tensor, mask: torch.Tensor):
         """loss is calculated as -log_likelihood from crf"""

--- a/src/biome/text/modules/heads/token_classification.py
+++ b/src/biome/text/modules/heads/token_classification.py
@@ -35,7 +35,6 @@ from biome.text.modules.configuration import FeedForwardConfiguration
 from biome.text.modules.heads.task_head import TaskHead
 from biome.text.modules.heads.task_head import TaskName
 from biome.text.modules.heads.task_prediction import Entity
-from biome.text.modules.heads.task_prediction import TaskPrediction
 from biome.text.modules.heads.task_prediction import TokenClassificationPrediction
 
 

--- a/src/biome/text/pipeline.py
+++ b/src/biome/text/pipeline.py
@@ -351,7 +351,7 @@ class Pipeline:
         add_attributions: bool = False,
         attributions_kwargs: Optional[Dict] = None,
         **kwargs,
-    ) -> Union[Dict[str, numpy.ndarray], List[Optional[Dict[str, numpy.ndarray]]]]:
+    ) -> Union[Dict[str, numpy.ndarray], List[Dict[str, numpy.ndarray]]]:
         """Returns a prediction given some input data based on the current state of the model
 
         The accepted input is dynamically calculated and can be checked via the `self.inputs` attribute
@@ -376,7 +376,6 @@ class Pipeline:
         -------
         predictions
             A dictionary or a list of dictionaries containing the predictions and additional information.
-            If a prediction fails, its return value will be `None`.
         """
         if args or kwargs:
             batch = [self._map_args_kwargs_to_input(*args, **kwargs)]
@@ -389,10 +388,7 @@ class Pipeline:
 
         predictions = self._model.predict(batch, prediction_config)
 
-        predictions_dict = [
-            prediction.as_dict() if prediction is not None else None
-            for prediction in predictions
-        ]
+        predictions_dict = [prediction.as_dict() for prediction in predictions]
 
         return predictions_dict[0] if (args or kwargs) else predictions_dict
 

--- a/tests/text/test_model_predict.py
+++ b/tests/text/test_model_predict.py
@@ -37,7 +37,7 @@ def test_forward_pass_error(model, monkeypatch, caplog):
         [{"text": "Some value that breaks the forward pass"}], PredictionConfiguration
     )
 
-    assert predictions == [None]
+    assert predictions == [model.head.fallback_prediction()]
     assert len(caplog.record_tuples) == 2
     assert caplog.record_tuples[0] == ("biome.text.model", 40, "mock Exception")
     assert caplog.record_tuples[1] == (

--- a/tests/text/test_model_predict.py
+++ b/tests/text/test_model_predict.py
@@ -37,7 +37,7 @@ def test_forward_pass_error(model, monkeypatch, caplog):
         [{"text": "Some value that breaks the forward pass"}], PredictionConfiguration
     )
 
-    assert predictions == [model.head.fallback_prediction()]
+    assert predictions == [model.head.empty_prediction]
     assert len(caplog.record_tuples) == 2
     assert caplog.record_tuples[0] == ("biome.text.model", 40, "mock Exception")
     assert caplog.record_tuples[1] == (

--- a/tests/text/test_pipeline_predict.py
+++ b/tests/text/test_pipeline_predict.py
@@ -15,9 +15,11 @@ def pipeline() -> Pipeline:
 
 
 def test_return_empty_prediction_for_failed_prediction(pipeline):
-    fallback_pred = {"labels": [], "probabilities": []}
-    assert pipeline.predict("") == fallback_pred
-    assert pipeline.predict(batch=[{"text": ""}, {"text": ""}]) == [fallback_pred] * 2
+    empty_prediction = {"labels": [], "probabilities": []}
+    assert pipeline.predict("") == empty_prediction
+    assert (
+        pipeline.predict(batch=[{"text": ""}, {"text": ""}]) == [empty_prediction] * 2
+    )
 
 
 def test_batch_parameter_gets_ignored(pipeline):
@@ -55,7 +57,7 @@ def test_return_single_or_list(pipeline, monkeypatch):
         return [
             TextClassificationPrediction(labels=["a"], probabilities=[1])
             if i % 2 == 0
-            else None
+            else pipeline.head.empty_prediction
             for i, _ in enumerate(batch)
         ]
 
@@ -71,4 +73,7 @@ def test_return_single_or_list(pipeline, monkeypatch):
         batch=[{"text": "test"}, {"text": "no instance for this input"}]
     )
     assert isinstance(batch_prediction, list) and len(batch_prediction) == 2
-    assert isinstance(batch_prediction[0], dict) and batch_prediction[1] is None
+    assert (
+        isinstance(batch_prediction[0], dict)
+        and batch_prediction[1] == pipeline.head.empty_prediction.as_dict()
+    )

--- a/tests/text/test_pipeline_predict.py
+++ b/tests/text/test_pipeline_predict.py
@@ -14,9 +14,10 @@ def pipeline() -> Pipeline:
     )
 
 
-def test_return_none_for_failed_prediction(pipeline):
-    assert pipeline.predict("") is None
-    assert pipeline.predict(batch=[{"text": ""}, {"text": ""}]) == [None, None]
+def test_return_empty_prediction_for_failed_prediction(pipeline):
+    fallback_pred = {"labels": [], "probabilities": []}
+    assert pipeline.predict("") == fallback_pred
+    assert pipeline.predict(batch=[{"text": ""}, {"text": ""}]) == [fallback_pred] * 2
 
 
 def test_batch_parameter_gets_ignored(pipeline):


### PR DESCRIPTION
Adding a fallback prediction instead of returning a `None` object, helps inference service integrations with tabular oriented operations, like mlflow serving (expecting a dataframe as result)


