### PR TITLE
Fix: create parent dirs when specifying an output_dir with Trainer.fit()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ if __name__ == "__main__":
             "lxml~=4.6.2",
             "mlflow~=1.13.1",
             "numpy",
-            "pandas",
+            "pandas<1.3.0",
             "pytorch-lightning~=1.3.0",
             "ray[tune]~=1.3.0",
             "spacy~=3.0.0",

--- a/src/biome/text/trainer.py
+++ b/src/biome/text/trainer.py
@@ -372,7 +372,7 @@ class Trainer:
         except TypeError:
             output_dir = None
         else:
-            output_dir.mkdir(exist_ok=exist_ok)
+            output_dir.mkdir(exist_ok=exist_ok, parents=True)
 
         # create dataloaders
         train_dataloader = create_dataloader(

--- a/tests/text/test_trainer.py
+++ b/tests/text/test_trainer.py
@@ -12,7 +12,6 @@ from biome.text import Dataset
 from biome.text import Pipeline
 from biome.text import Trainer
 from biome.text.configuration import TrainerConfiguration
-from biome.text.trainer import create_dataloader
 
 
 @pytest.fixture
@@ -155,3 +154,16 @@ def test_pipeline_test(pipeline_dict, dataset, tmp_path):
     assert pl.evaluate(dataset)["test_loss"] == pytest.approx(
         first_metrics["test_loss"]
     )
+
+
+def test_create_output_dir(pipeline_dict, dataset, tmp_path):
+    config = TrainerConfiguration(
+        logger=False, fast_dev_run=True, batch_size=1, max_epochs=1, gpus=0
+    )
+    pipeline = Pipeline.from_config(pipeline_dict)
+    trainer = Trainer(pipeline, train_dataset=dataset, trainer_config=config)
+
+    output_dir = tmp_path / "test_this_non_existing_parent_dir" / "output"
+    trainer.fit(output_dir=output_dir)
+
+    assert output_dir.is_dir()


### PR DESCRIPTION
Fixes #580 